### PR TITLE
Guidance proof-of-concept

### DIFF
--- a/.github/workflows/nrsr.yaml
+++ b/.github/workflows/nrsr.yaml
@@ -8,7 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: "-Dwarnings"
+  RUSTFLAGS: "-Dwarnings -Aclippy::uninlined_format_args"
   XJ_SHOW_CMDS: "1"
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ target/
 
 # Built Visual Studio Code Extensions
 *.vsix
+
+# Junk files & directories
+ju_*
+ju.*

--- a/c2rust/Cargo.lock
+++ b/c2rust/Cargo.lock
@@ -190,6 +190,7 @@ dependencies = [
  "is_executable",
  "log",
  "regex",
+ "serde_json",
  "shlex",
 ]
 

--- a/c2rust/c2rust-ast-builder/src/builder.rs
+++ b/c2rust/c2rust-ast-builder/src/builder.rs
@@ -2439,6 +2439,7 @@ mod tenjin {
             // Technically the C standard places very lax requirements on the
             // size of these types. In practice we do not expect to compile
             // for platforms where int is < 32 bits, for example.
+            // (As of 2025, the only such platforms Rust supports are AVR and MSP430.)
             //
             // If the value we pick here is smaller than the actual value
             // representable by the given C type, that's fine; we'll merely
@@ -2450,6 +2451,12 @@ mod tenjin {
             // depending on the situation.
             //
             // So these values are chosen conservatively.
+            if path.segments[1].ident.to_string().as_str() == "c_longlong" {
+                return Some(i64::MAX);
+            }
+            if path.segments[1].ident.to_string().as_str() == "c_ulonglong" {
+                return Some(i64::MAX);
+            }
             if path.segments[1].ident.to_string().as_str() == "c_ulong" {
                 return Some(i32::MAX as i64);
             }
@@ -2458,6 +2465,18 @@ mod tenjin {
             }
             if path.segments[1].ident.to_string().as_str() == "c_int" {
                 return Some(i32::MAX as i64);
+            }
+            if path.segments[1].ident.to_string().as_str() == "c_short" {
+                return Some(i16::MAX as i64);
+            }
+            if path.segments[1].ident.to_string().as_str() == "c_ushort" {
+                return Some(i16::MAX as i64);
+            }
+            if path.segments[1].ident.to_string().as_str() == "c_char" {
+                return Some(i8::MAX as i64);
+            }
+            if path.segments[1].ident.to_string().as_str() == "c_schar" {
+                return Some(i8::MAX as i64);
             }
         }
         match path.segments[0].ident.to_string().as_str() {

--- a/c2rust/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust/c2rust-transpile/src/c_ast/mod.rs
@@ -57,8 +57,6 @@ pub struct TypedAstContext {
     pub c_main: Option<CDeclId>,
     pub parents: HashMap<CDeclId, CDeclId>, // record fields and enum constants
 
-    pub parent_fn: HashMap<CDeclId, CDeclId>, // decl => parent function
-
     // Mapping from FileId to SrcFile. Deduplicated by file path.
     files: Vec<SrcFile>,
     // Mapping from clang file id to translator FileId

--- a/c2rust/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust/c2rust-transpile/src/c_ast/mod.rs
@@ -57,6 +57,8 @@ pub struct TypedAstContext {
     pub c_main: Option<CDeclId>,
     pub parents: HashMap<CDeclId, CDeclId>, // record fields and enum constants
 
+    pub parent_fn: HashMap<CDeclId, CDeclId>, // decl => parent function
+
     // Mapping from FileId to SrcFile. Deduplicated by file path.
     files: Vec<SrcFile>,
     // Mapping from clang file id to translator FileId

--- a/c2rust/c2rust-transpile/src/lib.rs
+++ b/c2rust/c2rust-transpile/src/lib.rs
@@ -83,6 +83,8 @@ pub struct TranspilerConfig {
     pub preserve_unused_functions: bool,
     pub log_level: log::LevelFilter,
 
+    pub guidance_json: serde_json::Value,
+
     // Options that control build files
     /// Emit `Cargo.toml` and `lib.rs`
     pub emit_build_files: bool,

--- a/c2rust/c2rust-transpile/src/lib.rs
+++ b/c2rust/c2rust-transpile/src/lib.rs
@@ -534,8 +534,9 @@ fn transpile_single(
     }
 
     // Perform the translation
+    let parent_fn_map = translator::parent_fn::compute_parent_fn_map(&typed_context);
     let (translated_string, pragmas, crates) =
-        translator::translate(typed_context, tcfg, input_path);
+        translator::translate(typed_context, tcfg, input_path, parent_fn_map);
 
     let mut file = match File::create(&output_path) {
         Ok(file) => file,

--- a/c2rust/c2rust-transpile/src/translator/literals.rs
+++ b/c2rust/c2rust-transpile/src/translator/literals.rs
@@ -138,6 +138,19 @@ impl Translation<'_> {
                     // zero terminator
                     _ => 1,
                 };
+
+                log::info!(
+                    "TENJIN TRACE: convert string literal, contents len {}, num elems {}",
+                    val.len(),
+                    num_elems
+                );
+
+                // XREF:TENJIN-GUIDANCE-STRAWMAN
+                if num_elems == 100 && val.is_empty() {
+                    let newstr = mk().call_expr(mk().path_expr(vec!["String", "new"]), vec![]);
+                    return Ok(WithStmts::new_val(newstr));
+                }
+
                 let size = num_elems * (width as usize);
                 val.resize(size, 0);
 

--- a/c2rust/c2rust-transpile/src/translator/literals.rs
+++ b/c2rust/c2rust-transpile/src/translator/literals.rs
@@ -140,7 +140,7 @@ impl Translation<'_> {
                     _ => 1,
                 };
 
-                log::info!(
+                log::trace!(
                     "TENJIN TRACE: convert string literal, contents len {}, num elems {}",
                     val.len(),
                     num_elems

--- a/c2rust/c2rust-transpile/src/translator/literals.rs
+++ b/c2rust/c2rust-transpile/src/translator/literals.rs
@@ -77,6 +77,7 @@ impl Translation<'_> {
         _ctx: ExprContext,
         ty: CQualTypeId,
         kind: &CLiteral,
+        guided_type: &Option<Type>,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
         match *kind {
             CLiteral::Integer(val, base) => Ok(WithStmts::new_val(self.mk_int_lit(ty, val, base)?)),
@@ -146,9 +147,13 @@ impl Translation<'_> {
                 );
 
                 // XREF:TENJIN-GUIDANCE-STRAWMAN
-                if num_elems == 100 && val.is_empty() {
-                    let newstr = mk().call_expr(mk().path_expr(vec!["String", "new"]), vec![]);
-                    return Ok(WithStmts::new_val(newstr));
+                if let Some(guided_type) = guided_type {
+                    if guided_type == &*mk().path_ty(vec!["String"]) {
+                        // If the type is a String, we need to convert the string literal
+                        // into a Rust String.
+                        let newstr = mk().call_expr(mk().path_expr(vec!["String", "new"]), vec![]);
+                        return Ok(WithStmts::new_val(newstr));
+                    }
                 }
 
                 let size = num_elems * (width as usize);

--- a/c2rust/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust/c2rust-transpile/src/translator/mod.rs
@@ -3085,7 +3085,10 @@ impl<'c> Translation<'c> {
                 };
 
                 // XREF:TENJIN-GUIDANCE-STRAWMAN
-                let fn_needs_abi_preservation: bool = name != "driver";
+                // Eventually, we must become more sophisticated about ABI preservation.
+                // Some common types like `String` and `Vec` are not FFI-safe.
+                // YOLO mode for now!
+                let fn_needs_abi_preservation: bool = false;
 
                 if fn_needs_abi_preservation && !is_main {
                     mk_ = mk_.extern_("C");

--- a/c2rust/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust/c2rust-transpile/src/translator/mod.rs
@@ -307,7 +307,7 @@ fn parse_tenjin_decl_specifier(s: &str) -> Option<TenjinDeclSpecifier> {
 }
 
 struct ParsedGuidance {
-    pub raw: serde_json::Value,
+    pub _raw: serde_json::Value,
     pub declspecs_of_type: HashMap<syn::Type, Vec<TenjinDeclSpecifier>>,
     pub type_of_decl: HashMap<CDeclId, syn::Type>,
     decls_without_type_guidance: HashSet<CDeclId>,
@@ -318,7 +318,7 @@ impl ParsedGuidance {
         let mut declspecs_of_type: HashMap<syn::Type, Vec<TenjinDeclSpecifier>> = HashMap::new();
 
         // These map will be filled in lazily.
-        let mut type_of_decl: HashMap<CDeclId, syn::Type> = HashMap::new();
+        let type_of_decl: HashMap<CDeclId, syn::Type> = HashMap::new();
 
         if let Some(decls) = raw.get("vars_of_type") {
             if let Some(decls) = decls.as_object() {
@@ -342,7 +342,7 @@ impl ParsedGuidance {
         dbg!(&declspecs_of_type);
 
         ParsedGuidance {
-            raw,
+            _raw: raw,
             declspecs_of_type,
             type_of_decl,
             decls_without_type_guidance: HashSet::new(),
@@ -2211,21 +2211,12 @@ impl<'c> Translation<'c> {
                         // Match field names against the declspecs
                         //spec.varname == name.as_str()
                         log::warn!(
-                            "TENJIN matches_decl: Field matching not implemented for decl {:?}",
-                            id
+                            "TENJIN matches_decl: Field matching not implemented for decl {:?} with name {}",
+                            id, name
                         );
                         false
                     }
-                    CDeclKind::Variable {
-                        has_static_duration,
-                        has_thread_duration,
-                        is_externally_visible,
-                        is_defn,
-                        ident,
-                        initializer,
-                        typ,
-                        attrs,
-                    } => {
+                    CDeclKind::Variable { ident, .. } => {
                         // Match variable declarations against the declspecs
                         spec.varname == ident.as_str()
                     }
@@ -4034,7 +4025,7 @@ impl<'c> Translation<'c> {
     /// ignored.
     pub fn convert_expr(
         &self,
-        mut ctx: ExprContext,
+        ctx: ExprContext,
         expr_id: CExprId,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
         self.convert_expr_guided(ctx, expr_id, &None)
@@ -5410,7 +5401,7 @@ impl<'c> Translation<'c> {
                                 expr
                             );
 
-                            if let Some(CExprKind::DeclRef(cqti, decl_id, lrval)) = expr_kind {
+                            if let Some(CExprKind::DeclRef(_cqti, decl_id, _lrval)) = expr_kind {
                                 if self
                                     .parsed_guidance
                                     .borrow_mut()

--- a/c2rust/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust/c2rust-transpile/src/translator/mod.rs
@@ -340,7 +340,7 @@ impl ParsedGuidance {
             }
         }
 
-        dbg!(&declspecs_of_type);
+        //dbg!(&declspecs_of_type);
 
         ParsedGuidance {
             _raw: raw,
@@ -626,7 +626,6 @@ pub fn translate(
     parent_fn_map: HashMap<CDeclId, CDeclId>,
 ) -> (String, PragmaVec, CrateSet) {
     let mut t = Translation::new(ast_context, tcfg, main_file.as_path(), parent_fn_map);
-    dbg!(&t.parent_fn_map);
     let ctx = ExprContext {
         used: true,
         is_static: false,
@@ -1376,7 +1375,7 @@ mod refactor_format {
     ) -> Macro {
         let old_fmt_str_expr = fmt_args[0].clone();
 
-        info!("  found fmt str {:?}", old_fmt_str_expr);
+        trace!("  found fmt str {:?}", old_fmt_str_expr);
 
         let ep = &old_fmt_str_expr;
         let s = match expr_as_lit_str(expr_strip_casts(ep)) {
@@ -1436,8 +1435,8 @@ mod refactor_format {
 
         let new_fmt_str_expr = mk().span(old_fmt_str_expr.span()).lit_expr(&new_s);
 
-        info!("old fmt str expr: {:?}", old_fmt_str_expr);
-        info!("new fmt str expr: {:?}", new_fmt_str_expr);
+        trace!("old fmt str expr: {:?}", old_fmt_str_expr);
+        trace!("new fmt str expr: {:?}", new_fmt_str_expr);
 
         let mut macro_tts: Vec<TokenTree> = Vec::new();
         let expr_tt = |e: Box<Expr>| {
@@ -2153,7 +2152,7 @@ impl<'c> Translation<'c> {
     }
 
     fn matches_decl(&self, spec: &TenjinDeclSpecifier, id: CDeclId) -> bool {
-        log::info!("TENJIN matches_decl: {:?} ({:?})", spec, id);
+        log::trace!("TENJIN matches_decl: {:?} ({:?})", spec, id);
         match self.ast_context.get_decl(&id) {
             Some(decl) => {
                 // XREF:TENJIN-DECL-SPEC-LINENUMBER
@@ -2248,7 +2247,7 @@ impl<'c> Translation<'c> {
             .get_span(SomeId::Decl(decl_id))
             .unwrap_or_else(Span::call_site);
 
-        log::info!("TENJIN convert_decl: {:?} ({:?})", decl.kind, decl_id);
+        log::trace!("TENJIN convert_decl: {:?} ({:?})", decl.kind, decl_id);
 
         use CDeclKind::*;
         match decl.kind {
@@ -2945,7 +2944,7 @@ impl<'c> Translation<'c> {
                     self.convert_variable(ctx, None, typ, &guided_type)?;
 
                 if body.is_some() {
-                    log::info!(
+                    log::trace!(
                         "Converting param variable {:?} {:?} of body-having function {:?}",
                         var,
                         decl_id,
@@ -3363,7 +3362,7 @@ impl<'c> Translation<'c> {
             ..
         } = self.ast_context.index(decl_id).kind
         {
-            log::info!(
+            log::trace!(
                 "TENJIN TRACE: convert decl var (local static duration) line {}",
                 line!()
             );
@@ -3418,7 +3417,7 @@ impl<'c> Translation<'c> {
                     "Only local variable definitions should be extracted"
                 );
 
-                log::info!(
+                log::trace!(
                     "TENJIN TRACE: convert decl var (local, non-static duration) line {}",
                     line!()
                 );
@@ -3457,7 +3456,7 @@ impl<'c> Translation<'c> {
                     self.convert_variable(ctx, initializer, typ, &guided_type)?;
                 let mut init = init?;
 
-                log::info!(
+                log::trace!(
                     "TENJIN TRACE: convert decl var line {}, stmts len = {}",
                     line!(),
                     stmts.len()
@@ -3466,13 +3465,13 @@ impl<'c> Translation<'c> {
                 stmts.append(init.stmts_mut());
                 let init = init.into_value();
 
-                log::info!(
+                log::trace!(
                     "TENJIN TRACE: convert decl var line {}, stmts+init len = {}",
                     line!(),
                     stmts.len()
                 );
 
-                log::info!(
+                log::trace!(
                     "TENJIN TRACE: convert decl var line {}, initializer = {:?}",
                     line!(),
                     initializer
@@ -3512,7 +3511,7 @@ impl<'c> Translation<'c> {
                         decl_and_assign,
                     ))
                 } else {
-                    log::info!(
+                    log::trace!(
                         "TENJIN TRACE: convert decl var line {}, no self reference",
                         line!()
                     );
@@ -3528,7 +3527,7 @@ impl<'c> Translation<'c> {
                         Some(ty)
                     };
 
-                    log::info!(
+                    log::trace!(
                         "TENJIN TRACE: convert decl var line {}, type_annotation = {:?}",
                         line!(),
                         type_annotation
@@ -3537,7 +3536,7 @@ impl<'c> Translation<'c> {
                     let local = mk().local(pat, type_annotation, Some(init.clone()));
                     let assign = mk().assign_expr(mk().ident_expr(rust_name), init);
 
-                    log::info!(
+                    log::trace!(
                         "TENJIN TRACE: convert decl var line {}, assign = {:?}",
                         line!(),
                         assign
@@ -4142,7 +4141,7 @@ impl<'c> Translation<'c> {
 
                 if let Some(fnname) = &self.function_context.borrow().name {
                     // XREF:TENJIN-GUIDANCE-STRAWMAN
-                    log::info!(
+                    log::trace!(
                         "Expr::DeclRef {:?} with name {} in function {}, decl =\n\n{:?}\n\n",
                         decl_id,
                         varname,
@@ -5395,7 +5394,7 @@ impl<'c> Translation<'c> {
                             Ok(val)
                         } else {
                             // XREF:TENJIN-GUIDANCE-STRAWMAN
-                            log::info!(
+                            log::trace!(
                                 "Array to pointer decay cast: {:?} -> {:?} expr {:?}",
                                 source_ty_kind,
                                 target_ty_kind,

--- a/c2rust/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust/c2rust-transpile/src/translator/mod.rs
@@ -246,13 +246,14 @@ struct TenjinDeclSpecifier {
     pub filespec: String,
     pub fnname: String,
     pub varname: String,
+    // XREF:TENJIN-DECL-SPEC-LINENUMBER
     pub linenumber: u32,
 }
 
 /// Example of a Tenjin declaration specifier:
 ///  fnname:varname#linenumber@pathsuffix
 /// The `:varname`, `#linenumber`, and `@pathsuffix` parts are optional.
-/// If omitted, they match all functions, lines, and files, respectively.
+/// If omitted, they match all variables, lines, and files, respectively.
 /// A pathsuffix can match one or more files in a directory tree.
 fn parse_tenjin_decl_specifier(s: &str) -> Option<TenjinDeclSpecifier> {
     if s.is_empty() {
@@ -2155,6 +2156,7 @@ impl<'c> Translation<'c> {
         log::info!("TENJIN matches_decl: {:?} ({:?})", spec, id);
         match self.ast_context.get_decl(&id) {
             Some(decl) => {
+                // XREF:TENJIN-DECL-SPEC-LINENUMBER
                 if spec.linenumber > 0
                     && decl.begin_loc().map(|loc| loc.line) != Some(spec.linenumber as u64)
                 {
@@ -2209,7 +2211,6 @@ impl<'c> Translation<'c> {
                     CDeclKind::Function { name, .. } => spec.varname == name.as_str(),
                     CDeclKind::Field { ref name, .. } => {
                         // Match field names against the declspecs
-                        //spec.varname == name.as_str()
                         log::warn!(
                             "TENJIN matches_decl: Field matching not implemented for decl {:?} with name {}",
                             id, name

--- a/c2rust/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust/c2rust-transpile/src/translator/mod.rs
@@ -1381,9 +1381,9 @@ mod refactor_format {
         let ep = &old_fmt_str_expr;
         let s = match expr_as_lit_str(expr_strip_casts(ep)) {
             Some(LitStrOrByteStr::LitStr(s)) => s.value(),
-            Some(LitStrOrByteStr::ByteStr(b)) => {
-                str::from_utf8(b.value().as_slice()).unwrap().to_owned()
-            }
+            Some(LitStrOrByteStr::ByteStr(b)) => std::str::from_utf8(b.value().as_slice())
+                .unwrap()
+                .to_owned(),
             None => panic!(
                 "TENJIN expected format string to be a string literal: {:?}",
                 ep

--- a/c2rust/c2rust-transpile/src/translator/parent_fn.rs
+++ b/c2rust/c2rust-transpile/src/translator/parent_fn.rs
@@ -1,0 +1,57 @@
+//! Compute a map from local variable/parameter `CDeclId`s to the `CDeclId` of
+//! their parent function.
+
+use crate::c_ast::iterators::SomeId;
+use crate::c_ast::{iterators::DFExpr, CDeclId, CDeclKind, CStmtId, TypedAstContext};
+use std::collections::HashMap;
+
+struct ParentFnCollector<'a> {
+    ast_context: &'a TypedAstContext,
+    parent_fn_map: HashMap<CDeclId, CDeclId>,
+    current_fn: Option<CDeclId>,
+}
+
+impl<'a> ParentFnCollector<'a> {
+    fn new(ast_context: &'a TypedAstContext) -> Self {
+        ParentFnCollector {
+            ast_context,
+            parent_fn_map: HashMap::new(),
+            current_fn: None,
+        }
+    }
+
+    fn visit_function_body(&mut self, body_id: CStmtId) {
+        let iter = DFExpr::new(self.ast_context, SomeId::Stmt(body_id));
+        for node in iter {
+            if let SomeId::Decl(decl_id) = node {
+                let decl = &self.ast_context[decl_id];
+                if let CDeclKind::Variable { .. } = decl.kind {
+                    if let Some(fn_id) = self.current_fn {
+                        self.parent_fn_map.insert(decl_id, fn_id);
+                    }
+                }
+            }
+        }
+    }
+}
+
+pub fn compute_parent_fn_map(ast_context: &TypedAstContext) -> HashMap<CDeclId, CDeclId> {
+    let mut collector = ParentFnCollector::new(ast_context);
+    for &decl_id in ast_context.c_decls_top.iter() {
+        let decl = &ast_context[decl_id];
+        if let CDeclKind::Function {
+            ref parameters,
+            body: Some(body_id),
+            ..
+        } = decl.kind
+        {
+            collector.current_fn = Some(decl_id);
+            for param_id in parameters {
+                collector.parent_fn_map.insert(*param_id, decl_id);
+            }
+            collector.visit_function_body(body_id);
+            collector.current_fn = None;
+        }
+    }
+    collector.parent_fn_map
+}

--- a/c2rust/c2rust-transpile/src/translator/tenjin.rs
+++ b/c2rust/c2rust-transpile/src/translator/tenjin.rs
@@ -171,12 +171,14 @@ impl Translation<'_> {
                 }
 
                 if let Some(base_decl_id) = self.c_expr_decl_id(*raw_base) {
-                    let base_decl = &self.ast_context[base_decl_id].kind;
-                    if let CDeclKind::Variable { ident, .. } = base_decl {
-                        if !(ident == "s1" || ident == "s2") {
-                            log::info!("target string not s1 or s2");
-                            return Ok(None);
-                        }
+                    let guided_type = self
+                        .parsed_guidance
+                        .borrow_mut()
+                        .query_decl_type(self, base_decl_id);
+
+                    if guided_type != Some(syn::parse_str("String").unwrap()) {
+                        log::info!("target variable not guided to be of type String");
+                        return Ok(None);
                     }
                 } else {
                     return Ok(None);

--- a/c2rust/c2rust-transpile/src/translator/tenjin.rs
+++ b/c2rust/c2rust-transpile/src/translator/tenjin.rs
@@ -131,11 +131,11 @@ impl Translation<'_> {
         &self,
         ctx: ExprContext,
         op: c_ast::BinOp,
-        qtype: CQualTypeId,
+        _qtype: CQualTypeId,
         lhs: CExprId,
         rhs: CExprId,
-        compute_type: Option<CQualTypeId>,
-        result_type: Option<CQualTypeId>,
+        _compute_type: Option<CQualTypeId>,
+        _result_type: Option<CQualTypeId>,
     ) -> TranslationResult<Option<WithStmts<Box<Expr>>>> {
         // Code matching
         //     s1[strlen(s1)-1] = '\0';

--- a/c2rust/c2rust-transpile/src/translator/tenjin.rs
+++ b/c2rust/c2rust-transpile/src/translator/tenjin.rs
@@ -143,14 +143,14 @@ impl Translation<'_> {
         // can be translated to
         //     s1.pop();
         // (assuming the assignment expr is in a statement position)
-        log::info!("Recognizing C assignment string pop?...");
+        log::trace!("Recognizing C assignment string pop?...");
         if op != c_ast::BinOp::Assign {
-            log::info!("Not an assignment operator");
+            log::trace!("Not an assignment operator");
             return Ok(None);
         }
 
         if !self.is_integral_lit(self.strip_integral_cast(rhs), 0) {
-            log::info!("Not assigned an integral literal 0");
+            log::trace!("Not assigned an integral literal 0");
             return Ok(None);
         }
 
@@ -166,7 +166,7 @@ impl Translation<'_> {
             ) = self.ast_context.index(*index).kind
             {
                 if !self.is_integral_lit(self.strip_integral_cast(sub_rhs), 1) {
-                    log::info!("Not subtracting 1 from the index");
+                    log::trace!("Not subtracting 1 from the index");
                     return Ok(None);
                 }
 
@@ -177,7 +177,7 @@ impl Translation<'_> {
                         .query_decl_type(self, base_decl_id);
 
                     if guided_type != Some(syn::parse_str("String").unwrap()) {
-                        log::info!("target variable not guided to be of type String");
+                        log::trace!("target variable not guided to be of type String");
                         return Ok(None);
                     }
                 } else {
@@ -207,15 +207,15 @@ impl Translation<'_> {
                                     mk().path_segment("pop"),
                                     vec![],
                                 );
-                                log::info!("Recognized assignment, returning pop call");
+                                log::trace!("Recognized assignment, returning pop call");
                                 return Ok(Some(WithStmts::new_val(pop_call)));
                             } else {
-                                log::info!("Call to strlen does not match the expected argument");
+                                log::trace!("Call to strlen does not match the expected argument");
                             }
                         }
-                        log::info!("Not a call to strlen");
+                        log::trace!("Not a call to strlen");
                     } else {
-                        log::info!(
+                        log::trace!(
                             "Callee is not a decl ref: {:?}",
                             self.ast_context.index(callee).kind
                         );
@@ -223,7 +223,7 @@ impl Translation<'_> {
                 }
             }
         }
-        log::info!("LHS not an array subscript");
+        log::trace!("LHS not an array subscript");
         Ok(None)
     }
 }

--- a/c2rust/c2rust-transpile/src/translator/tenjin.rs
+++ b/c2rust/c2rust-transpile/src/translator/tenjin.rs
@@ -1,0 +1,219 @@
+use super::*;
+use syn::{Expr, Path, Type};
+
+pub fn is_known_size_1_type(ty: &Type) -> bool {
+    match ty {
+        Type::Path(path) => path.qself.is_none() && is_known_size_1_path(&path.path),
+        _ => false,
+    }
+}
+
+fn is_path_exactly_1(path: &Path, a: &str) -> bool {
+    if path.segments.len() == 1 {
+        path.segments[0].ident.to_string().as_str() == a
+    } else {
+        false
+    }
+}
+
+fn is_path_exactly_2(path: &Path, a: &str, b: &str) -> bool {
+    if path.segments.len() == 2 {
+        path.segments[0].ident.to_string().as_str() == a
+            && path.segments[1].ident.to_string().as_str() == b
+    } else {
+        false
+    }
+}
+
+fn is_known_size_1_path(path: &Path) -> bool {
+    match path.segments.len() {
+        1 => matches!(
+            path.segments[0].ident.to_string().as_str(),
+            "u8" | "i8" | "bool" | "char"
+        ),
+        2 => is_path_exactly_2(path, "libc", "c_char"),
+        _ => false,
+    }
+}
+
+pub fn expr_is_ident(expr: &Expr, ident: &str) -> bool {
+    if let Expr::Path(ref path) = *expr {
+        is_path_exactly_1(&path.path, ident)
+    } else {
+        false
+    }
+}
+
+/// The given expression is being used in a context expecting a u64 value.
+/// Builder::cast_expr() will strip value-preserving casts. Because we know
+/// the type imposed by the context, we can also entirely elide casts of
+/// compatible integer literals.
+/// Examples with expr = x of type i16, and with the implicit `as u64` written explicitly:
+///      (x as i8)    as u64 => (x as i8) as u64     # inner cast may change value
+///      (x as i32)   as u64 => x as u64             # inner cast is value-preserving
+///      (1000 as i8) as u64 => (1000 as i8) as u64  # with large literal, inner cast is not value-preserving
+///      (10 as i8)   as u64 => 10                   # with small literal, inner cast is value-preserving
+///      1000 as u64         => 1000                 # outer cast is made redundant by known context
+pub fn expr_in_u64(expr: Box<Expr>) -> Box<Expr> {
+    use crate::translator::mk;
+    let cast_box = mk().cast_expr(expr, mk().path_ty(vec!["u64"]));
+    // If we end up with a cast of a literal, we can elide the outer cast.
+    if let Expr::Cast(ref cast) = *cast_box {
+        if let Expr::Lit(ref elit) = *cast.expr {
+            if let syn::Lit::Int(ref lit_int) = elit.lit {
+                // If the literal is small enough, we can elide the cast
+                if lit_int.base10_parse::<u64>().is_ok() {
+                    return cast.expr.clone();
+                }
+            }
+        }
+    }
+    cast_box
+}
+
+impl Translation<'_> {
+    pub fn recognize_c_assignment_cases(
+        &self,
+        ctx: ExprContext,
+        op: c_ast::BinOp,
+        qtype: CQualTypeId,
+        lhs: CExprId,
+        rhs: CExprId,
+        compute_type: Option<CQualTypeId>,
+        result_type: Option<CQualTypeId>,
+    ) -> TranslationResult<Option<WithStmts<Box<Expr>>>> {
+        self.recognize_c_assignment_string_pop(ctx, op, qtype, lhs, rhs, compute_type, result_type)
+    }
+
+    fn strip_integral_cast(&self, expr: CExprId) -> CExprId {
+        let kind = &self.ast_context.index(expr).kind;
+        if let CExprKind::ImplicitCast(_, inner, CastKind::IntegralCast, _, _) = kind {
+            *inner
+        } else {
+            expr
+        }
+    }
+
+    fn is_integral_lit(&self, expr: CExprId, val: u64) -> bool {
+        let kind = &self.ast_context.index(expr).kind;
+        if let CExprKind::Literal(_, clit) = kind {
+            match clit {
+                CLiteral::Integer(value, _base) => *value == val,
+                CLiteral::Character(value) => *value == val,
+                _ => false,
+            }
+        } else {
+            false
+        }
+    }
+
+    fn c_expr_decl_id(&self, expr: CExprId) -> Option<CDeclId> {
+        let kind = &self
+            .ast_context
+            .index(self.c_strip_implicit_casts(expr))
+            .kind;
+        if let CExprKind::DeclRef(_, decl_id, _) = kind {
+            Some(*decl_id)
+        } else {
+            None
+        }
+    }
+
+    fn recognize_c_assignment_string_pop(
+        &self,
+        ctx: ExprContext,
+        op: c_ast::BinOp,
+        qtype: CQualTypeId,
+        lhs: CExprId,
+        rhs: CExprId,
+        compute_type: Option<CQualTypeId>,
+        result_type: Option<CQualTypeId>,
+    ) -> TranslationResult<Option<WithStmts<Box<Expr>>>> {
+        // Code matching
+        //     s1[strlen(s1)-1] = '\0';
+        //         when s1 is guided to be a String
+        // can be translated to
+        //     s1.pop();
+        // (assuming the assignment expr is in a statement position)
+        log::info!("Recognizing C assignment string pop?...");
+        if op != c_ast::BinOp::Assign {
+            log::info!("Not an assignment operator");
+            return Ok(None);
+        }
+
+        if !self.is_integral_lit(self.strip_integral_cast(rhs), 0) {
+            log::info!("Not assigned an integral literal 0");
+            return Ok(None);
+        }
+
+        let lhs_kind = &self.ast_context.index(lhs).kind;
+        if let CExprKind::ArraySubscript(_, raw_base, index, _lrvalue) = lhs_kind {
+            if let CExprKind::Binary(
+                _sub_cq,
+                c_ast::BinOp::Subtract,
+                sub_lhs,
+                sub_rhs,
+                _opt_cq_lhs,
+                _opt_cq_rhs,
+            ) = self.ast_context.index(*index).kind
+            {
+                if !self.is_integral_lit(self.strip_integral_cast(sub_rhs), 1) {
+                    log::info!("Not subtracting 1 from the index");
+                    return Ok(None);
+                }
+
+                if let Some(base_decl_id) = self.c_expr_decl_id(*raw_base) {
+                    let base_decl = &self.ast_context[base_decl_id].kind;
+                    if let CDeclKind::Variable { ident, .. } = base_decl {
+                        if !(ident == "s1" || ident == "s2") {
+                            log::info!("target string not s1 or s2");
+                            return Ok(None);
+                        }
+                    }
+                } else {
+                    return Ok(None);
+                };
+
+                if let CExprKind::Call(_, callee_raw, args) = &self.ast_context.index(sub_lhs).kind
+                {
+                    let callee = self.c_strip_implicit_casts(*callee_raw);
+                    if let CExprKind::DeclRef(_, callee_decl_id, _opt_cq) =
+                        self.ast_context.index(callee).kind
+                    {
+                        if let CDeclKind::Function { name, .. } =
+                            &self.ast_context[callee_decl_id].kind
+                        {
+                            if name != "strlen" {
+                                return Ok(None);
+                            }
+
+                            if args.len() == 1
+                                && self.c_expr_decl_id(args[0]) == self.c_expr_decl_id(*raw_base)
+                            {
+                                let tgt_expr =
+                                    self.convert_expr(ctx, self.c_strip_implicit_casts(*raw_base))?;
+                                let pop_call = mk().method_call_expr(
+                                    tgt_expr.to_expr(),
+                                    mk().path_segment("pop"),
+                                    vec![],
+                                );
+                                log::info!("Recognized assignment, returning pop call");
+                                return Ok(Some(WithStmts::new_val(pop_call)));
+                            } else {
+                                log::info!("Call to strlen does not match the expected argument");
+                            }
+                        }
+                        log::info!("Not a call to strlen");
+                    } else {
+                        log::info!(
+                            "Callee is not a decl ref: {:?}",
+                            self.ast_context.index(callee).kind
+                        );
+                    }
+                }
+            }
+        }
+        log::info!("LHS not an array subscript");
+        Ok(None)
+    }
+}

--- a/c2rust/c2rust-transpile/src/translator/tenjin.rs
+++ b/c2rust/c2rust-transpile/src/translator/tenjin.rs
@@ -8,7 +8,7 @@ pub fn is_known_size_1_type(ty: &Type) -> bool {
     }
 }
 
-fn is_path_exactly_1(path: &Path, a: &str) -> bool {
+pub fn is_path_exactly_1(path: &Path, a: &str) -> bool {
     if path.segments.len() == 1 {
         path.segments[0].ident.to_string().as_str() == a
     } else {
@@ -33,6 +33,14 @@ fn is_known_size_1_path(path: &Path) -> bool {
         ),
         2 => is_path_exactly_2(path, "libc", "c_char"),
         _ => false,
+    }
+}
+
+pub fn expr_get_path(expr: &Expr) -> Option<&Path> {
+    if let Expr::Path(ref path) = *expr {
+        Some(&path.path)
+    } else {
+        None
     }
 }
 

--- a/c2rust/c2rust/Cargo.toml
+++ b/c2rust/c2rust/Cargo.toml
@@ -25,6 +25,7 @@ log = "0.4"
 regex = "1.3"
 shlex = "1.3"
 c2rust-transpile = { version = "0.20.0", path = "../c2rust-transpile" }
+serde_json = "1.0"
 
 [build-dependencies]
 c2rust-build-paths = { path = "../c2rust-build-paths", version = "0.20.0" }

--- a/cli/hermetic.py
+++ b/cli/hermetic.py
@@ -135,14 +135,17 @@ def cargo_encoded_rustflags_env_ext() -> dict:
 
 
 def run_cargo_in(
-    args: Sequence[str], cwd: Path | None, check=True, **kwargs
+    args: Sequence[str], cwd: Path | None, env_ext=None, check=True, **kwargs
 ) -> subprocess.CompletedProcess:
+    if not env_ext:
+        env_ext = {}
+
     return run(
         ["cargo", cargo_toolchain_specifier(), *args],
         cwd=cwd,
         check=check,
         with_tenjin_deps=True,
-        env_ext=cargo_encoded_rustflags_env_ext(),
+        env_ext={**env_ext, **cargo_encoded_rustflags_env_ext()},
         **kwargs,
     )
 
@@ -159,7 +162,7 @@ def opam_non_hermetic() -> bool:
     """If we're running in CI and opam is installed, we should use it.
 
     Note that we don't do any version checks; we're assuming that CI is
-    set up to use a version opam that is either known to be compatible,
+    set up to use a version of opam that is either known to be compatible,
     or that we want to test the compatibility of.
     """
     return running_in_ci() and shutil.which("opam") is not None

--- a/cli/translation.py
+++ b/cli/translation.py
@@ -1,0 +1,122 @@
+import shutil
+import tempfile
+from pathlib import Path
+import re
+
+import hermetic
+
+
+def do_translate(
+    root: Path,
+    codebase: Path,
+    resultsdir: Path,
+    cratename: str,
+    c_main_in: str | None = None,
+    guidance: str | None = None,
+):
+    """
+    Translate a codebase from C to Rust.
+
+    The input directory should have a pre-generated compile_commands.json file,
+    or an easy means of generating one (such as a CMakeLists.txt file).
+
+    The `resultsdir` directory will contain subdirectories with intermediate
+    stages of the resulting translation. Assuming no errors occurred, the final
+    translation will be in the `final` subdirectory. The `resultsdir` will also
+    (eventually)
+    have a file called `ingest.json` containing metadata about the translation.
+    """
+
+    def perform_pre_translation(builddir: Path) -> Path:
+        provided_compdb = codebase / "compile_commands.json"
+        provided_cmakelists = codebase / "CMakeLists.txt"
+
+        if provided_cmakelists.exists() and not provided_compdb.exists():
+            # If we have a CMakeLists.txt, we can generate the compile_commands.json
+            hermetic.run(
+                [
+                    "cmake",
+                    "-S",
+                    str(codebase),
+                    "-B",
+                    str(builddir),
+                    "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
+                ],
+                check=True,
+            )
+            return builddir / "compile_commands.json"
+        else:
+            # Otherwise, we assume the compile_commands.json is already present
+            return provided_compdb
+
+    c2rust_transpile_flags = [
+        "--translate-const-macros",
+        "--reduce-type-annotations",
+        "--disable-refactoring",
+        "--log-level",
+        "INFO",
+        "--guidance",
+        guidance if guidance else "{}",
+    ]
+
+    if c_main_in:
+        c2rust_transpile_flags.extend(["--binary", c_main_in.removesuffix(".c")])
+
+    with tempfile.TemporaryDirectory() as builddirname:
+        builddir = Path(builddirname)
+        compdb = perform_pre_translation(builddir)
+
+        c2rust_bin = root / "c2rust" / "target" / "debug" / "c2rust"
+
+        # The crate name that c2rust uses is based on the directory stem,
+        # so we create a subdirectory with the desired crate name.
+        output = resultsdir / cratename
+        output.mkdir(parents=True, exist_ok=False)
+        hermetic.run(
+            [str(c2rust_bin), "transpile", str(compdb), "-o", str(output), *c2rust_transpile_flags],
+            check=True,
+            env_ext={
+                "RUST_BACKTRACE": "1",
+            },
+        )
+        # Normalize the unmodified translation results to end up
+        # in a directory with a project-independent name.
+        renamed_output = resultsdir / "out_00"
+        output.rename(renamed_output)
+
+        # Eventually, we'll add improvement passes here which will
+        # generate additional intermediate `out_XX` directories.
+
+        # Find the highest numbered output directory and copy its contents
+        # to the final output directory.
+        highest_out = find_highest_output_dir(resultsdir)
+        if highest_out is not None:
+            shutil.copytree(
+                highest_out,
+                resultsdir / "final",
+            )
+
+
+def find_highest_output_dir(base: Path) -> Path | None:
+    """
+    Find the directory matching pattern 'out_X' with the largest X.
+    """
+    pattern = re.compile(r"^out_(\d+)$")
+    base = Path(base)
+
+    if not base.exists():
+        return None
+
+    max_num = -1
+    latest_dir = None
+
+    for item in base.iterdir():
+        if item.is_dir():
+            match = pattern.match(item.name)
+            if match:
+                num = int(match.group(1))
+                if num > max_num:
+                    max_num = num
+                    latest_dir = item
+
+    return latest_dir if latest_dir else None

--- a/docs/c2rust_notes.md
+++ b/docs/c2rust_notes.md
@@ -121,7 +121,7 @@ The intermediate TypedAstContext will have entries such as
 
 along with more for `FunctionToPointerDecay` and `ImplicitCast`. This output can be viewed by passing the `--dump-typed-clang-ast` flag to `c2rust transpile`.
 
-The structure can be viewed more compactly with a command like `10j exec clang -Xclang -ast-dump <SOME_FILE.c>`, for which the `puts(s)` statement will be shown with
+The structure can be viewed more compactly with a command like `10j exec clang -Xclang -ast-dump -fsyntax-only <SOME_FILE.c>`, for which the `puts(s)` statement will be shown with
 
 ```
 ...


### PR DESCRIPTION
Without guidance, translation of

```
void helper(const char *s1) {
    printf("%zd!\n", strlen(s1));
}

int main() {
    char s1[32] = "";
    fgets(s1, sizeof(s1), stdin);
    helper(s1);
    return 0;
}
```

produces

```
pub unsafe fn helper(mut s1: *const libc::c_char) {
    println!("{:}!", strlen(s1) as libc::ssize_t);
}
unsafe fn main_0() -> libc::c_int {
    let mut s1 = *::core::mem::transmute::<
        &[u8; 32],
        &mut [libc::c_char; 32],
    >(b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0");
    fgets(s1.as_mut_ptr(), 32 as libc::c_int, stdin);
    helper(s1.as_mut_ptr());
    return 0 as libc::c_int;
}
```

as compared with the c2rust v0.20.0 result of

```
pub unsafe extern "C" fn helper(mut s1: *const libc::c_char) {
    printf(b"%zd\n\0" as *const u8 as *const libc::c_char, strlen(s1));
}
unsafe fn main_0() -> libc::c_int {
    let mut s1: [libc::c_char; 32] = *::core::mem::transmute::<
        &[u8; 32],
        &mut [libc::c_char; 32],
    >(b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0");
    fgets(
        s1.as_mut_ptr(),
        ::core::mem::size_of::<[libc::c_char; 32]>() as libc::c_ulong as libc::c_int,
        stdin,
    );
    helper(s1.as_mut_ptr());
    return 0 as libc::c_int;
}
```

With `--guidance '{"vars_of_type":{"String":["*:s1"]}}'` we now get

```
pub unsafe fn helper(s1: String) {
    println!("{:}", s1.len() as libc::ssize_t);
}
unsafe fn main_0() -> libc::c_int {
    let mut s1 = String::new();
    (std::io::stdin()).lock().take(32).read_line(&mut s1).unwrap();
    helper(s1);
    return 0 as libc::c_int;
}
```