### PR TITLE
Have LLVM version specifier include a tenjin-build-deps release tag

### DIFF
--- a/cli/constants.py
+++ b/cli/constants.py
@@ -1,7 +1,7 @@
 # Note: the keys in this dict are not command names, or file names,
 # just arbitrary labels for the things we are tracking.
 WANT = {
-    "10j-llvm": "18.1.8",
+    "10j-llvm": "18.1.8@rev-03d4672c4",
     "10j-opam": "2.3.0",
     "10j-dune": "3.19.0",
     "10j-ocaml": "5.2.0",


### PR DESCRIPTION
This also fixes the HAVE logic for `provision_10j_llvm_with()` to enforce the invariant that we end up having exactly the wanted version.