### PR TITLE
Modify CI to automatically run once per day

### DIFF
--- a/.github/workflows/nrsr.yaml
+++ b/.github/workflows/nrsr.yaml
@@ -5,6 +5,15 @@ on:
     branches: [ "test/**", "test-**" ]
   pull_request:
     branches: [ "main" ]
+  schedule:
+    # Run every day at 12:39 UTC (mid morning on the US East Coast).
+    # Daily runs are done for two reasons:
+    # 1. To ensure that GitHub Actions has a fresh cache to use.
+    #    See https://docs.github.com/en/actions/reference/dependency-caching-reference#restrictions-for-accessing-a-cache
+    # 2. To catch any issues arising from external changes.
+    - cron:  '39 12 * * *'
+  workflow_dispatch:
+    # No particular downsides to enabling manual workflow runs, afaik?
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
If we don't do this, we end up not getting anything cached for most runs because we'd only be creating caches in PR and test branches, and GitHub's cache isolation ensures that each branch could only use caches from itself or the base branch (`main`).

While we're here, this also enables manual runs via `workflow_dispatch` (mostly so I don't have to wait until tomorrow to get a usable cache entry).