### PR TITLE
Have CI build `xj-improve-multitool` via `10j build-rs`

### DIFF
--- a/.github/workflows/nrsr.yaml
+++ b/.github/workflows/nrsr.yaml
@@ -62,7 +62,7 @@ jobs:
         run: cd c2rust && ../cli/10j cargo test --locked --release $C2RUST_TESTED_CRATES
 
       - name: Build c2rust binaries
-        run: cd c2rust && ../cli/10j cargo build --locked --release $C2RUST_TESTED_CRATES
+        run: XJ_BUILD_RS_PROFILE=release cli/10j build-rs
 
   not-rocket-science-rs-lint:
     runs-on: ubuntu-latest

--- a/cli/main.py
+++ b/cli/main.py
@@ -81,13 +81,15 @@ def do_fix_rs():
 
 
 def do_build_rs(root: Path):
+    cargo_profile = os.environ.get("XJ_BUILD_RS_PROFILE", "dev")
+    cargo_flags = f"--locked --profile={cargo_profile}"
     hermetic.run_cargo_in(
-        "build --locked -p c2rust -p c2rust-transpile".split(),
+        f"build {cargo_flags} -p c2rust -p c2rust-transpile".split(),
         cwd=root / "c2rust",
         check=True,
     )
     hermetic.run_cargo_in(
-        "build --locked --workspace".split(),
+        f"build {cargo_flags} --workspace".split(),
         cwd=root / "xj-improve-multitool",
         check=True,
     )

--- a/cli/provisioning.py
+++ b/cli/provisioning.py
@@ -451,9 +451,6 @@ def provision_10j_rust_toolchain_with(version: str, keyname: str):
     cmd = ["rustup", "component", "add", "--toolchain", toolchain_spec, "clippy", "rustfmt"]
     if toolchain_spec.startswith("nightly"):
         cmd.append("rustc-dev")
-        # Removing the `llvm-tools` component will not break CI on GitHub Actions because the standard
-        # runners come with LLVM preinstalled. But it will break installs in a fresh VM/container
-        # when executing `10 build-rs` (when linking `xj-improve-multitool`).
         cmd.append("llvm-tools")
 
     say(f"Installing Rust toolchain {toolchain_spec}...")


### PR DESCRIPTION
For a while we were failing to detect broken provisioning because CI was only running `10j check-rs` and not `10j build-rs` -- the latter also does linking, and it was the linking that was failing!