### PR TITLE
Fix re-provisioning of LLVM on Mac

### DIFF
--- a/cli/provisioning.py
+++ b/cli/provisioning.py
@@ -60,7 +60,8 @@ class TrackingWhatWeHave:
             self.save()
 
     def note_removed(self, name: str):
-        del self._have[name]
+        if name in self._have:
+            del self._have[name]
         self.save()
 
     def query(self, name: str) -> str | None:


### PR DESCRIPTION
Because macOS does not need a sysroot, the HAVE dict would not have the key. But we would unconditionally try to delete the sysroot key and wind up raising a KeyError.