### PR TITLE
Update to an LLVM build which provides an `as` for us

### DIFF
--- a/cli/constants.py
+++ b/cli/constants.py
@@ -1,7 +1,7 @@
 # Note: the keys in this dict are not command names, or file names,
 # just arbitrary labels for the things we are tracking.
 WANT = {
-    "10j-llvm": "18.1.8@rev-03d4672c4",
+    "10j-llvm": "18.1.8@rev-2523bdaf6",
     "10j-opam": "2.3.0",
     "10j-dune": "3.19.0",
     "10j-ocaml": "5.2.0",

--- a/cli/provisioning.py
+++ b/cli/provisioning.py
@@ -894,7 +894,9 @@ def provision_10j_llvm_with(version: str, keyname: str):
     def add_binutils_alike_symbolic_links():
         # Add symbolic links for the binutils-alike tools.
         # Tools not provided by LLVM: ranlib, size
-        binutils_names = ["ar", "as", "nm", "objcopy", "objdump", "readelf", "strings", "strip"]
+        # Tenjin's LLVM ships `as` as a wrapper around `llvm-mc`
+        #   because `llvm-as` is for assembling LLVM IR, not platform assembly.
+        binutils_names = ["ar", "nm", "objcopy", "objdump", "readelf", "strings", "strip"]
         for name in binutils_names:
             src = hermetic.xj_llvm_root(localdir) / "bin" / f"llvm-{name}"
             dst = hermetic.xj_llvm_root(localdir) / "bin" / f"{name}"


### PR DESCRIPTION
Having `as` symlinked to `llvm-as` (which is for LLVM IR, not platform-specific assembly) caused `10j clang` to fail to build `tcc` 0.9.28rc.