### PR TITLE
Include `_local/xj-llvm/lib` in `LD_LIBRARY_PATH`

### DIFF
--- a/cli/hermetic.py
+++ b/cli/hermetic.py
@@ -55,6 +55,10 @@ def mk_env_for(localdir: Path, with_tenjin_deps=True, env_ext=None, **kwargs) ->
             str(localdir / "cmake" / "bin"),
             env["PATH"],
         ])
+        env["LD_LIBRARY_PATH"] = os.pathsep.join([
+            str(xj_llvm_root(localdir) / "lib"),
+            env.get("LD_LIBRARY_PATH", ""),
+        ])
 
     return env
 


### PR DESCRIPTION
This ensures that binaries dynamically linked against libLLVM and/or libClang will run when invoked via `10j exec`, without needing the binary to embed RPATH or RUNPATH.