### PR TITLE
10j translate: Add `--buildcmd flag`, e.g. for bespokely named Makefiles

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -197,13 +197,19 @@ def cli():
     "--guidance",
     help="Guidance for the translation process. Path or JSON literal.",
 )
-def translate(codebase, resultsdir, cratename, c_main_in, guidance):
+@click.option(
+    "--buildcmd",
+    help="Build command (for in-tree build), will be run via `intercept-build`.",
+)
+def translate(codebase, resultsdir, cratename, c_main_in, guidance, buildcmd):
     root = repo_root.find_repo_root_dir_Path()
     do_build_rs(root)
     if guidance is None:
         click.echo("Using empty guidance; pass `--guidance` to refine translation.", err=True)
         guidance = "{}"
-    translation.do_translate(root, Path(codebase), Path(resultsdir), cratename, guidance, c_main_in)
+    translation.do_translate(
+        root, Path(codebase), Path(resultsdir), cratename, guidance, c_main_in, buildcmd
+    )
 
 
 @cli.command()


### PR DESCRIPTION
For codebases which furnish multiple binaries, we need some way of distinguishing which binary should be built.