### PR TITLE
Do not erase lines starting with whitespace before dead outer attributes

### DIFF
--- a/xj-improve-multitool/src/span_eraser.rs
+++ b/xj-improve-multitool/src/span_eraser.rs
@@ -61,19 +61,18 @@ impl SpanEraser {
                 continue;
             }
 
-            fn line_chars_looks_like_outer_attribute(line: &str, allow_whitespace: bool) -> bool {
+            fn line_chars_looks_like_outer_attribute(line: &str) -> bool {
                 if line.len() < 2 {
                     return false;
                 }
                 let mut chars = line.chars();
                 let first_char = chars.next().unwrap();
                 let second_char = chars.next().unwrap();
-                let outer_attr = first_char == '#' && second_char == '[';
-                let was_spaces = first_char.is_whitespace() && second_char.is_whitespace();
-                outer_attr || (allow_whitespace && was_spaces)
+
+                first_char == '#' && second_char == '['
             }
 
-            if !line_chars_looks_like_outer_attribute(srclines[item_start_lineno - 1], false) {
+            if !line_chars_looks_like_outer_attribute(srclines[item_start_lineno - 1]) {
                 // Looks like this item wasn't preceded by an attribute, so we'll short circuit.
                 continue;
             }
@@ -85,8 +84,7 @@ impl SpanEraser {
                     break;
                 }
 
-                if !line_chars_looks_like_outer_attribute(srclines[current_lineno - 1_usize], true)
-                {
+                if !line_chars_looks_like_outer_attribute(srclines[current_lineno - 1_usize]) {
                     break;
                 }
 


### PR DESCRIPTION
Counterexample:

```
pub static mut authority: *mut core::ffi::c_char =
    0 as *const core::ffi::c_char as *mut core::ffi::c_char;
#[no_mangle]
```

The attribute should be removed, but not the line before it.