### PR TITLE
Remove trivial casts of numeric literals

### DIFF
--- a/cli/translation_improvement.py
+++ b/cli/translation_improvement.py
@@ -1,6 +1,7 @@
 import os
 import enum
 import json
+
 import time
 import shutil
 import tempfile
@@ -407,6 +408,184 @@ def run_whiteout_clippy_no_effect_paths(root: Path, dir: Path) -> None:
     rewriter.erase_spans()
 
 
+def run_trivial_numeric_casts_improvement(root: Path, dir: Path) -> None:
+    """Remove trivial numeric casts, as reported by clippy."""
+
+    # Stats
+    cargo_check_runs = 0
+    cargo_check_failures = 0
+    cargo_clippy_runs = 0
+
+    def run_check(cwd: Path) -> bool:
+        nonlocal cargo_check_runs, cargo_check_failures
+        cargo_check_runs += 1
+        cp = hermetic.run_cargo_in(
+            ["check"],
+            cwd=cwd,
+            check=False,
+            capture_output=True,
+        )
+        if cp.returncode != 0:
+            cargo_check_failures += 1
+            return False
+        return True
+
+    def get_trivial_casts(cwd: Path) -> list[dict]:
+        nonlocal cargo_clippy_runs
+        cargo_clippy_runs += 1
+
+        allowed_lints = [
+            "unused",
+            "static_mut_refs",
+            "clippy::missing_safety_doc",
+            "clippy::if_same_then_else",
+        ]
+        clippy_args = ["clippy", "--message-format=json", "--", "-W", "trivial_numeric_casts"]
+        for lint in allowed_lints:
+            clippy_args.extend(["-A", lint])
+
+        cp = hermetic.run_cargo_in(
+            clippy_args,
+            cwd=cwd,
+            check=False,
+            capture_output=True,
+        )
+
+        messages = []
+        if cp.stdout:
+            for line in cp.stdout.decode("utf-8").splitlines():
+                try:
+                    messages.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+
+        trivial_casts = []
+        file_contents: dict[str, str] = {}
+
+        for msg in messages:
+            if msg.get("reason") != "compiler-message":
+                continue
+            message = msg.get("message", {})
+            if message.get("code", {}).get("code") != "trivial_numeric_casts":
+                continue
+
+            for span in message.get("spans", []):
+                if not span.get("is_primary"):
+                    continue
+
+                file_path = dir / span["file_name"]
+                if str(file_path) not in file_contents:
+                    try:
+                        with open(file_path, "r", encoding="utf-8") as f:
+                            file_contents[str(file_path)] = f.read()
+                    except FileNotFoundError:
+                        continue
+
+                content = file_contents[str(file_path)]
+                span_text = content[span["byte_start"] : span["byte_end"]]
+
+                if " as " in span_text:
+                    val_part = span_text.split(" as ")[0].strip()
+                    cleaned_val = val_part.replace("_", "")
+                    try:
+                        int(cleaned_val, base=0)
+                        trivial_casts.append(span)
+                    except ValueError:
+                        continue
+        return trivial_casts
+
+    def apply_removals(casts: list[dict]) -> dict[str, SpeculativeFileRewriter]:
+        rewriters: dict[str, SpeculativeFileRewriter] = {}
+        for span in casts:
+            file_name = span["file_name"]
+            if file_name not in rewriters:
+                rewriters[file_name] = SpeculativeFileRewriter(dir / file_name)
+
+            rewriter = rewriters[file_name]
+
+            def create_replacer(span_to_replace):
+                def replacer(content: str) -> str:
+                    start = span_to_replace["byte_start"]
+                    end = span_to_replace["byte_end"]
+                    original_snippet = content[start:end]
+
+                    as_index = original_snippet.find(" as ")
+                    if as_index != -1:
+                        value_part = original_snippet[:as_index]
+                        padding = " " * (len(original_snippet) - len(value_part))
+                        new_snippet = value_part + padding
+                        return content[:start] + new_snippet + content[end:]
+                    return content
+
+                return replacer
+
+            rewriter.update_content_via(create_replacer(span))
+
+        for rewriter in rewriters.values():
+            rewriter.write()
+        return rewriters
+
+    def revert_removals(rewriters: dict[str, SpeculativeFileRewriter]):
+        for rewriter in rewriters.values():
+            rewriter.restore()
+
+    def span_to_tuple(span) -> tuple[str, int, int]:
+        return (span["file_name"], span["byte_start"], span["byte_end"])
+
+    def find_all_bad_and_apply_good(casts: list[dict]) -> list[dict]:
+        if not casts:
+            return []
+
+        rewriters = apply_removals(casts)
+        if run_check(dir):
+            # All good, leave applied.
+            return []
+
+        revert_removals(rewriters)
+
+        if len(casts) == 1:
+            return casts
+
+        mid = len(casts) // 2
+        h1 = casts[:mid]
+        h2 = casts[mid:]
+
+        bad1 = find_all_bad_and_apply_good(h1)
+        # Good ones from h1 are now applied.
+
+        bad2 = find_all_bad_and_apply_good(h2)
+        # Good ones from h2 are now applied.
+
+        return bad1 + bad2
+
+    removed_count = 0
+    known_failing_spans: set[tuple[str, int, int]] = set()
+    while True:
+        current_casts = get_trivial_casts(dir)
+        current_spans = {span_to_tuple(c) for c in current_casts}
+
+        if not current_spans or current_spans.issubset(known_failing_spans):
+            break
+
+        casts_to_try = [c for c in current_casts if span_to_tuple(c) not in known_failing_spans]
+
+        new_failures = find_all_bad_and_apply_good(casts_to_try)
+
+        removed_count += len(casts_to_try) - len(new_failures)
+
+        for failure in new_failures:
+            known_failing_spans.add(span_to_tuple(failure))
+
+        # Even if we had no new failures, we must loop and check again
+        # in case clippy didn't feed us all the trivial casts in one go.
+
+    print(
+        f"TENJIN: Trivial numeric cast removal: Ran cargo clippy+check {cargo_clippy_runs}+{cargo_check_runs} times,"
+        f" with {cargo_check_failures} failures."
+    )
+    print(f"TENJIN: Trivial numeric cast removal: Removed {removed_count} casts.")
+
+
 def elapsed_ms_of_ns(start_ns: int, end_ns: int) -> float:
     """Calculate elapsed time in milliseconds from nanoseconds."""
     return (end_ns - start_ns) / 1_000_000.0
@@ -454,6 +633,10 @@ def run_improvement_passes(
         # the block safe, and therefore subject to removal.
         # But if we format first, the block may not be removable by `fix`!
         ("fix", run_cargo_fix),
+        # Numeric cast removal should come before `clippy fix` because the latter
+        # can collapse literal casts into suffixed literals, which won't be counted
+        # as fixable.
+        ("trivial-numeric-casts", run_trivial_numeric_casts_improvement),
         ("clippy-fix", run_cargo_clippy_fix),
         ("clippy-whiteout-no-effect-paths", run_whiteout_clippy_no_effect_paths),
         ("trim-allows", run_trim_allows),


### PR DESCRIPTION
Given C source like

```
ent->mode & (unsigned int )(((((448 | (448 >> 3)) | ((448 >> 3) >> 3)) | 04000) | 02000) | 01000),
```

Before:
```
            (*ent).mode as core::ffi::c_uint
                & (448 as core::ffi::c_int
                    | 448 as core::ffi::c_int >> 3 as core::ffi::c_int
                    | 448 as core::ffi::c_int >> 3 as core::ffi::c_int >> 3 as core::ffi::c_int
                    | 0o4000 as core::ffi::c_int
                    | 0o2000 as core::ffi::c_int
                    | 0o1000 as core::ffi::c_int) as core::ffi::c_uint,
```

After:
```
            (*ent).mode as core::ffi::c_uint
                & (448 | 448 >> 3 | 448 >> 3 >> 3 | 0o4000 | 0o2000 | 0o1000) as core::ffi::c_uint,
```

This implementation was (mostly) one-shot by `gemini-2.5-pro` with the following prompts:

=================================== (1)

Look in `cli/translation_improvement.py`, at the `run_un_unsafe_improvement` function. Let's do something similar, but for trivial numeric casts.

Run `cargo clippy --message-format=json -- -A unused -A static_mut_refs -A clippy::missing_safety_doc -A clippy::if_same_then_else -W trivial_numeric_casts` (via the `hermetic.run_cargo_in()` function) to get a list of messages.

Some of those messages will be for trivial numeric casts, where the casted value is a numeric literal. Collect those into a list.

Select batches from the list (roughly sqrt size of original list) to work on. For each cast in the batch, erase the cast (from the `as` token, leaving the casted value alone) by overwriting the source with spaces. But save the original contents to restore if needed. Use `cargo check` to confirm that the batch's edits were good.

If edits from the whole batch fail, print a warning, restore the prior contents, and apply them one-by-one, reverting any that fail.

At the end, print how many times you ran `cargo check` and how many times it failed.

===================================== (2)

Refactor the logic in `run_trivial_numeric_casts_improvement` in @cli/translation_improvement.py -- instead of collecting all casts once and running in multiple batches, it should instead iteratively loop and optimistically try removing all casts at once, recursively splitting a batch if any fail. The outer loop should track how many casts are expected to fail, and only stop when the number of collected casts equals the number of failing casts. Failing casts should not be re-tried on subsequent iterations.

=====================================

Example trivial numeric cast message:

```
{
  "reason": "compiler-message",
  "package_id": "path+file:///home/brk/xj-res/tree_amalg_g0/final#tenjinized@0.0.0",
  "manifest_path": "/home/brk/xj-res/tree_amalg_g0/final/Cargo.toml",
  "target": {
    "kind": [
      "bin"
    ],
    "crate_types": [
      "bin"
    ],
    "name": "MAIN",
    "src_path": "/home/brk/xj-res/tree_amalg_g0/final/src/MAIN.rs",
    "edition": "2021",
    "doc": true,
    "doctest": false,
    "test": true
  },
  "message": {
    "rendered": "warning: trivial numeric cast: `i32` as `i32`\n     --> src/MAIN.rs:10431:56\n      |\n10431 |     if *buf___1.offset(0_isize) as core::ffi::c_int == 32 as core::ffi::c_int {\n      |                                                        ^^^^^^^^^^^^^^^^^^^^^^\n      |\n      = help: cast can be replaced by coercion; this might require a temporary variable\n\n",
    "$message_type": "diagnostic",
    "children": [
      {
        "children": [],
        "code": null,
        "level": "help",
        "message": "cast can be replaced by coercion; this might require a temporary variable",
        "rendered": null,
        "spans": []
      }
    ],
    "code": {
      "code": "trivial_numeric_casts",
      "explanation": null
    },
    "level": "warning",
    "message": "trivial numeric cast: `i32` as `i32`",
    "spans": [
      {
        "byte_end": 459643,
        "byte_start": 459621,
        "column_end": 78,
        "column_start": 56,
        "expansion": null,
        "file_name": "src/MAIN.rs",
        "is_primary": true,
        "label": null,
        "line_end": 10431,
        "line_start": 10431,
        "suggested_replacement": null,
        "suggestion_applicability": null,
        "text": [
          {
            "highlight_end": 78,
            "highlight_start": 56,
            "text": "    if *buf___1.offset(0_isize) as core::ffi::c_int == 32 as core::ffi::c_int {"
          }
        ]
      }
    ]
  }
}
```