### PR TITLE
Exclusive references never alias!

### DIFF
--- a/c2rust/c2rust-transpile/src/translator/tenjin.rs
+++ b/c2rust/c2rust-transpile/src/translator/tenjin.rs
@@ -100,6 +100,13 @@ pub fn type_is_vec(ty: &Type) -> bool {
     false
 }
 
+pub fn type_is_mut_ref(ty: &Type) -> bool {
+    if let Type::Reference(ref tref) = *ty {
+        return tref.mutability.is_some();
+    }
+    false
+}
+
 pub fn expr_get_path(expr: &Expr) -> Option<&Path> {
     if let Expr::Path(ref path) = *expr {
         Some(&path.path)


### PR DESCRIPTION
So if we have `lhs == rhs`, and either side is guided to be a `mut` reference, then the translation of the comparison should be `false` (and vice versa for `!=`).