### PR TITLE
Bugfix: do not skip provisioning of `10j-build-deps` on Darwin

### DIFF
--- a/cli/provisioning.py
+++ b/cli/provisioning.py
@@ -601,9 +601,6 @@ def want_10j_sysroot_extras():
 
 
 def want_10j_deps():
-    if platform.system() == "Darwin":
-        return
-
     want(
         "10j-build-deps",
         "10j-build-deps",


### PR DESCRIPTION
Doing so means we may end up without `pkgconf`,
which then causes OCaml installation to fail.