### PR TITLE
A few sysroot related changes

### DIFF
--- a/cli/hermetic.py
+++ b/cli/hermetic.py
@@ -106,7 +106,7 @@ def mk_env_for(localdir: Path, with_tenjin_deps=True, env_ext=None, **kwargs) ->
         ])
 
         ld_lib_paths = [str(llvm_root / "lib")]
-        if platform.system() == "Linux" and not running_in_ci():
+        if os.environ.get("XJ_LD_SYSROOT", "") == "1":
             triple = f"{platform.machine()}-linux-gnu"
             ld_lib_paths.append(str(llvm_root / "sysroot" / "usr" / "lib" / triple))
 


### PR DESCRIPTION
1. Only put xj_sysroot/usr/lib/TRIPLE in `LD_LIBRARY_PATH` when explicitly requested.
2. Do not pass -L xj_sysroot/usr/lib/TRIPLE  in `clang.cfg`
3. Do not quarantine "surplus" sysroot files

### Motivations:

1. In general, overriding system-provided libraries with ones from our sysroot is dangerous. Program A might depend on library B, which is not in our sysroot, and B in turn references library C, which is in our sysroot. Library B expects C to have a symbol X, which exists in the version of C outside the sysroot, but not in the sysroot's version of C. This situation happens in practice where A is `curl`, B is `libcurl.so.4`, and C is `libssh2.so.1`

2. This was originally done to avoid an issue seen with OCaml provisioning on newer OSes with an older sysroot. After updating the pinned sysroot, I have not been able to reproduce the issue.

3. When we are no longer doing (1), there's no need to do (3).