### PR TITLE
VIBE: Add support for the `%g` printf specifier

### DIFF
--- a/c2rust/c2rust-transpile/src/lib.rs
+++ b/c2rust/c2rust-transpile/src/lib.rs
@@ -170,6 +170,7 @@ pub enum ExternCrate {
     XjScanf,
     LibzRsSys,
     Bytemuck,
+    GPoint,
 }
 
 #[derive(Serialize)]
@@ -216,6 +217,7 @@ impl From<ExternCrate> for ExternCrateDetails {
             ExternCrate::LibzRsSys => Self::new("libz-rs-sys", "0.5.1", false),
             ExternCrate::Bytemuck => Self::new("bytemuck", "1.23.2", false)
                 .with_features(vec!["derive", "extern_crate_alloc"]),
+            ExternCrate::GPoint => Self::new("gpoint", "0.2.1", false),
         }
     }
 }

--- a/c2rust/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust/c2rust-transpile/src/translator/mod.rs
@@ -1752,6 +1752,7 @@ mod refactor_format {
         Str,
         Float,
         HexFloat,
+        GFloat,
         None(char),
     }
 
@@ -1781,6 +1782,14 @@ mod refactor_format {
                     // hexfloat2::format(e)
                     x.use_crate(ExternCrate::Hexfloat2);
                     mk().call_expr(mk().path_expr(vec!["hexfloat2", "format"]), vec![e])
+                }
+                CastType::GFloat => {
+                    // GPoint(e)
+                    x.use_crate(ExternCrate::GPoint);
+                    x.with_cur_file_item_store(|item_store| {
+                        item_store.add_use(false, vec!["gpoint".into()], "GPoint");
+                    });
+                    mk().call_expr(mk().path_expr(vec!["GPoint"]), vec![e])
                 }
                 CastType::Char => {
                     // e as u8 as char
@@ -1890,6 +1899,7 @@ mod refactor_format {
         Str,
         Float,
         HexFloat,
+        GFloat,
         Unknown(char),
     }
 
@@ -1897,7 +1907,11 @@ mod refactor_format {
         fn is_numeric(&self) -> bool {
             matches!(
                 *self,
-                ConvType::Int(_) | ConvType::Uint(_) | ConvType::Hex(_, _) | ConvType::Float
+                ConvType::Int(_)
+                    | ConvType::Uint(_)
+                    | ConvType::Hex(_, _)
+                    | ConvType::Float
+                    | ConvType::GFloat
             )
         }
 
@@ -1963,6 +1977,7 @@ mod refactor_format {
                 ConvType::Str => CastType::Str,
                 ConvType::Float => CastType::Float,
                 ConvType::HexFloat => CastType::HexFloat,
+                ConvType::GFloat => CastType::GFloat,
                 ConvType::Unknown(c) => CastType::None(c),
             };
 
@@ -2197,6 +2212,7 @@ mod refactor_format {
                 's' => ConvType::Str,
                 'f' => ConvType::Float,
                 'a' => ConvType::HexFloat,
+                'g' => ConvType::GFloat,
                 _ => ConvType::Unknown(c),
             }
         }


### PR DESCRIPTION
PROMPT:

Please search the c2rust/ directory for usage of xj_scanf and the XjScanf crate. Then, implement support for the Gpoint crate, to  allow printing floating point numbers accurately. So when c2rust recognizes use of the %g specifier in a printf family call, the  corresponding argument should be wrapped in a GPoint() constructor. Use `gpoint` version "0.2.1".

For example, given `printf("answer: %g\n");` we want c2rust to generate

```
use gpoint::GPoint;

println!("answer: {}", GPoint(42.));
```

Observe how XjScanf inserts a use item for xj_scanf, and use similar logic for gpoint.