### PR TITLE
Add snapshot test for Tenjin guidance

### DIFF
--- a/c2rust/c2rust-transpile/src/cfg/mod.rs
+++ b/c2rust/c2rust-transpile/src/cfg/mod.rs
@@ -1437,6 +1437,7 @@ impl CfgBuilder {
                         .parsed_guidance
                         .borrow_mut()
                         .query_fn_return_type(self.fn_name.as_str());
+                    // XREF:snapshot_guided_ret_ostr
                     translator.convert_expr_guided(ctx.used(), i, ret_ty, &ret_ty_guidance)
                 }) {
                     Some(r) => Some(r?),

--- a/c2rust/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust/c2rust-transpile/src/translator/mod.rs
@@ -1816,11 +1816,13 @@ mod refactor_format {
                     if let Some(g) = x.parsed_guidance.borrow_mut().query_expr_type(x, cexpr) {
                         if g.pretty == "String" {
                             // For a variable that's already type String, we can leave it as is.
+                            // XREF:guided_cast_str_of_owned_string
                             return e;
                         }
 
                         if g.pretty_sans_refs() == "Vec < u8 >" {
                             // For a variable that's type Vec<u8>, we can convert it to String directly.
+                            // XREF:guided_cast_str_of_shared_vec_u8
                             return mk().call_expr(
                                 mk().path_expr(vec!["String", "from_utf8_lossy"]),
                                 vec![mk().addr_of_expr(e)],
@@ -3825,6 +3827,7 @@ impl<'c> Translation<'c> {
         return_type: Option<CQualTypeId>,
     ) -> TranslationResult<ReturnType> {
         if let Some(guided_type) = self.parsed_guidance.borrow().query_fn_return_type(name) {
+            // XREF:guided_ret_type
             return Ok(ReturnType::Type(
                 Default::default(),
                 Box::new(guided_type.parsed),
@@ -3878,6 +3881,7 @@ impl<'c> Translation<'c> {
             if let Some(guided_type) = mb_guided_type {
                 if guided_type.pretty == "String" {
                     // strings are never null, so the base value is false, which matches the value of negated.
+                    // XREF:guided_condition_string_null_check_neq
                     return mk().lit_expr(mk().bool_lit(negated));
                 }
             }
@@ -3928,6 +3932,7 @@ impl<'c> Translation<'c> {
                 null_pointer_case(!target, ptr)
             }
 
+            // XREF:guided_condition_string_null_check_neq
             CExprKind::Binary(_, c_ast::BinOp::NotEqual, null_expr, ptr, _, _)
                 if self.ast_context.is_null_expr(null_expr) =>
             {

--- a/c2rust/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust/c2rust-transpile/src/translator/operators.rs
@@ -708,6 +708,7 @@ impl Translation<'_> {
                         if lhs_guided_type.is_some_and(|g| tenjin::type_is_mut_ref(&g.parsed))
                             || rhs_guided_type.is_some_and(|g| tenjin::type_is_mut_ref(&g.parsed))
                         {
+                            // XREF:guided_mut_ref_neq
                             mk().lit_expr(mk().int_unsuffixed_lit(1)) // mutable references never alias, so pointer inequality is true
                         } else {
                             mk().binary_expr(BinOp::Ne(Default::default()), lhs, rhs)

--- a/c2rust/c2rust-transpile/tests/snapshots.rs
+++ b/c2rust/c2rust-transpile/tests/snapshots.rs
@@ -52,6 +52,19 @@ fn guidance_for_file(c_path: &Path) -> serde_json::Value {
         serde_json::json!({
             "no_math_errno": true,
         })
+    } else if c_path.ends_with("tenjin_guided.c") {
+        serde_json::json!({
+            "vars_of_type": {
+                "String" : "*:ostr",
+                "&str" : "*:rstr",
+                "&mut str" : ["*:xstr", "*:xstr2"],
+                "Vec<u8>" : "*:ovu8",
+                "&Vec<u8>" : "*:rvu8",
+            },
+            "fn_return_type": {
+                "guided_ret_ostr": "String"
+            }
+        })
     } else {
         serde_json::json!({})
     }

--- a/c2rust/c2rust-transpile/tests/snapshots/snapshots__transpile@tenjin_guided.c.snap
+++ b/c2rust/c2rust-transpile/tests/snapshots/snapshots__transpile@tenjin_guided.c.snap
@@ -1,0 +1,59 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+expression: cat tests/snapshots/tenjin_guided.rs
+input_file: c2rust-transpile/tests/snapshots/tenjin_guided.c
+---
+#![allow(
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+extern "C" {
+    fn printf(fmt: *const ::core::ffi::c_char, ...) -> ::core::ffi::c_int;
+}
+#[no_mangle]
+pub unsafe extern "C" fn print_owned_String(mut ostr: String) {
+    println!("{:>}", ostr);
+}
+#[no_mangle]
+pub unsafe extern "C" fn print_unguided_ptr(mut ptr: *const ::core::ffi::c_char) {
+    println!("{:>}", {
+        std::ffi::CStr::from_ptr(ptr as *const core::ffi::c_char)
+            .to_str()
+            .unwrap()
+    });
+}
+#[no_mangle]
+pub unsafe extern "C" fn print_shared_vec_u8(mut rvu8: &Vec<u8>) {
+    println!("{:>}", String::from_utf8_lossy(&rvu8));
+}
+#[no_mangle]
+pub unsafe extern "C" fn guided_str_init_lit() {
+    let mut ostr: String = String::from("owned String");
+    let mut uptr: *const ::core::ffi::c_char =
+        b"unguided pointer\0" as *const u8 as *const ::core::ffi::c_char;
+}
+#[no_mangle]
+pub unsafe extern "C" fn guided_ret_ostr() -> String {
+    return String::new();
+}
+#[no_mangle]
+pub unsafe extern "C" fn guided_condition_string_null_check_neq(
+    mut ostr: String,
+) -> ::core::ffi::c_int {
+    return if true {
+        2 as ::core::ffi::c_int
+    } else {
+        5 as ::core::ffi::c_int
+    };
+}
+#[no_mangle]
+pub unsafe extern "C" fn guided_mut_ref_neq(
+    mut xstr: &mut str,
+    mut xstr2: &mut str,
+) -> ::core::ffi::c_int {
+    return 1 as ::core::ffi::c_int;
+}

--- a/c2rust/c2rust-transpile/tests/snapshots/tenjin_guided.c
+++ b/c2rust/c2rust-transpile/tests/snapshots/tenjin_guided.c
@@ -1,0 +1,62 @@
+// To avoid cross-platform output differences from `printf` argument names,
+// we'll just declare printf ourselves.
+int printf(const char* fmt, ...);
+
+void print_owned_String(const char* ostr) {
+    // XREF:guided_cast_str_of_owned_string
+    printf("%s\n", ostr);
+}
+//void print_shared_str(const char* rstr) { printf("%s\n", rstr); }
+//void print_exclusive_str(const char* xstr) { printf("%s\n", xstr); }
+void print_unguided_ptr(const char* ptr) { printf("%s\n", ptr); }
+
+void print_shared_vec_u8(const char* rvu8) {
+    // XREF:guided_cast_str_of_shared_vec_u8
+    printf("%s\n", rvu8);
+}
+
+void guided_str_init_lit() {
+    const char* ostr = "owned String";
+    // const char* rstr = "shared &str";
+    // const char* xstr = "exclusive &mut str";
+    const char* uptr = "unguided pointer";
+}
+
+// XREF:guided_ret_type
+const char* guided_ret_ostr() {
+    // XREF:snapshot_guided_ret_ostr
+    return "";
+}
+
+// NULL translates to use DARWIN_NULL on Mac; keep this
+// snapshot test platform-independent.
+
+int guided_condition_string_null_check_neq(const char* ostr) {
+    // XREF:guided_condition_string_null_check_neq
+    return (ostr != ((void*)0)) ? 2 : 5;
+}
+
+// int guided_noncondition_string_null_check_neq(const char* ostr) {
+//     // XREF:guided_noncondition_string_null_check_neq
+//     return ostr != ((void*)0);
+// }
+
+
+// int guided_condition_string_null_check_implicit(const char* ostr) {
+//     // XREF:guided_condition_string_null_check_implicit (match_bool)
+//     return ostr ? 2 : -1;
+// }
+
+// void guided_str_ptr_to_owned(const char* ptr) {
+//     // Initializing an owned String from an unguided pointer.
+//     // const char* ostr = ptr;
+
+//     // Currently, trying to pass unguided pointer to owned String
+//     // will result in a type mismatch in the generated Rust code.
+//     // print_owned_String(ptr);
+// }
+
+int guided_mut_ref_neq(const char* xstr, const char* xstr2) {
+    // XREF:guided_mut_ref_neq
+    return xstr != xstr2;
+}

--- a/docs/USE.md
+++ b/docs/USE.md
@@ -68,7 +68,7 @@ such variable named `bar` in every function.
 * `declspecs_of_type` - closely related, but applies to global variables.
 * `vars_mut`: likewise, a dict mapping specifiers to boolean values
     indicating whether that declaration should be marked `mut` in Rust.
-* `fn_return_types` - a dict mapping function names to the Rust type they should be made to / assumed to return
+* `fn_return_type` - a dict mapping function names to the Rust type they should be made to / assumed to return
 * `pod_types` - a list of type names which should be considered to
 be plain old data, and thereby eligible for type-safe casting with
 the `bytemuck` crate.


### PR DESCRIPTION
Also, begin adding cross-references between sites implementing guidance and tests exercising those code paths.