### PR TITLE
Automatically retry when fetching `uv` install script fails

### DIFF
--- a/cli/sh/fetch-uv.sh
+++ b/cli/sh/fetch-uv.sh
@@ -27,10 +27,10 @@ check_cmd () {
 
 download () {
   if check_cmd curl
-  then curl -sSfL "$1" -o "$2"
+  then curl --connect-timeout 11 --retry 2 -sSfL "$1" -o "$2"
 
   elif check_cmd wget
-  then wget "$1" -O "$2"
+  then wget --connect-timeout=11 --tries=3 "$1" -O "$2"
 
   else die "need curl or wget!"
   fi


### PR DESCRIPTION
GitHub Actions runners sometimes halt here due to unreliable networking.

The Python code in `provisioning.py` already retries failed downloads, for the same reason.