### PR TITLE
Resolve `resultsdir` before use

### DIFF
--- a/cli/translation.py
+++ b/cli/translation.py
@@ -217,6 +217,8 @@ def do_translate(
     tracker = ingest_tracking.TimingRepo(stub_ingestion_record(codebase, guidance))
 
     skip_remainder_of_translation = False
+
+    resultsdir = resultsdir.resolve()
     resultsdir.mkdir(parents=True, exist_ok=True)
 
     # Preparation passes may modify the guidance stored in XJ_GUIDANCE_FILENAME


### PR DESCRIPTION
If we do not do this, and a path with `..` elements is provided, c2rust will fail here: https://github.com/immunant/c2rust/blob/613d3f5a7ef568aecb1681ef5960f956c1ed7344/c2rust-transpile/src/c_ast/mod.rs#L161