### PR TITLE
Switch `pytest` build step to occur in `main.py`

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -392,6 +392,7 @@ if __name__ == "__main__":
         if sys.argv[1] == "clang":
             sys.exit(hermetic.run_shell_cmd(sys.argv[1:]).returncode)
         if sys.argv[1] == "pytest":
+            cli_subcommands.do_build_star()  # Build once, before concurrent tests start
             # When pytest executes from outside of the repo, e.g. because `10j` is on the PATH,
             # it cannot find the repo root from the executing script or the cwd.
             env_ext = {"XJ_REPO_ROOT_DIR": str(repo_root.find_repo_root_dir_Path())}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,1 @@
-import cli_subcommands
-
 pytest_plugins = "10j_pytest_fixtures"
-
-
-def pytest_sessionstart(session):
-    """Called after the Session object has been created and before performing collection and entering the run test loop."""
-    cli_subcommands.do_build_star()


### PR DESCRIPTION
I had incorrectly assumed that `pytest_sessionstart()` would be executed once per invocation, not once per executor.