### PR TITLE
Make codebase VCS info optional for `translation_metadata.json`

### DIFF
--- a/cli/ingest.py
+++ b/cli/ingest.py
@@ -31,7 +31,7 @@ class IngestedCodebase:
 @dataclass_json
 @dataclass
 class TranslationInputs:
-    codebase: IngestedCodebase
+    codebase: IngestedCodebase | None
     host_platform: str
     per_file_preprocessor_definitions: PerFilePreprocessorDefinitions
     tenjin_git_repo_url: str

--- a/cli/main.py
+++ b/cli/main.py
@@ -5,6 +5,8 @@ import argparse
 from pathlib import Path
 import shutil
 import tempfile
+import textwrap
+import json
 from typing import Literal, cast
 
 import click
@@ -330,6 +332,22 @@ def upload_results(directory: Path, host_port: str):
 
     if not snapshot_file.exists():
         click.echo(f"Error: {snapshot_file} does not exist", err=True)
+        sys.exit(1)
+
+    # Check if codebase information is present
+    with open(metadata_file, "r", encoding="utf-8") as f:
+        metadata = json.load(f)
+
+    if metadata.get("inputs", {}).get("codebase") is None:
+        click.echo(
+            textwrap.dedent(
+                """\
+                Error: Cannot upload results without codebase VCS information."
+                       The translated codebase was not in a Git repository,"
+                       so the translation is not mechanically reproducible."""
+            ),
+            err=True,
+        )
         sys.exit(1)
 
     if host_port.startswith("http"):


### PR DESCRIPTION
This means we always produce `translation_metadata.json`, and thereby do not completely drop output from c2rust.

However, metadata files without a codebase URL cannot be uploaded, because they are not reproducible.