### PR TITLE
Apply renaming from static uniquify to guidance

### DIFF
--- a/cli/c_refact.py
+++ b/cli/c_refact.py
@@ -27,8 +27,8 @@ import compilation_database
 import batching_rewriter
 from cindex_helpers import render_declaration_sans_qualifiers, yield_matching_cursors
 import c_refact_type_mod_replicator
-from constants import XJ_GUIDANCE_FILENAME
 import targets
+import guidance
 
 
 def create_xj_clang_index() -> Index:
@@ -1785,14 +1785,13 @@ def update_vars_of_type_guidance_for_xjg(
                     else:
                         # passed as an argument
                         higher_order_tissue_functions.add(v.spelling)
-    guidance: dict = json.load(open(current_codebase / XJ_GUIDANCE_FILENAME, "r", encoding="utf-8"))
+    codebase_guidance: dict = guidance.load_from_codebase(current_codebase)
     can_take_mut_xjg = phase1results.nonmain_tissue_functions - higher_order_tissue_functions
-    mut_specs = guidance.get("vars_of_type", {}).get("&mut XjGlobals", [])
+    mut_specs = codebase_guidance.get("vars_of_type", {}).get("&mut XjGlobals", [])
     for tissue_fn_name in can_take_mut_xjg:
         mut_specs.append(f"{tissue_fn_name}:xjg")
-    guidance.setdefault("vars_of_type", {})["&mut XjGlobals"] = mut_specs
-    with open(current_codebase / XJ_GUIDANCE_FILENAME, "w", encoding="utf-8") as fh:
-        json.dump(guidance, fh, indent=2)
+    codebase_guidance.setdefault("vars_of_type", {})["&mut XjGlobals"] = mut_specs
+    guidance.store_in_codebase(codebase_guidance, current_codebase)
 
 
 def extract_function_info(

--- a/cli/guidance.py
+++ b/cli/guidance.py
@@ -1,0 +1,105 @@
+import json
+from pathlib import Path
+
+from constants import XJ_GUIDANCE_FILENAME
+
+
+def store_in_codebase(guidance: dict, codebase: Path, name: str = XJ_GUIDANCE_FILENAME):
+    """Serialize guidance as json to codebase / name"""
+    json.dump(
+        guidance,
+        open(codebase / name, "w", encoding="utf-8"),
+        indent=2,
+    )
+
+
+def load_from_codebase(codebase: Path, name: str = XJ_GUIDANCE_FILENAME) -> dict:
+    """Deserialize json guidance as dict from codebase / name"""
+    return load_and_parse_guidance(codebase / name)
+
+
+def load_and_parse_guidance(guidance_path_or_literal: Path | str) -> dict:
+    if isinstance(guidance_path_or_literal, Path):
+        return json.load(guidance_path_or_literal.open("r", encoding="utf-8"))
+    elif type(guidance_path_or_literal) is str:
+        try:
+            if guidance_path_or_literal == "":
+                guidance = {}
+            else:
+                guidance = json.loads(guidance_path_or_literal)
+        except json.JSONDecodeError:
+            guidance = json.load(Path(guidance_path_or_literal).open("r", encoding="utf-8"))
+        return guidance
+    else:
+        assert False
+
+
+def parse_decl_specifier(s: str) -> tuple[str, str | None, str | None, str | None]:
+    """Parse <function name>:<var name>@<line number>#<file path>"""
+
+    def split_from_back(inp: str, at: str) -> tuple[str, str | None]:
+        res = inp.split(at)
+        assert len(res) <= 2
+        if len(res) == 1:
+            return (res[0], None)
+        else:
+            assert len(res) == 2
+            return (res[0], res[1])
+
+    s, prefix = split_from_back(s, "@")
+    s, linum = split_from_back(s, "#")
+    fn, v = split_from_back(s, ":")
+    return (fn, v, linum, prefix)
+
+
+def make_decl_specifier_str(fn: str, v: str | None, linum: str | None, filename: str | None) -> str:
+    """Construct string representation of declspec pieces (suitable for serializing to JSON)"""
+
+    def prefix(p: str, x: str | None):
+        if x is None:
+            return ""
+        else:
+            return f"{p}{x}"
+
+    return fn + prefix(":", v) + prefix("#", linum) + prefix("@", filename)
+
+
+def map_guidance_value(guidance: dict, key: str, f):
+    """Assuming guidance[key] is a dict, map f on the kv pairs of guidance[key].
+    f should return a new kv pair"""
+    if key not in guidance:
+        return
+
+    obj = guidance[key]
+    new_obj = {}
+    for k, v in list(obj.items()):
+        k2, v2 = f(k, v)
+        new_obj[k2] = v2
+    guidance[key] = new_obj
+
+
+def map_function_names(guidance: dict, f):
+    """Transform the function names in guidance (in place) by applying f to them"""
+
+    def ap_specifier(sp: str) -> str:
+        (fn, v, line, filename) = parse_decl_specifier(sp)
+        fn2 = f(fn)
+        return make_decl_specifier_str(fn2, v, line, filename)
+
+    def apply_vars_of_type(ty: str, spec: str | list[str]):
+        if type(spec) is str:
+            return (ty, ap_specifier(spec))
+        else:
+            return (ty, [ap_specifier(s) for s in spec])
+
+    def apply_vars_mut(sp: str, b: str):
+        return (ap_specifier(sp), b)
+
+    def apply_fn_return_type(fn: str, t: str):
+        return (f(fn), t)
+
+    map_guidance_value(guidance, "vars_of_type", apply_vars_of_type)
+    # TODO 'declspecs_of_type' appears to be unimplemented in rust,
+    # format with fn prefix may not be correct
+    map_guidance_value(guidance, "vars_mut", apply_vars_mut)
+    map_guidance_value(guidance, "fn_return_type", apply_fn_return_type)

--- a/cli/guidance.py
+++ b/cli/guidance.py
@@ -6,11 +6,8 @@ from constants import XJ_GUIDANCE_FILENAME
 
 def store_in_codebase(guidance: dict, codebase: Path, name: str = XJ_GUIDANCE_FILENAME):
     """Serialize guidance as json to codebase / name"""
-    json.dump(
-        guidance,
-        open(codebase / name, "w", encoding="utf-8"),
-        indent=2,
-    )
+    with open(codebase / name, "w", encoding="utf-8") as fh:
+        json.dump(guidance, fh, indent=2)
 
 
 def load_from_codebase(codebase: Path, name: str = XJ_GUIDANCE_FILENAME) -> dict:

--- a/tests/guidance/test_guidance.py
+++ b/tests/guidance/test_guidance.py
@@ -1,0 +1,46 @@
+import guidance
+
+def parse_testcase(s, e1, e2, e3, e4):
+    a, b, c, d = guidance.parse_decl_specifier(s)
+    assert a == e1
+    assert b == e2
+    assert c == e3
+    assert d == e4
+    assert guidance.make_decl_specifier_str(a, b, c, d) == s
+
+def test_parse_full():
+    parse_testcase("f:x#13@a/b/c/d", "f", "x", "13", "a/b/c/d")
+
+def test_parse_start_var():
+    parse_testcase("*:v", "*", "v", None, None)
+
+def test_parse_no_linum():
+    parse_testcase("f:v@a/b/c/d", "f", "v", None, "a/b/c/d")
+
+def test_parse_no_file():
+    parse_testcase("f:v#13", "f", "v", "13", None)
+
+def rename(x):
+    if x == "me":
+        return "rename"
+    return x
+
+def test_singleton():
+    g = {
+        'vars_of_type': { 't' : 'me:x' },
+        'vars_mut': { 'me' : True },
+        'fn_return_type' : { 'me' : 't' }
+    }
+    guidance.map_function_names(g, rename)
+    assert g['vars_of_type']['t'] == 'rename:x'
+    assert g['vars_mut']['rename']
+    assert g['fn_return_type']['rename'] == 't'
+
+def test_list():
+    g = { 'vars_of_type': { 't' : ['me:x'] } }
+    guidance.map_function_names(g, rename)
+    assert g['vars_of_type']['t'] == ['rename:x']
+
+    g = { 'vars_of_type': { 't' : ['foo:y', 'me:x'] } }
+    guidance.map_function_names(g, rename)
+    assert g['vars_of_type']['t'][1] == 'rename:x'

--- a/tests/guidance/test_guidance.py
+++ b/tests/guidance/test_guidance.py
@@ -1,5 +1,6 @@
 import guidance
 
+
 def parse_testcase(s, e1, e2, e3, e4):
     a, b, c, d = guidance.parse_decl_specifier(s)
     assert a == e1
@@ -8,39 +9,42 @@ def parse_testcase(s, e1, e2, e3, e4):
     assert d == e4
     assert guidance.make_decl_specifier_str(a, b, c, d) == s
 
+
 def test_parse_full():
     parse_testcase("f:x#13@a/b/c/d", "f", "x", "13", "a/b/c/d")
+
 
 def test_parse_start_var():
     parse_testcase("*:v", "*", "v", None, None)
 
+
 def test_parse_no_linum():
     parse_testcase("f:v@a/b/c/d", "f", "v", None, "a/b/c/d")
 
+
 def test_parse_no_file():
     parse_testcase("f:v#13", "f", "v", "13", None)
+
 
 def rename(x):
     if x == "me":
         return "rename"
     return x
 
+
 def test_singleton():
-    g = {
-        'vars_of_type': { 't' : 'me:x' },
-        'vars_mut': { 'me' : True },
-        'fn_return_type' : { 'me' : 't' }
-    }
+    g = {"vars_of_type": {"t": "me:x"}, "vars_mut": {"me": True}, "fn_return_type": {"me": "t"}}
     guidance.map_function_names(g, rename)
-    assert g['vars_of_type']['t'] == 'rename:x'
-    assert g['vars_mut']['rename']
-    assert g['fn_return_type']['rename'] == 't'
+    assert g["vars_of_type"]["t"] == "rename:x"
+    assert g["vars_mut"]["rename"]
+    assert g["fn_return_type"]["rename"] == "t"
+
 
 def test_list():
-    g = { 'vars_of_type': { 't' : ['me:x'] } }
+    g = {"vars_of_type": {"t": ["me:x"]}}
     guidance.map_function_names(g, rename)
-    assert g['vars_of_type']['t'] == ['rename:x']
+    assert g["vars_of_type"]["t"] == ["rename:x"]
 
-    g = { 'vars_of_type': { 't' : ['foo:y', 'me:x'] } }
+    g = {"vars_of_type": {"t": ["foo:y", "me:x"]}}
     guidance.map_function_names(g, rename)
-    assert g['vars_of_type']['t'][1] == 'rename:x'
+    assert g["vars_of_type"]["t"][1] == "rename:x"


### PR DESCRIPTION
`uniquify_statics` renames some decls. Since the input guidance is not aware of this renaming, guidance may not be applied. This PR applies the generated renaming to the input guidance.