### PR TITLE
Update `hexfloat2` version to fix printing of `-0.0`

### DIFF
--- a/c2rust/c2rust-transpile/src/lib.rs
+++ b/c2rust/c2rust-transpile/src/lib.rs
@@ -212,7 +212,7 @@ impl From<ExternCrate> for ExternCrateDetails {
             ExternCrate::NumTraits => Self::new("num-traits", "0.2", true),
             ExternCrate::Memoffset => Self::new("memoffset", "0.5", true),
             ExternCrate::Libc => Self::new("libc", "0.2", false),
-            ExternCrate::Hexfloat2 => Self::new("hexfloat2", "0.1.3", false),
+            ExternCrate::Hexfloat2 => Self::new("hexfloat2", "0.2.0", false),
             ExternCrate::XjScanf => Self::new("xj_scanf", "0.2.1", false),
             ExternCrate::LibzRsSys => Self::new("libz-rs-sys", "0.5.1", false),
             ExternCrate::Bytemuck => Self::new("bytemuck", "1.23.2", false)

--- a/c2rust/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust/c2rust-transpile/src/translator/mod.rs
@@ -1786,9 +1786,12 @@ mod refactor_format {
                 CastType::Usize => mk().span(span).cast_expr(e, mk().ident_ty("usize")),
                 CastType::Float => mk().span(span).cast_expr(e, mk().ident_ty("f64")),
                 CastType::HexFloat => {
-                    // hexfloat2::format(e)
+                    // hexfloat2::HexFloat::from(e)
                     x.use_crate(ExternCrate::Hexfloat2);
-                    mk().call_expr(mk().path_expr(vec!["hexfloat2", "format"]), vec![e])
+                    mk().call_expr(
+                        mk().path_expr(vec!["hexfloat2", "HexFloat", "from"]),
+                        vec![e],
+                    )
                 }
                 CastType::GFloat => {
                     // GPoint(e)


### PR DESCRIPTION
Also, use `hexfloat2::HexFloat::from(x)` instead of `hexfloat2::format(x)` as the latter produces a string with default options and thus will not respect formatting flags like `+` to show signs.