### PR TITLE
Drop `lib` prefix from shared library crate names

### DIFF
--- a/cli/targets.py
+++ b/cli/targets.py
@@ -399,6 +399,19 @@ def _CompileCommand_from_intercepted_command(
 
     cc_res = current_codebase.resolve()
 
+    def drop_lib_prefix(name: str | None) -> str | None:
+        if name is None:
+            return None
+
+        p = Path(name)
+        if (
+            p.name.startswith("lib")
+            and link_cmd_handling == LinkCommandHandling.ADAPT_FOR_C2RUST
+            and p.suffix != ".o"
+        ):
+            return p.with_name(p.name[3:]).as_posix()
+        return name
+
     def tweak_suffix(p: Path) -> str:
         if use_preprocessed_files:
             if p.suffix == ".c":
@@ -490,10 +503,11 @@ def _CompileCommand_from_intercepted_command(
             link_type = "exe"
         link_info = {
             "inputs": [
-                compilation_database.legalize_output_name_for_rust(inp) for inp in icmd.rest_inputs
+                drop_lib_prefix(compilation_database.legalize_output_name_for_rust(inp))
+                for inp in icmd.rest_inputs
             ],  # FIXME: wrong order???
             "c_files": [],
-            "libs": icmd.libs,
+            "libs": [drop_lib_prefix(lib) for lib in icmd.libs],
             "lib_dirs": icmd.lib_dirs,
             "type": link_type,
             # TODO: parse and add in other linker flags
@@ -517,5 +531,5 @@ def _CompileCommand_from_intercepted_command(
         directory=icmd.entry["directory"],
         file=update(filename),
         arguments=[update_arg(arg) for arg in raw_arguments],
-        output=icmd.output,
+        output=drop_lib_prefix(icmd.output),
     )

--- a/tests/test_third_party.py
+++ b/tests/test_third_party.py
@@ -615,19 +615,19 @@ def eval_tractor_ta3_corpus_lib(
         monkeypatch=monkeypatch,
     )
 
-    # cando2 usually requires the built library exist in a `build-ninja` directory
-    # and be named `{candidate_name}.so`. Sometimes they hardcode the name `driver.so`.
+    # For single-library tests, cando2 usually requires the built library exist
+    # in a `build-ninja` directory and be named `{candidate_name}.so`.
+    # Sometimes they hardcode the name `driver.so`.
     # (B02_organic/encode_base64_lib is an example of the latter.)
+    # Tests with multiple libraries keep library names as-is.
     build_ninja_dir = Path(candidate_resultsdir / "build-ninja")
     build_ninja_dir.mkdir(exist_ok=False)
     built_dir = candidate_resultsdir / "final" / "target" / profile
     built_libs = list(built_dir.glob("lib*.so")) + list(built_dir.glob("lib*.dylib"))
     for built_lib in built_libs:
+        shutil.copyfile(built_lib, build_ninja_dir / f"{built_lib.name}")
         shutil.copyfile(built_lib, build_ninja_dir / f"lib{candidate_name}{built_lib.suffix}")
         shutil.copyfile(built_lib, build_ninja_dir / f"libdriver{built_lib.suffix}")
-        if built_lib.name.startswith("liblib"):
-            # Sometimes Rust produces 'liblibX.so' but cando2 needs 'libX.so'.
-            shutil.copyfile(built_lib, build_ninja_dir / built_lib.name[3:])
 
     if "P01_sphincs_plus" in str(case_dir):
         monkeypatch.setenv(


### PR DESCRIPTION
We derive crate names from C artifact names, and Rust unconditionally adds a `lib` prefix back to the artifact it builds. This avoids ending up with artifacts named `liblibX.so`