### PR TITLE
Improve generated Rust project src directory structure

### DIFF
--- a/c2rust/c2rust-transpile/src/lib.rs
+++ b/c2rust/c2rust-transpile/src/lib.rs
@@ -403,6 +403,9 @@ pub fn transpile(tcfg: TranspilerConfig, cc_db: &Path, extra_clang_args: &[&str]
         if cmds.len() > 1 {
             for cmd in &cmds[1..] {
                 let cmd_path = cmd.abs_file();
+                if cmd_path.starts_with("/c2rust/link") {
+                    continue;
+                }
                 ancestor_path = ancestor_path
                     .ancestors()
                     .find(|a| cmd_path.starts_with(a))


### PR DESCRIPTION
Fake link file paths should not count in determining common ancestor paths!