### PR TITLE
Run `cargo clean` instead of `cargo clean -p <workspace>` between translation improvement passes

### DIFF
--- a/cli/translation_improvement.py
+++ b/cli/translation_improvement.py
@@ -768,6 +768,11 @@ def run_improvement_passes(
                 ["clean", *cargo_workspace_helpers.flags_for_all_cargo_workspace_packages(newdir)],
                 cwd=newdir,
             )
+            # Ensure any plugin results are also removed, since they may prevent
+            # subsequent passes from running correctly.
+            for child in (newdir / "target").glob("plugin-*"):
+                if child.is_dir():
+                    shutil.rmtree(child)
             end_ns = time.perf_counter_ns()
 
             core_ms = round(elapsed_ms_of_ns(start_ns, mid_ns))

--- a/tests/smoke_tests/test_smoketests.py
+++ b/tests/smoke_tests/test_smoketests.py
@@ -183,3 +183,22 @@ def test_triplicated_compilation(root, test_dir, tmp_codebase, tmp_resultsdir, r
     )
 
     annotate_pytest_request_with_translation_notes(request, tmp_resultsdir, extras)
+
+
+def test_trivial_un_unsafe(root, test_dir, tmp_codebase, tmp_resultsdir, request, extras):
+    codebase = test_dir / "trivial_un_unsafe"
+    translation_preparation.copy_codebase(codebase, tmp_codebase)
+    # Run translation
+    translation.do_translate(
+        root,
+        codebase,
+        tmp_resultsdir,
+        cratename="safe",
+        guidance_path_or_literal='{ "public_api" : [] }',
+    )
+
+    with open(tmp_resultsdir / "translation_metadata.json", "r", encoding="utf-8") as f:
+        translate_meta = json.load(f)
+        unsafe_count = translate_meta["results"]["tenjin_final"]["total_unsafe_fns_count"]
+        assert unsafe_count == 0, f"Expected no unsafe functions, got {unsafe_count}"
+    annotate_pytest_request_with_translation_notes(request, tmp_resultsdir, extras)

--- a/tests/smoke_tests/trivial_un_unsafe/safe.c
+++ b/tests/smoke_tests/trivial_un_unsafe/safe.c
@@ -1,0 +1,1 @@
+int safe(int x) { return x; }


### PR DESCRIPTION
The title says it all: essentially, `cargo clean -p` does not seem to clean up plugin artifacts. This affects runs of `xj-improve-multitool`: only the first is guaranteed to run, later runs may be blocked by the presence of said artifacts.