### PR TITLE
Fix global lowering inconsistency

### DIFF
--- a/cli/c_refact.py
+++ b/cli/c_refact.py
@@ -1186,6 +1186,13 @@ def localize_mutable_globals(
         print("No liftable mutated globals found; skipping further localization steps.")
         return
 
+    mutated_globals_cursors_by_name = {c.spelling: c for c in liftable_mutated_globals_and_statics}
+
+    assert len(mutated_globals_cursors_by_name) == len(liftable_mutated_globals_and_statics), (
+        "Expected all (liftable) mutated global names to be unique, "
+        + f"but got duplicates within: {mutated_globals_cursors_by_name.keys()}"
+    )
+
     # Step 2b: Construct transitive closure of struct/union definitions
     print("\n" + "=" * 80)
     print("STEP 2b: Finding struct/union dependencies")
@@ -1392,8 +1399,7 @@ def localize_mutable_globals(
 
                 if (
                     child.kind == CursorKind.DECL_REF_EXPR
-                    and child.spelling in phase1results.mutd_global_names
-                    and child.spelling not in phase1results.all_function_names
+                    and child.spelling in mutated_globals_cursors_by_name
                 ):
                     # Get the extent of the variable reference
                     start_offset = child.extent.start.offset
@@ -1498,14 +1504,6 @@ def localize_mutable_globals(
         #                 break
 
         # Add the XjGlobals struct definition
-        mutated_globals_cursors_by_name = {
-            c.spelling: c for c in liftable_mutated_globals_and_statics
-        }
-        assert len(mutated_globals_cursors_by_name) == len(liftable_mutated_globals_and_statics), (
-            "Expected all (liftable) mutated global names to be unique, "
-            + f"but got duplicates within: {mutated_globals_cursors_by_name.keys()}"
-        )
-
         header_lines.append("struct XjGlobals {")
         for global_name in sorted(mutated_globals_cursors_by_name.keys()):
             var_cursor = mutated_globals_cursors_by_name[global_name]

--- a/tests/regression_tests/errno_global/main.c
+++ b/tests/regression_tests/errno_global/main.c
@@ -1,0 +1,9 @@
+extern int errno;
+int z;
+
+int main()
+{
+  z = 0;
+  errno = 1;
+  return 0;
+}

--- a/tests/regression_tests/test_regression_tests.py
+++ b/tests/regression_tests/test_regression_tests.py
@@ -1,0 +1,22 @@
+from tenjin_pytest_helpers import annotate_pytest_request_with_translation_notes
+import translation
+import translation_preparation
+
+
+def test_errno_global(root, test_dir, tmp_codebase, tmp_resultsdir, extras, request):
+    codebase = test_dir / "errno_global" / "main.c"
+
+    translation_preparation.copy_codebase(codebase, tmp_codebase)
+
+    # Run translation
+    translation.do_translate(
+        root,
+        tmp_codebase,
+        tmp_resultsdir,
+        cratename="errno_global",
+        guidance_path_or_literal="{}",
+    )
+
+    assert (tmp_resultsdir / "final" / "Cargo.toml").exists()
+
+    annotate_pytest_request_with_translation_notes(request, tmp_resultsdir, extras)


### PR DESCRIPTION
In
```c
extern int errno;
int z;

int main()
{
  z = 0;
  errno = 1;
  return 0;
}
```

we will mistakenly generate an access to `xjg->errno` even though the `XjgGlobals` struct will (correctly) not contain an `errno` field. The PR fixes this by using the same set of names for struct fields as well as lowered global accesses.