### PR TITLE
Fix coercion from `*mut T` -> `Option<&mut T>`

### DIFF
--- a/c2rust/c2rust-transpile/src/translator/tenjin.rs
+++ b/c2rust/c2rust-transpile/src/translator/tenjin.rs
@@ -1830,8 +1830,8 @@ impl Translation<'_> {
         Ok(None)
     }
 
-    /// Map NULL -> None, &x -> Some(&[mut] x), otherwise `x.as_ref()`.
-    fn c_coerce_pointer_to_option_ref(
+    /// Map NULL -> None, &x -> Some(&[mut] x), otherwise `x.as_mut()`.
+    fn c_coerce_pointer_to_option_mut(
         &self,
         ctx: ExprContext,
         cexpr: CExprId,
@@ -1845,7 +1845,7 @@ impl Translation<'_> {
             if let Expr::Reference(_) = &*e {
                 mk().call_expr(mk().path_expr("Some"), vec![e])
             } else {
-                mk().method_call_expr(e, "as_ref", vec![])
+                mk().method_call_expr(e, "as_mut", vec![])
             }
         }))
     }
@@ -1859,7 +1859,7 @@ impl Translation<'_> {
         if cargs.len() == 1 {
             self.use_crate(ExternCrate::XjCtime);
             return Ok(Some(
-                self.c_coerce_pointer_to_option_ref(ctx, cargs[0])?
+                self.c_coerce_pointer_to_option_mut(ctx, cargs[0])?
                     .map(|arg_expr| {
                         mk().call_expr(
                             mk().path_expr(vec!["xj_ctime", "compat", "time"]),

--- a/tests/regression_tests/test_regression_tests.py
+++ b/tests/regression_tests/test_regression_tests.py
@@ -29,3 +29,9 @@ def test_errno_global(root, test_dir, tmp_codebase, tmp_resultsdir, extras, requ
     single_file_check_translation(
         "errno_global", "main.c", root, test_dir, tmp_codebase, tmp_resultsdir, extras, request
     )
+
+
+def test_time_coercion(root, test_dir, tmp_codebase, tmp_resultsdir, extras, request):
+    single_file_check_translation(
+        "time_coercion", "main.c", root, test_dir, tmp_codebase, tmp_resultsdir, extras, request
+    )

--- a/tests/regression_tests/test_regression_tests.py
+++ b/tests/regression_tests/test_regression_tests.py
@@ -35,3 +35,5 @@ def test_time_coercion(root, test_dir, tmp_codebase, tmp_resultsdir, extras, req
     single_file_check_translation(
         "time_coercion", "main.c", root, test_dir, tmp_codebase, tmp_resultsdir, extras, request
     )
+    rs_prog_output = run_cargo_on_final(tmp_resultsdir / "final", ["run"], capture_output=True)
+    assert rs_prog_output.stdout == b"1\n"

--- a/tests/regression_tests/test_regression_tests.py
+++ b/tests/regression_tests/test_regression_tests.py
@@ -1,4 +1,4 @@
-from tenjin_pytest_helpers import annotate_pytest_request_with_translation_notes
+from tenjin_pytest_helpers import annotate_pytest_request_with_translation_notes, run_cargo_on_final
 import translation
 import translation_preparation
 
@@ -20,6 +20,7 @@ def single_file_check_translation(
     )
 
     assert (tmp_resultsdir / "final" / "Cargo.toml").exists()
+    run_cargo_on_final(tmp_resultsdir / "final", ["build"])
 
     annotate_pytest_request_with_translation_notes(request, tmp_resultsdir, extras)
 

--- a/tests/regression_tests/test_regression_tests.py
+++ b/tests/regression_tests/test_regression_tests.py
@@ -3,8 +3,10 @@ import translation
 import translation_preparation
 
 
-def test_errno_global(root, test_dir, tmp_codebase, tmp_resultsdir, extras, request):
-    codebase = test_dir / "errno_global" / "main.c"
+def single_file_check_translation(
+    dir, filename, root, test_dir, tmp_codebase, tmp_resultsdir, extras, request
+):
+    codebase = test_dir / dir / filename
 
     translation_preparation.copy_codebase(codebase, tmp_codebase)
 
@@ -13,10 +15,16 @@ def test_errno_global(root, test_dir, tmp_codebase, tmp_resultsdir, extras, requ
         root,
         tmp_codebase,
         tmp_resultsdir,
-        cratename="errno_global",
+        cratename=dir,
         guidance_path_or_literal="{}",
     )
 
     assert (tmp_resultsdir / "final" / "Cargo.toml").exists()
 
     annotate_pytest_request_with_translation_notes(request, tmp_resultsdir, extras)
+
+
+def test_errno_global(root, test_dir, tmp_codebase, tmp_resultsdir, extras, request):
+    single_file_check_translation(
+        "errno_global", "main.c", root, test_dir, tmp_codebase, tmp_resultsdir, extras, request
+    )

--- a/tests/regression_tests/time_coercion/main.c
+++ b/tests/regression_tests/time_coercion/main.c
@@ -1,0 +1,13 @@
+#include <time.h>
+
+time_t wrap_time(time_t *tloc)
+{
+  return time(tloc);
+}
+
+int main()
+{
+  time_t t;
+  (void)wrap_time(&t);
+  return 0;
+}

--- a/tests/regression_tests/time_coercion/main.c
+++ b/tests/regression_tests/time_coercion/main.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include <time.h>
 
 time_t wrap_time(time_t *tloc)
@@ -9,5 +10,6 @@ int main()
 {
   time_t t;
   (void)wrap_time(&t);
+  printf("%d\n", t > 1776456020);
   return 0;
 }


### PR DESCRIPTION
Call `e.as_mut()` instead of `e.as_ref()` when coercing to an `Option` and `e` is neither a reference nor `null`.