### PR TITLE
Recognize env flag to skip removal of unnecessary unsafe markers

### DIFF
--- a/cli/translation_improvement.py
+++ b/cli/translation_improvement.py
@@ -145,6 +145,10 @@ def run_un_unsafe_improvement(root: Path, dir: Path):
        `unsafe_status` but are not yet using it.
     """
 
+    if os.environ.get("XJ_SKIP_UNUNSAFE", "0") == "1":
+        click.echo("TENJIN NOTE: skipping un-unsafe improvement as XJ_SKIP_UNUNSAFE=1")
+        return
+
     def hacky_rewrite_fn_range(path: Path, lo: int, hi: int, replacement: bytes):
         """Rewrite a range in a file to a replacement string."""
         with path.open("rb+") as f:


### PR DESCRIPTION
This can be slow for larger translations, and we don't need to pay that cost to evaluate general compilability.