### PR TITLE
Forcibly capture static libraries created via CMake builds

### DIFF
--- a/cli/targets_from_intercept.py
+++ b/cli/targets_from_intercept.py
@@ -76,6 +76,14 @@ def is_shared_lib_flag(arg: str) -> bool:
 def is_ar_creation(args: list[str]) -> bool:
     def is_ar_creation_flags(arg: str) -> bool:
         if "q" in arg:
+            dot_a_args = [a for a in args if a.endswith(".a")]
+            if len(dot_a_args) == 1:
+                out = Path(dot_a_args[0])
+                if not out.is_file():
+                    # We don't currently support the full generality of quick-append semantics,
+                    # but if the output file doesn't exist,
+                    # then it's effectively the same as creating a new archive.
+                    return True
             raise ValueError("ar command with 'q' flag is not supported: " + " ".join(args))
         if "r" not in arg:
             return False

--- a/cli/translation_preparation.py
+++ b/cli/translation_preparation.py
@@ -100,6 +100,16 @@ def compute_build_info_in(
         )
         tracker.update_sub(cp)
 
+        # Redirect llvm-ar in link.txt files to use our ar interceptor;
+        # CMake doesn't have a built-in way to specify an `ar` launcher
+        # like it does for `cc` and `ld`.
+        llvm_ar_path = str(hermetic.xj_llvm_root(repo_root.localdir()) / "bin" / "llvm-ar")
+        ar_interceptor = str(cc_ld_intercept_dir / "ar")
+        for link_txt in (builddir / "CMakeFiles").rglob("link.txt"):
+            content = link_txt.read_text(encoding="utf-8")
+            if llvm_ar_path in content:
+                link_txt.write_text(content.replace(llvm_ar_path, ar_interceptor), encoding="utf-8")
+
         # Build the project to ensure all compile and link commands are intercepted.
         cp2 = hermetic.run(
             [


### PR DESCRIPTION
Also, permit the `q` flag to `ar` when the target output file doesn't exist yet.

These changes unlock `zopfli`.