### PR TITLE
Tie Rust caches to GitHub runner image versions

### DIFF
--- a/.github/workflows/nrsr.yaml
+++ b/.github/workflows/nrsr.yaml
@@ -52,6 +52,7 @@ jobs:
           prefix-key: release-
           key: ${{ matrix.runner }}
           cache-workspace-crates: true
+          env-vars: "ImageVersion RUST"
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install tss utility for showing timestamps
@@ -152,6 +153,7 @@ jobs:
         with:
           workspaces: c2rust
           cache-workspace-crates: true
+          env-vars: "ImageVersion RUST"
           # No need for key since we only run this on one runner.
           save-if: ${{ github.ref == 'refs/heads/main' }}
 


### PR DESCRIPTION
Fix taken from https://github.com/gfx-rs/wgpu/pull/9544/

We had been seeing intermittent issues with Rust behavior in CI:

1. Intermittent failure to access the `rust-src` component on Linux:
```
2026-05-14T09:39:23.074660Z ERROR ra_ap_project_model::sysroot: can't load standard library, try installing `rust-src` sysroot_path=/home/runner/.rustup/toolchains/nightly-2025-08-20-x86_64-unknown-linux-gnu
```

2. Intermittent failure when executing `cargo` on macOS:
```
 340.7ms          : ( cd xj-improve-synsub ; cargo +1.88.0 test --locked )
 360.2ms   19.5ms error: error: unexpected argument '+1.88.0' found
 360.2ms    0.0ms 
 360.2ms    0.0ms Usage: rustup-init[EXE] [OPTIONS]
 360.2ms    0.0ms 
 360.2ms    0.0ms For more information, try '--help'.
 360.2ms    0.0ms 
```

Fingers crossed...