### PR TITLE
VIBE: Fix macro-related bug in union bitcast refactoring

### DIFF
--- a/.github/workflows/nrsr.yaml
+++ b/.github/workflows/nrsr.yaml
@@ -135,6 +135,8 @@ jobs:
 
       - run: cd /tenjin && cli/10j provision  # Reprovisioning is automatic outside of CI.
 
+      - run: rustup component list | grep 'rust-src'
+
       - name: Build c2rust tests
         run: cd /tenjin/c2rust && ../cli/10j cargo test --locked --release $C2RUST_TESTED_CRATES --no-run
 

--- a/xj-prepare-unionbitcasts/FunctionAccessAnalyzer.cpp
+++ b/xj-prepare-unionbitcasts/FunctionAccessAnalyzer.cpp
@@ -139,7 +139,10 @@ std::string FunctionAccessAnalyzer::generateTmpDeclaration(const std::string tmp
 void FunctionAccessAnalyzer::ensureMemcpyDeclared(const FunctionDecl *FD, ASTContext &Ctx,
                                                    std::vector<Edit> &edits) {
     SourceManager &SM = Ctx.getSourceManager();
-    FileID FID = SM.getFileID(FD->getSourceRange().getBegin());
+    // Resolve through macro expansion: if the function's start is spelled via a macro
+    // (e.g. `uint32_t` from `#define uint32_t unsigned int`), the raw FileID points to
+    // a scratch buffer with no FileEntry, and we'd bail out without declaring memcpy.
+    FileID FID = SM.getFileID(SM.getExpansionLoc(FD->getSourceRange().getBegin()));
     const FileEntry *FE = SM.getFileEntryForID(FID);
     if (!FE)
         return;

--- a/xj-prepare-unionbitcasts/TransformationMethods.cpp
+++ b/xj-prepare-unionbitcasts/TransformationMethods.cpp
@@ -167,9 +167,12 @@ bool FunctionAccessAnalyzer::generateConversionFunctionCode(TransformContext &ct
         return false;
     }
 
-    // Queue edit to insert typedefs and function definition before the enclosing function
+    // Queue edit to insert typedefs and function definition before the enclosing function.
+    // If the function's start location is inside a macro expansion (e.g. the return type
+    // is spelled via a macro like `uint32_t`), `InsertTextBefore` would silently fail,
+    // so resolve to the file (expansion) location before inserting.
     if (generatedObjects.find(ctx.funcName) == generatedObjects.end()) {
-        SourceLocation funcStart = ctx.FD->getSourceRange().getBegin();
+        SourceLocation funcStart = ctx.SM.getExpansionLoc(ctx.FD->getSourceRange().getBegin());
         ctx.edits.push_back({Edit::InsertBefore, ctx.SM.getFileOffset(funcStart), funcStart,
                              SourceLocation(),
                              ctx.src_typedef_code + ctx.dst_typedef_code + funcCode + "\n"});


### PR DESCRIPTION
PROMPT:
```
When I run `./_local/_build_unionbitcasts/xj-prepare-unionbitcasts ju_unionbitcasts_good.c` I get output that defines the helper   
  function __tenjin_bvm_6_5_float_to_unsigned_int but when I run it on `ju_unionbitcasts_bad.c` the output is missing the helper     
  function definition. Please help debug, the source is in `xj-prepare-unionbitcasts` 
```

```sh
> diff -U2 ju_*.c
--- ju_unionbitcasts_bad.c	2026-05-14 15:03:41.807451951 -0400
+++ ju_unionbitcasts_good.c	2026-05-14 15:03:41.807475205 -0400
@@ -1,10 +1,10 @@
 // // stdint.h induces different liftings on Mac vs Linux.
-#define uint32_t unsigned int
+// #define uint32_t unsigned int
 
-uint32_t float_to_bits(float flt) {
+unsigned int float_to_bits(float flt) {
     union {
         float flt;
-        uint32_t num;
+        unsigned int num;
     } in;
     in.flt = flt;
```

### Claude's summary:
                                                                                                                                    
When the function's return type is spelled via a macro (e.g. `#define uint32_t unsigned int`),
  ctx.FD->getSourceRange().getBegin() returns a macro-expansion SourceLocation, not a file location. That broke two things:          
                                                                                                                                     
  1. ensureMemcpyDeclared (FunctionAccessAnalyzer.cpp:142) — SM.getFileID(...) on that location returns the FileID of a scratch       buffer with no FileEntry, so if (!FE) return; bailed out silently, dropping the memcpy prototype.                                  
  2. generateConversionFunctionCode (TransformationMethods.cpp:172) — Rewriter::InsertTextBefore silently rejects non-file locations  (isRewritable requires Loc.isFileID()), so the helper definition never got inserted.


### Cost
   claude-opus-4-7:  513 input, 26.3k output, 3.4m cache read, 87.2k cache write ($2.89)