### PR TITLE
Apply XJ_BUILD_RS_PROFILE to `10j test-unit-rs` too

### DIFF
--- a/cli/cli_subcommands.py
+++ b/cli/cli_subcommands.py
@@ -125,15 +125,17 @@ def do_build_rs(root: Path, capture_output: bool = False):
 
 
 def do_test_unit_rs():
+    cargo_profile_dev = os.environ.get("XJ_BUILD_RS_PROFILE", "dev")
+    cargo_profile_rel = os.environ.get("XJ_BUILD_RS_PROFILE", "release")
     root = repo_root.find_repo_root_dir_Path()
 
     hermetic.run_cargo_in(
-        "test --locked".split(),
+        f"test --locked --profile={cargo_profile_dev}".split(),
         cwd=root / "xj-improve-synsub",
         check=True,
     )
     hermetic.run_cargo_in(
-        "test --locked".split(),
+        f"test --locked --profile={cargo_profile_rel}".split(),
         cwd=root / "xj-improve-lift-call-args",
         check=True,
     )
@@ -146,7 +148,7 @@ def do_test_unit_rs():
         env_ext["INSTA_UPDATE"] = "always"
 
     hermetic.run_cargo_in(
-        "test --locked -p c2rust -p c2rust-transpile".split(),
+        f"test --locked --profile={cargo_profile_dev} -p c2rust -p c2rust-transpile".split(),
         cwd=root / "c2rust",
         check=True,
         env_ext=env_ext,


### PR DESCRIPTION
Otherwise we end up degrading CI times significantly because we build tests in dev profile, then rebuild in release profile and cache that, so the next run has to re-build in dev profile again.