### PR TITLE
Add `rust-src` component dependency for XILCA

### DIFF
--- a/xj-improve-lift-call-args/rust-toolchain.toml
+++ b/xj-improve-lift-call-args/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 # The `ra_ap_*` v0.0.332 line needs >=1.95.
 channel = "nightly-2026-05-01"
+components = ["rust-src"]


### PR DESCRIPTION
This way, older installations that didn't get the component during provisioning will fetch it on demand.