### PR TITLE
Clean up cargo subdirs with a consistent toolchain

### DIFF
--- a/tests/tenjin_pytest_helpers.py
+++ b/tests/tenjin_pytest_helpers.py
@@ -28,7 +28,7 @@ def clean_up_resultsdir(resultsdir: Path):
     # This can add up to dozens of gigabytes across all tests if left in place.
     for subdir in resultsdir.iterdir():
         if (subdir / "target").is_dir():
-            run_cargo_on_final(subdir, ["clean", "-q"])
+            run_cargo_on_final(subdir, [hermetic.tenjin_cargo_toolchain_specifier(), "clean"])
 
     for item in resultsdir.rglob("*.refoldmap.json"):
         if "expand_preprocessor" not in item.as_posix():


### PR DESCRIPTION
I'm seeing intermittent errors in GitHub Actions on both Mac and Linux at this step.

Removing the `-q` flag (temporarily) in case they recur.