### PR TITLE
Slightly bump TA3 test vector timeout

### DIFF
--- a/tests/tenjin_pytest_helpers.py
+++ b/tests/tenjin_pytest_helpers.py
@@ -164,7 +164,7 @@ def _run_test_command(
     test_name: str,
     cwd: Path | None = None,
     stdin: str | None = None,
-    timeout: int = 30,
+    timeout: int = 42,
 ) -> tuple[CompletedProcess | None, TestOutcome | None]:
     try:
         return (


### PR DESCRIPTION
`016_sphincs_PQCgenKAT_sign_blake_256s_robust` usually takes 10-12 seconds on my main machine, but it can be slowed (maybe by paging under memory contention?) in parallel test scenarios to overrun the 30s timeout.