### PR TITLE
Switch to size-gating expensive static analysis by default

### DIFF
--- a/cli/translation_preparation.py
+++ b/cli/translation_preparation.py
@@ -896,6 +896,13 @@ def run_preparation_passes(
     def prep_localize_mutable_globals(
         prev: Path, current_codebase: Path, store: PrepPassResultStore
     ):
+        xj_cclyzer_path = current_codebase / "xj-cclyzer.json"
+        if not xj_cclyzer_path.exists():
+            print(
+                "TENJIN: WARNING: Skipping localization of mutable globals because cclyzer++ results not found.\n"
+                "This likely means that the cclyzer++ analysis failed or was skipped.\n"
+            )
+            return
         # XREF:NON_TRIVIAL_REFACTORING_PRECONDITIONS
         # Preconditions for localizing mutable globals:
         # A. The project must consist of a single executable target, OR
@@ -915,9 +922,7 @@ def run_preparation_passes(
             # Case A
             compdb = store.build_info.compdb_for_target_within(all_targets[0].key, current_codebase)
 
-            c_refact.localize_mutable_globals(
-                current_codebase / "xj-cclyzer.json", compdb, prev, current_codebase
-            )
+            c_refact.localize_mutable_globals(xj_cclyzer_path, compdb, prev, current_codebase)
         else:
             # Case B
             print(
@@ -1030,7 +1035,9 @@ def run_preparation_passes(
             curr_compdb, bitcode_module_path, use_llvm14=True
         )
 
-        run_cc2json_or_cached(bitcode_module_path, current_codebase)
+        bitcode_is_small = bitcode_module_path.stat().st_size < 1 * 1024 * 1024
+        if bitcode_is_small or os.environ.get("XJ_FORCE_CCLYZERPP", "0") == "1":
+            run_cc2json_or_cached(bitcode_module_path, current_codebase)
 
     def prep_uniquify_statics(prev: Path, current_codebase: Path, store: PrepPassResultStore):
         # For now, we restrict analysis to single-target projects,

--- a/tests/test_third_party.py
+++ b/tests/test_third_party.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 import shutil
-import os
 import platform
 
 import pytest
@@ -396,8 +395,9 @@ def test_lua_5_4_0_immunant(tenjin_fixtures: TenjinFixtures):
         "lua",
     ]
 
-    # cclyzer takes 7+ hours to analyze Lua, ain't nobody got time for that.
-    os.environ["XJ_SKIP_CCLYZERPP"] = "1"
+    # Note that cclyzer++ currently does not run on this codebase due to two
+    # incidental restrictions: we don't run it on multi-target codebases (lua + liblua),
+    # and we don't run it on bitcode files as large as liblua's.
     translation.do_translate(
         tenjin_fixtures.root,
         tmp_codebase,
@@ -406,7 +406,6 @@ def test_lua_5_4_0_immunant(tenjin_fixtures: TenjinFixtures):
         buildcmd=hermetic.shellize(buildcmd_args),
         guidance_path_or_literal="{}",
     )
-    del os.environ["XJ_SKIP_CCLYZERPP"]
 
     c_prog_output = hermetic.run(
         [str(tmp_resultsdir / "_build_1" / "lua"), "-v"], check=True, capture_output=True


### PR DESCRIPTION
`liblua.a` compiles to 1.9 MB of LLVM bitcode and takes many hours for our extended version of `cclyzer++` to analyze. `tree` is 0.5 MB and takes about 7 minutes.

Currently we have an opt-out env var, `XJ_SKIP_CCLYZERPP`, to allow translation to proceed that would otherwise get stuck.

Eventually we'd like to have a much more efficient static analysis that can handle large codebases. Until then, we'll switch to running cclyzer++ only on "small enough" codebases, with an opt-in env var to enable cclyzer++ even on large inputs.