### PR TITLE
Find VCS root in git worktrees

### DIFF
--- a/cli/translation.py
+++ b/cli/translation.py
@@ -40,26 +40,26 @@ def stub_ingestion_record(
     This is used to initialize the ingestion record before the actual translation.
     """
 
-    codebase_vcs_dir = vcs_helpers.find_containing_vcs_dir(codebase)
+    codebase_vcs_path = vcs_helpers.find_containing_vcs_path(codebase)
     ingested_codebase = None
 
-    if codebase_vcs_dir is not None:
-        codebase_wcs = vcs_helpers.vcs_working_copy_status(codebase_vcs_dir)
+    if codebase_vcs_path is not None:
+        codebase_wcs = vcs_helpers.vcs_working_copy_status(codebase_vcs_path)
         if codebase_wcs.origin is not None and codebase_wcs.commit is not None:
             codebase_relative_path = codebase
             if codebase_relative_path.is_absolute():
                 codebase_relative_path = codebase.relative_to(
-                    vcs_helpers.vcs_root(codebase_vcs_dir)
+                    vcs_helpers.vcs_root(codebase_vcs_path)
                 )
             ingested_codebase = ingest.IngestedCodebase(
                 git_repo_url=codebase_wcs.origin,
                 git_commit=codebase_wcs.commit,
                 relative_path=str(codebase_relative_path),
             )
-    tenjin_vcs_dir = vcs_helpers.find_containing_vcs_dir(find_repo_root_dir_Path())
-    assert tenjin_vcs_dir is not None, "No VCS directory found for Tenjin?!?!"
+    tenjin_vcs_path = vcs_helpers.find_containing_vcs_path(find_repo_root_dir_Path())
+    assert tenjin_vcs_path is not None, "No VCS directory found for Tenjin?!?!"
 
-    tenjin_wcs = vcs_helpers.vcs_working_copy_status(tenjin_vcs_dir)
+    tenjin_wcs = vcs_helpers.vcs_working_copy_status(tenjin_vcs_path)
 
     assert tenjin_wcs.origin is not None, "Tenjin working copy has no origin URL?!?"
     assert tenjin_wcs.commit is not None, "Tenjin working copy has no commit hash?!?"

--- a/cli/vcs_helpers.py
+++ b/cli/vcs_helpers.py
@@ -9,19 +9,19 @@ import hermetic
 
 
 def vcs_diff(path: Path) -> bytes:
-    vcs_dir = find_containing_vcs_dir(path)
-    if vcs_dir is None:
+    vcs_path = find_containing_vcs_path(path)
+    if vcs_path is None:
         raise RuntimeError(f"No containing .jj or .git directory found for path {path}")
-    if vcs_dir.name == ".jj":
+    if vcs_path.name == ".jj":
         return hermetic.check_output(
             ["jj", "diff", "--git", "--no-pager", "--quiet", path.as_posix()],
-            cwd=vcs_root(vcs_dir),
+            cwd=vcs_root(vcs_path),
         )
     else:
-        assert vcs_dir.name == ".git"
+        assert vcs_path.name == ".git"
         return hermetic.check_output(
             ["git", "diff", path.as_posix()],
-            cwd=vcs_root(vcs_dir),
+            cwd=vcs_root(vcs_path),
         )
 
 
@@ -47,11 +47,11 @@ class WorkingCopyStatus:
     commit: str | None = None
 
 
-def vcs_working_copy_status(vcs_dir: Path, origin_remote: str = "origin") -> WorkingCopyStatus:
-    if vcs_dir.name == ".git":
-        return git_working_copy_status(vcs_root(vcs_dir), origin_remote)
-    assert vcs_dir.name == ".jj", "Expected .jj or .git directory"
-    return jj_working_copy_status(vcs_root(vcs_dir), origin_remote)
+def vcs_working_copy_status(vcs_path: Path, origin_remote: str = "origin") -> WorkingCopyStatus:
+    if vcs_path.name == ".git":
+        return git_working_copy_status(vcs_root(vcs_path), origin_remote)
+    assert vcs_path.name == ".jj", "Expected .jj or .git file"
+    return jj_working_copy_status(vcs_root(vcs_path), origin_remote)
 
 
 def jj_working_copy_status(vcs_root: Path, origin_remote: str = "origin") -> WorkingCopyStatus:
@@ -211,15 +211,15 @@ def git_working_copy_status(vcs_root: Path, origin_remote: str = "origin") -> Wo
     )
 
 
-def vcs_root(vcs_dir: Path) -> Path:
-    return vcs_dir.parent
+def vcs_root(vcs_path: Path) -> Path:
+    return vcs_path.parent
 
 
-def find_containing_vcs_dir(start_dir: Path) -> Path | None:
+def find_containing_vcs_path(start_dir: Path) -> Path | None:
     """
     Walk up from the specified directory towards the filesystem root, looking
-    for directories named '.jj' or '.git' and return the full path of the first
-    such directory found, or None if no such directory was found.
+    for directories/files named '.jj' or '.git' and return the full path of the first
+    such file found, or None if no such file was found.
     """
     if start_dir is None:
         start_dir = os.getcwd()
@@ -231,9 +231,10 @@ def find_containing_vcs_dir(start_dir: Path) -> Path | None:
     while True:
         # Check for .jj or .git in the current directory, preferring .jj
         # (in case of a colocated repository).
+        # .git can be a file (not a directory) when working in a worktree
         for repo_dir in [".jj", ".git"]:
             potential_path = os.path.join(current_dir, repo_dir)
-            if os.path.isdir(potential_path):
+            if os.path.exists(potential_path):
                 return Path(potential_path)
 
         # Move up one directory


### PR DESCRIPTION
`.git` is a regular file in worktrees. Relax vcs detection to just check the paths `.jj` or `.git` exist