### PR TITLE
Fix formatting coercion of pointer to string

### DIFF
--- a/c2rust/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust/c2rust-transpile/src/translator/mod.rs
@@ -2128,17 +2128,24 @@ mod refactor_format {
                 );
                 mk().method_call_expr(ctime_call, "unwrap", Vec::new())
             } else {
+                x.with_cur_file_item_store(|item_store| {
+                    // TODO(brk): handle emission of bytes
+                    item_store.add_item_str_once(
+                        r#"unsafe fn xj_str_from_ptr<'a>(ptr: *const core::ffi::c_char) -> &'a str {
+                          if ptr.is_null() {
+                              "(null)"
+                          } else {
+                              core::ffi::CStr::from_ptr(ptr).to_str().unwrap()
+                          }
+                        }"#,
+                    );
+                });
+
                 let span = e.span();
-                // CStr::from_ptr(e as *const libc::c_char).to_str().unwrap()
+
                 let e = mk().cast_expr(e, mk().ptr_ty(mk().path_ty(vec!["core", "ffi", "c_char"])));
-                let cs = mk().call_expr(
-                    // TODO(kkysen) change `"std"` to `"core"` after `#![feature(core_c_str)]` is stabilized in `1.63.0`
-                    mk().path_expr(vec!["std", "ffi", "CStr", "from_ptr"]),
-                    vec![e],
-                );
-                let s = mk().method_call_expr(cs, "to_str", Vec::new());
-                let call = mk().method_call_expr(s, "unwrap", Vec::new());
-                let b = mk().unsafe_().block(vec![mk().expr_stmt(call)]);
+                let cs = mk().call_expr(mk().path_expr(vec!["xj_str_from_ptr"]), vec![e]);
+                let b = mk().unsafe_().block(vec![mk().expr_stmt(cs)]);
                 mk().span(span).block_expr(b)
             }
         }

--- a/c2rust/c2rust-transpile/tests/snapshots/snapshots__transpile@varargs.c.2021.x86_64.linux.snap
+++ b/c2rust/c2rust-transpile/tests/snapshots/snapshots__transpile@varargs.c.2021.x86_64.linux.snap
@@ -74,10 +74,8 @@ pub unsafe extern "C" fn my_printf(mut fmt: *const ::core::ffi::c_char, mut c2ru
                         }
                         115 => {
                             print!("{:>}", {
-                                std::ffi::CStr::from_ptr(ap.arg::<*mut ::core::ffi::c_char>()
+                                xj_str_from_ptr(ap.arg::<*mut ::core::ffi::c_char>()
                                     as *const core::ffi::c_char)
-                                .to_str()
-                                .unwrap()
                             });
                         }
                         _ => {}
@@ -153,5 +151,12 @@ pub unsafe extern "C" fn borrowed_valist(mut count: size_t, mut c2rust_args: ...
     while count > 0 as size_t {
         print_int(&raw mut ap);
         count = count.wrapping_sub(1);
+    }
+}
+unsafe fn xj_str_from_ptr<'a>(ptr: *const core::ffi::c_char) -> &'a str {
+    if ptr.is_null() {
+        "(null)"
+    } else {
+        core::ffi::CStr::from_ptr(ptr).to_str().unwrap()
     }
 }

--- a/c2rust/c2rust-transpile/tests/snapshots/snapshots__transpile@varargs.c.2024.x86_64.linux.snap
+++ b/c2rust/c2rust-transpile/tests/snapshots/snapshots__transpile@varargs.c.2024.x86_64.linux.snap
@@ -75,10 +75,8 @@ pub unsafe extern "C" fn my_printf(mut fmt: *const ::core::ffi::c_char, mut c2ru
                         }
                         115 => {
                             print!("{:>}", {
-                                std::ffi::CStr::from_ptr(ap.arg::<*mut ::core::ffi::c_char>()
+                                xj_str_from_ptr(ap.arg::<*mut ::core::ffi::c_char>()
                                     as *const core::ffi::c_char)
-                                .to_str()
-                                .unwrap()
                             });
                         }
                         _ => {}
@@ -154,5 +152,12 @@ pub unsafe extern "C" fn borrowed_valist(mut count: size_t, mut c2rust_args: ...
     while count > 0 as size_t {
         print_int(&raw mut ap);
         count = count.wrapping_sub(1);
+    }
+}
+unsafe fn xj_str_from_ptr<'a>(ptr: *const core::ffi::c_char) -> &'a str {
+    if ptr.is_null() {
+        "(null)"
+    } else {
+        core::ffi::CStr::from_ptr(ptr).to_str().unwrap()
     }
 }

--- a/tests/snapshotted/assorted_guidance/_xj_snapshot/00_out/src/assorted_guidance.rs
+++ b/tests/snapshotted/assorted_guidance/_xj_snapshot/00_out/src/assorted_guidance.rs
@@ -75,11 +75,7 @@ pub unsafe fn print_owned_String(mut ostr: String) {
 }
 #[no_mangle]
 pub unsafe fn print_unguided_ptr(mut ptr: *const ::core::ffi::c_char) {
-    println!("{:>}", {
-        std::ffi::CStr::from_ptr(ptr as *const core::ffi::c_char)
-            .to_str()
-            .unwrap()
-    });
+    println!("{:>}", { xj_str_from_ptr(ptr as *const core::ffi::c_char) });
 }
 #[no_mangle]
 pub unsafe fn print_shared_vec_u8(mut rvu8: &Vec<u8>) {
@@ -308,6 +304,13 @@ pub unsafe fn printf_in_cond(mut ostr: String) -> ::core::ffi::c_int {
         return 42 as ::core::ffi::c_int;
     }
     return 0 as ::core::ffi::c_int;
+}
+unsafe fn xj_str_from_ptr<'a>(ptr: *const core::ffi::c_char) -> &'a str {
+    if ptr.is_null() {
+        "(null)"
+    } else {
+        core::ffi::CStr::from_ptr(ptr).to_str().unwrap()
+    }
 }
 fn xj_sprintf_Vec_u8(dest: &mut Vec<u8>, lim: Option<usize>, val: String) -> usize {
     if lim == Some(0) {

--- a/tests/snapshotted/assorted_guidance/_xj_snapshot/final/src/assorted_guidance.rs
+++ b/tests/snapshotted/assorted_guidance/_xj_snapshot/final/src/assorted_guidance.rs
@@ -47,11 +47,7 @@ pub fn print_owned_String(mut ostr: String) {
 }
 #[no_mangle]
 pub unsafe fn print_unguided_ptr(mut ptr: *const ::core::ffi::c_char) {
-    println!("{:>}", {
-        std::ffi::CStr::from_ptr(ptr as *const core::ffi::c_char)
-            .to_str()
-            .unwrap()
-    },);
+    println!("{:>}", { xj_str_from_ptr(ptr as *const core::ffi::c_char) });
 }
 #[no_mangle]
 pub fn print_shared_vec_u8(mut rvu8: &Vec<u8>) {
@@ -255,6 +251,13 @@ pub unsafe fn printf_in_cond(mut ostr: String) -> ::core::ffi::c_int {
         return 42;
     }
     0
+}
+unsafe fn xj_str_from_ptr<'a>(ptr: *const core::ffi::c_char) -> &'a str {
+    if ptr.is_null() {
+        "(null)"
+    } else {
+        core::ffi::CStr::from_ptr(ptr).to_str().unwrap()
+    }
 }
 fn xj_sprintf_Vec_u8(dest: &mut Vec<u8>, lim: Option<usize>, val: String) -> usize {
     if lim == Some(0) {

--- a/tests/snapshotted/various_unguided/_xj_snapshot/00_out/src/various_unguided.rs
+++ b/tests/snapshotted/various_unguided/_xj_snapshot/00_out/src/various_unguided.rs
@@ -20,14 +20,19 @@ pub unsafe extern "C" fn isatty_stdin() -> ::core::ffi::c_int {
 #[no_mangle]
 pub unsafe extern "C" fn string_cond_1(mut cond: ::core::ffi::c_int) {
     println!("{:>}", {
-        std::ffi::CStr::from_ptr(
+        xj_str_from_ptr(
             (if cond != 0 {
                 b"true\0".as_ptr() as *const ::core::ffi::c_char
             } else {
                 b"false\0".as_ptr() as *const ::core::ffi::c_char
             }) as *const core::ffi::c_char,
         )
-        .to_str()
-        .unwrap()
     });
+}
+unsafe fn xj_str_from_ptr<'a>(ptr: *const core::ffi::c_char) -> &'a str {
+    if ptr.is_null() {
+        "(null)"
+    } else {
+        core::ffi::CStr::from_ptr(ptr).to_str().unwrap()
+    }
 }

--- a/xj-improve-synsub/src/rewrites.rs
+++ b/xj-improve-synsub/src/rewrites.rs
@@ -612,48 +612,26 @@ impl Rewriter {
 
     /// Rewrite code like
     ///   ```ignore
-    ///     std::ffi::CStr::from_ptr((if COND { THN } else { ELS })
-    ///          as *const core::ffi::c_char)
-    ///             .to_str()
-    ///             .unwrap()
+    ///     xj_str_from_ptr((if COND { THN } else { ELS }) as *const core::ffi::c_char)
     /// ```
-    /// to distribute the from_ptr() over the if, so long as at least one of
+    /// to distribute xj_str_from_ptr() over the if, so long as at least one of
     /// THN and ELS is a byte string literal with valid UTF-8 text.
     pub fn rewrite_cstr_ctor_over_if(
         &self,
         _symbols: &SymbolTable,
         expr: &Expr,
     ) -> Option<(Expr, Depth)> {
-        let Expr::MethodCall(method_call) = expr else {
+        let Expr::Call(str_from_ptr_call) = expr else {
             return None;
         };
-        if method_call.method != "unwrap" || !method_call.args.is_empty() {
+        let Expr::Path(ref func) = *str_from_ptr_call.func else {
+            return None;
+        };
+        if !func.path.is_ident("xj_str_from_ptr") || str_from_ptr_call.args.len() != 1 {
             return None;
         }
 
-        let Expr::MethodCall(to_str_call) = &*method_call.receiver else {
-            return None;
-        };
-        if to_str_call.method != "to_str" || !to_str_call.args.is_empty() {
-            return None;
-        }
-        let Expr::Call(from_ptr_call) = &*to_str_call.receiver else {
-            return None;
-        };
-        let Expr::Path(ref func) = *from_ptr_call.func else {
-            return None;
-        };
-        if func
-            .path
-            .segments
-            .last()
-            .is_none_or(|seg| seg.ident != "from_ptr")
-            || from_ptr_call.args.len() != 1
-        {
-            return None;
-        }
-
-        let arg = &from_ptr_call.args[0];
+        let arg = &str_from_ptr_call.args[0];
         let Expr::Cast(cast) = expr_strip_parens(arg) else {
             return None;
         };
@@ -679,13 +657,13 @@ impl Rewriter {
         let then_expr = if let Some(lit) = mb_then_lit {
             *lit
         } else {
-            syn::parse_quote! { std::ffi::CStr::from_ptr( #then_expr_full as *const core::ffi::c_char ).to_str().unwrap() }
+            syn::parse_quote! { xj_str_from_ptr( #then_expr_full as *const core::ffi::c_char ) }
         };
 
         let else_expr = if let Some(lit) = mb_else_lit {
             *lit
         } else {
-            syn::parse_quote! { std::ffi::CStr::from_ptr( #else_expr_full as *const core::ffi::c_char ).to_str().unwrap() }
+            syn::parse_quote! { xj_str_from_ptr( #else_expr_full as *const core::ffi::c_char ) }
         };
 
         let cond = &if_expr.cond;


### PR DESCRIPTION
Simply using `CStr::from_ptr(p)` is incorrect because `printf` gives special handling to null pointers.