### PR TITLE
Use context to decide whether to coerce slice to pointer

### DIFF
--- a/c2rust/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust/c2rust-transpile/src/translator/mod.rs
@@ -4603,6 +4603,10 @@ impl<'c> Translation<'c> {
                     .query_decl_type(self, decl_id)
                 {
                     if (var_guided_type.is_slice_ref() || var_guided_type.is_array_ref())
+                        && ctx_guided_type
+                            .as_ref()
+                            .map(|t| !(t.is_slice_ref() || t.is_array_ref()))
+                            .unwrap_or(true)
                         && !self.wrapped_with_array_decay(expr_id)
                         && !self.wrapped_with_subscript_base(expr_id)
                     {

--- a/c2rust/c2rust-transpile/src/translator/named_references.rs
+++ b/c2rust/c2rust-transpile/src/translator/named_references.rs
@@ -107,7 +107,12 @@ impl Translation<'_> {
             .get_qual_type()
             .ok_or_else(|| format_err!("bad reference type"))?;
         let read = |write| self.read(reference_ty, write);
-        let reference = self.convert_expr(ctx.used(), reference, Some(reference_ty))?;
+        let ctx_guided_type = self
+            .parsed_guidance
+            .borrow_mut()
+            .query_expr_type(self, reference);
+        let reference =
+            self.convert_expr_guided(ctx.used(), reference, Some(reference_ty), &ctx_guided_type)?;
         reference.and_then(|reference| {
             if !uses_read && is_lvalue(&reference) {
                 Ok(WithStmts::new_val(NamedReference {

--- a/c2rust/c2rust-transpile/src/translator/named_references.rs
+++ b/c2rust/c2rust-transpile/src/translator/named_references.rs
@@ -107,6 +107,9 @@ impl Translation<'_> {
             .get_qual_type()
             .ok_or_else(|| format_err!("bad reference type"))?;
         let read = |write| self.read(reference_ty, write);
+        // Pass in the expression's guided type here as the context - we really just want
+        // an expression corresponding to whatever the guided type is
+        // (this avoids the temptation to coerce to some other type)
         let ctx_guided_type = self
             .parsed_guidance
             .borrow_mut()

--- a/c2rust/c2rust-transpile/tests/snapshots.rs
+++ b/c2rust/c2rust-transpile/tests/snapshots.rs
@@ -89,6 +89,12 @@ fn guidance_for_file(c_path: &Path) -> serde_json::Value {
                 "foo": "u8"
             }
         })
+    } else if c_path.ends_with("tenjin_slices.c") {
+        serde_json::json!({
+            "vars_of_type" : {
+                "&[u8]" : "inc:x"
+            }
+        })
     } else {
         serde_json::json!({})
     }
@@ -527,6 +533,11 @@ fn test_sigign() {
 #[test]
 fn test_typedefidx() {
     transpile("typedefidx.c").os_specific(true).run();
+}
+
+#[test]
+fn test_tenjin_slices() {
+    transpile("tenjin_slices.c").run();
 }
 
 #[test]

--- a/c2rust/c2rust-transpile/tests/snapshots/snapshots__transpile@tenjin_slices.c.2021.snap
+++ b/c2rust/c2rust-transpile/tests/snapshots/snapshots__transpile@tenjin_slices.c.2021.snap
@@ -1,0 +1,17 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+expression: cat tests/snapshots/tenjin_slices.2021.rs
+---
+#![allow(
+    clippy::missing_safety_doc,
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+#[no_mangle]
+pub unsafe extern "C" fn inc(mut x: &[u8]) {
+    x = &x[1..];
+}

--- a/c2rust/c2rust-transpile/tests/snapshots/snapshots__transpile@tenjin_slices.c.2024.snap
+++ b/c2rust/c2rust-transpile/tests/snapshots/snapshots__transpile@tenjin_slices.c.2024.snap
@@ -1,0 +1,18 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+expression: cat tests/snapshots/tenjin_slices.2024.rs
+---
+#![allow(
+    clippy::missing_safety_doc,
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unsafe_op_in_unsafe_fn,
+    unused_assignments,
+    unused_mut
+)]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn inc(mut x: &[u8]) {
+    x = &x[1..];
+}

--- a/c2rust/c2rust-transpile/tests/snapshots/tenjin_slices.c
+++ b/c2rust/c2rust-transpile/tests/snapshots/tenjin_slices.c
@@ -1,0 +1,5 @@
+// XREF:array_decay
+void inc(unsigned char *x)
+{
+    x++;
+}


### PR DESCRIPTION
The immediate goal is to fix the following:
```
char *x; // <- guided type is &[u8]
...
x++;
```
is translated (today) to:
```
let c2rust_fresh0 = x.as_ptr();
*c2rust_fresh0 = &(*c2rust_fresh0[1..])`
```
because the coercion to a pointer is always applied to the expression (`x`) provided that is not a subscript/array decay expression. 

The change is to take the context guided type into account, and only to coerce to a pointer if the context's expectation is not a slice/array.