### PR TITLE
Update LLVM 21.1.8 build with refolder fix for `u8c`

### DIFF
--- a/cli/constants.py
+++ b/cli/constants.py
@@ -1,7 +1,7 @@
 # Note: the keys in this dict are not command names, or file names,
 # just arbitrary labels for the things we are tracking.
 WANT = {
-    "10j-llvm": "21.1.8+refold@rev-37d52f4c8",
+    "10j-llvm": "21.1.8+refold@rev-73a471b80",
     "10j-llvm14": "14.0.6@llvmorg-14.0.6",
     "10j-opam": "2.3.0",
     "10j-dune": "3.19.1",


### PR DESCRIPTION
This corresponds to https://github.com/Aarno-Labs/llvm-project/commit/dafd84d9772856ad942e6c1c0ae676fa8460a786