### PR TITLE
Bugfix for union conversion applied to functions from headers

### DIFF
--- a/tests/snapshotted/assorted_guidance/_xj_snapshot/00_out/Cargo.lock
+++ b/tests/snapshotted/assorted_guidance/_xj_snapshot/00_out/Cargo.lock
@@ -24,18 +24,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]

--- a/tests/snapshotted/assorted_guidance/_xj_snapshot/final/Cargo.lock
+++ b/tests/snapshotted/assorted_guidance/_xj_snapshot/final/Cargo.lock
@@ -24,18 +24,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]

--- a/xj-prepare-unionbitcasts/UnionTransformAction.cpp
+++ b/xj-prepare-unionbitcasts/UnionTransformAction.cpp
@@ -12,6 +12,9 @@ bool UnionTransformAction::BeginSourceFileAction(CompilerInstance &CI) {
     gLog.replacedUnion = false;
     gLog.error = "";
     addedMemcpyDecl = false;
+    // Helper definitions are static, so each translation unit needs its own
+    // copy even when the same union appears in several TUs via a shared header.
+    generatedObjects.clear();
     return true;
 }
 


### PR DESCRIPTION
Before, when a static function definition was pasted from a header into multiple translation units, only one of the translation units would get a definition for the `__tenjin_bvm_` helper function.

This was exposed by `libusb`.