### PR TITLE
VIBE: Bugfix for pointer transformation pass

### DIFF
--- a/xj-prepare-pointertransform/FunctionAccessAnalyzer.cpp
+++ b/xj-prepare-pointertransform/FunctionAccessAnalyzer.cpp
@@ -274,6 +274,26 @@ void FunctionAccessAnalyzer::detectAllTransformations(ASTContext &Ctx) {
                 if (access.kind == PointerAccessKind::ComparisonExpr) {
                     std::string op_text = access.operand_text;
 
+                    // Case 0: pointer-form equality "base + idx != (end)"
+                    // (field_name carries the base; see the collector's
+                    // equality handling).
+                    if (!access.field_name.empty()) {
+                        if (op_text.size() > 2 && op_text.front() == '(' &&
+                            op_text.back() == ')') {
+                            std::string end_name =
+                                op_text.substr(1, op_text.size() - 2);
+                            for (unsigned i = 0; i < FD->getNumParams(); i++) {
+                                if (FD->getParamDecl(i)->getNameAsString() == end_name &&
+                                    FD->getParamDecl(i)->getType()->isPointerType()) {
+                                    info.end_param_index = i;
+                                    found_rs = true;
+                                    break;
+                                }
+                            }
+                        }
+                        break;
+                    }
+
                     // Case 1: pointer pair "(end - base)"
                     std::string pair_suffix = " - " + candidate.base_array_text + ")";
                     if (op_text.size() > pair_suffix.size() &&
@@ -1216,8 +1236,13 @@ void FunctionAccessAnalyzer::transformAllFunctions(ASTContext &Ctx) {
                     continue;
                 // Check if operand_text is "(other - base)" pattern
                 // and the other is also being transformed
-                if (!acc.field_name.empty())
-                    continue; // already using pointer reconstruction
+                if (!acc.field_name.empty() &&
+                    acc.field_name != candidate.base_array_text)
+                    continue; // shape-5 param reconstruction; leave alone
+                // (pointer-form equality records — field_name == base —
+                // fall through: their operand still names the other
+                // pointer and must be reconstructed below if that
+                // pointer is transformed too)
                 // Look for the other pointer in the comparison's parent
                 const Stmt *P = skipTransparentParents(acc.expr, Ctx);
                 const BinaryOperator *BO = P ? dyn_cast<BinaryOperator>(P) : nullptr;
@@ -1251,7 +1276,7 @@ void FunctionAccessAnalyzer::transformAllFunctions(ASTContext &Ctx) {
                 // base + index <op> other_base + other_index
                 auto &other_cand = analysis.tracked_pointers[OtherVD];
                 std::string other_base = other_cand.base_array_text;
-                std::string other_idx = OtherVD->getNameAsString() + "_index";
+                std::string other_idx = OtherVD->getNameAsString() + "_index_xj";
                 std::string rhs = other_base.empty() ?
                     other_idx : other_base + " + " + other_idx;
                 acc.field_name = candidate.base_array_text;
@@ -1413,7 +1438,7 @@ static const FunctionDecl *findEnclosingFunction(SourceLocation Loc,
 // pointers / removed params it references render as their new spelling.
 //
 // Handled cases:
-//   - A DeclRefExpr to a transformed local pointer -> append "_index".
+//   - A DeclRefExpr to a transformed local pointer -> append "_index_xj".
 //   - A DeclRefExpr to a return-type-changed local -> use the bare
 //     name (no suffix; the variable is already an int).
 //   - A DeclRefExpr to one of the caller's *removed* params (the
@@ -1450,7 +1475,7 @@ std::string FunctionAccessAnalyzer::translateArgExpr(const Expr *ArgExpr,
                 if (analysis.tracked_pointers.count(VD) &&
                     !analysis.tracked_pointers[VD].is_parameter &&
                     !analysis.accesses[VD].empty()) {
-                    return VD->getNameAsString() + "_index";
+                    return VD->getNameAsString() + "_index_xj";
                 }
             }
 

--- a/xj-prepare-pointertransform/PointerAccessCollector.cpp
+++ b/xj-prepare-pointertransform/PointerAccessCollector.cpp
@@ -598,6 +598,22 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
                 }
 
                 if (!candidate.base_array_text.empty()) {
+                    // Equality comparisons stay in pointer form:
+                    //   p != q  →  base + p_index != (q)
+                    // The index form `p_index != (q - base)` is ill-typed
+                    // when q's pointee type differs from base's (e.g. a
+                    // `void *` operand, which `==`/`!=` accept but `-`
+                    // does not), and is UB when q doesn't point into
+                    // base's array — equality alone is defined for any
+                    // two pointers.
+                    if (BO->getOpcode() == BO_EQ || BO->getOpcode() == BO_NE) {
+                        access_list.push_back({PointerAccessKind::ComparisonExpr,
+                                               BO->getBeginLoc(), DRE, nullptr,
+                                               op_text, candidate.base_array_text,
+                                               "", "(" + other_text + ")"});
+                        return;
+                    }
+
                     std::string resolved = "(" + other_text + " - " +
                                            candidate.base_array_text + ")";
                     access_list.push_back({PointerAccessKind::ComparisonExpr,

--- a/xj-prepare-pointertransform/TransformationMethods.cpp
+++ b/xj-prepare-pointertransform/TransformationMethods.cpp
@@ -135,6 +135,26 @@ bool FunctionAccessAnalyzer::generateTransformation(
                 if (access.kind == PointerAccessKind::ComparisonExpr) {
                     std::string op_text = access.operand_text;
 
+                    // Case 0: pointer-form equality "base + idx != (end)"
+                    // (field_name carries the base; see the collector's
+                    // equality handling).
+                    if (!access.field_name.empty()) {
+                        if (op_text.size() > 2 && op_text.front() == '(' &&
+                            op_text.back() == ')') {
+                            std::string end_name =
+                                op_text.substr(1, op_text.size() - 2);
+                            for (unsigned i = 0; i < FD->getNumParams(); i++) {
+                                if (FD->getParamDecl(i)->getNameAsString() == end_name &&
+                                    FD->getParamDecl(i)->getType()->isPointerType()) {
+                                    slice_info.end_param_index = i;
+                                    is_rust_slice = true;
+                                    break;
+                                }
+                            }
+                        }
+                        break;
+                    }
+
                     // Case 1: pointer pair "(end - base)"
                     std::string pair_suffix = " - " + original_base_array + ")";
                     if (op_text.size() > pair_suffix.size() &&
@@ -187,8 +207,24 @@ bool FunctionAccessAnalyzer::generateTransformation(
             // *(p + lookahead).
             base_array = slice_info.slice_param_name + ".ptr";
 
+            std::string end_pat;
+            if (slice_info.end_param_index >= 0)
+                end_pat = "(" +
+                          FD->getParamDecl(slice_info.end_param_index)->getNameAsString() +
+                          ")";
             for (auto &access : accesses) {
                 if (access.kind == PointerAccessKind::ComparisonExpr) {
+                    if (!access.field_name.empty()) {
+                        // Pointer-form equality. If it bounded the pointer
+                        // against `end` it becomes an index bound against
+                        // arr.len (same object by construction); otherwise
+                        // it stays in pointer form, rebased onto arr.ptr.
+                        if (access.operand_text != end_pat) {
+                            access.field_name = base_array;
+                            continue;
+                        }
+                        access.field_name.clear();
+                    }
                     int adjustment = slice_info.lookahead;
                     if (slice_info.inclusive_end)
                         adjustment += 1;
@@ -1921,21 +1957,36 @@ bool FunctionAccessAnalyzer::generatePointerPairTransformation(
             std::string base_pname = FD->getParamDecl(base_idx)->getNameAsString();
             std::string end_pname = FD->getParamDecl(end_idx)->getNameAsString();
             std::string sub_pat = "(" + end_pname + " - " + base_pname + ")";
+            std::string ptr_pat = "(" + end_pname + ")";
             bool incl = (tf_it != g_transformed_functions.end())
                             ? tf_it->second.inclusive_end
                             : inclusive_end;
             for (auto &acc : accesses) {
-                if (acc.kind == PointerAccessKind::ComparisonExpr &&
-                    acc.operand_text == sub_pat) {
-                    int adj = candidate.max_relative_offset;
-                    if (incl)
-                        adj += 1;
-                    if (adj > 0)
-                        acc.operand_text =
-                            arr_name + ".len - " + std::to_string(adj);
-                    else
-                        acc.operand_text = arr_name + ".len";
+                if (acc.kind != PointerAccessKind::ComparisonExpr)
+                    continue;
+                // Pointer-form equality (field_name carries the base):
+                // a bound against `end` becomes an index bound against
+                // arr.len; anything else keeps its pointer form, rebased
+                // onto arr.ptr.
+                if (!acc.field_name.empty()) {
+                    if (acc.operand_text == ptr_pat) {
+                        acc.field_name.clear();
+                    } else {
+                        if (acc.field_name == base_pname)
+                            acc.field_name = arr_name + ".ptr";
+                        continue;
+                    }
+                } else if (acc.operand_text != sub_pat) {
+                    continue;
                 }
+                int adj = candidate.max_relative_offset;
+                if (incl)
+                    adj += 1;
+                if (adj > 0)
+                    acc.operand_text =
+                        arr_name + ".len - " + std::to_string(adj);
+                else
+                    acc.operand_text = arr_name + ".len";
             }
         }
 


### PR DESCRIPTION
The pass was transforming `(p != q)` into `(q_index != (p - q_base))` but that's problematic for at least two (related) reasons.

First, it potentially introduces UB, since equality comparison is defined for pointers to distinct objects, but subtraction is not.

Second, it potentially introduces type errors: if one of the pointers is typed as `void*` and the other is not, the equality comparison is well typed but the subtraction is ill typed.

This commit instead keeps the pointer (in)equality by rewriting to e.g. `p != (q_base + q_index)`.

Cost:
- claude-fable-5:  664 input, 31.5k output, 2.2m cache read, 75.3k cache write ($5.33)