### PR TITLE
VIBE: Bugfix for pointer transformation handling of "shape 2"

### DIFF
--- a/xj-prepare-pointertransform/PointerAccessCollector.cpp
+++ b/xj-prepare-pointertransform/PointerAccessCollector.cpp
@@ -571,16 +571,33 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
                 return;
             }
 
-            // Shape 2: p ?= arr + n  →  index ?= n
+            // Shape 2: p ?= base + n  →  index ?= n
+            // Only when the added-to pointer is p's own base array —
+            // `p ?= other + n` for a foreign pointer must not collapse
+            // to an index-vs-n comparison. A parameter with no base yet
+            // may still match its own name: validation later makes the
+            // parameter itself the base (index counts from its incoming
+            // value), so `p ?= p + n` is `index ?= n`.
             if (const BinaryOperator *AddBO = dyn_cast<BinaryOperator>(OtherSide)) {
                 if (AddBO->getOpcode() == BO_Add) {
                     const Expr *AddLHS = AddBO->getLHS()->IgnoreParenImpCasts();
                     if (AddLHS->getType()->isPointerType() || AddLHS->getType()->isArrayType()) {
-                        std::string offset = getSourceText(AddBO->getRHS(), SM, LO);
-                        access_list.push_back({PointerAccessKind::ComparisonExpr,
-                                               BO->getBeginLoc(), DRE, nullptr,
-                                               op_text, "", "", offset});
-                        return;
+                        std::string add_lhs_text = getSourceText(AddLHS, SM, LO);
+                        bool lhs_is_base =
+                            !candidate.base_array_text.empty()
+                                ? add_lhs_text == candidate.base_array_text
+                                : candidate.is_parameter &&
+                                      add_lhs_text ==
+                                          candidate.ptr_var->getNameAsString();
+                        if (lhs_is_base) {
+                            std::string offset = getSourceText(AddBO->getRHS(), SM, LO);
+                            access_list.push_back({PointerAccessKind::ComparisonExpr,
+                                                   BO->getBeginLoc(), DRE, nullptr,
+                                                   op_text, "", "", offset});
+                            return;
+                        }
+                        // Foreign base: fall through to the pointer-
+                        // expression shapes below.
                     }
                 }
             }


### PR DESCRIPTION
Clanker sez:

`p <op> X + n` → `p_index <op> n` now requires X to be the tracked pointer's own base array. For a parameter candidate whose base isn't known yet, X may match the parameter's own name, since validation later makes the parameter itself the base — that keeps the `p < p + n` degenerate form and, more importantly, doesn't disturb parameter slice detection.

A foreign X falls through to the pointer-expression shapes, which now produce:

  - `p == b + n` → `a + p_index_xj == (b + n)` (pointer form, per the previous fix)
  - `p < b + n` → `p_index_xj < (b + n - a)` (value-correct offset arithmetic)