### PR TITLE
Fix pointer return index propagation

### DIFF
--- a/tests/test_pointer_transform.py
+++ b/tests/test_pointer_transform.py
@@ -13,6 +13,15 @@ def test_rewritten_pointer_return_type_is_separated_from_function_name(root, tmp
         "static Item *find_item(int index) {\n"
         "    if (index == 0) return &items[index];\n"
         "    return (void *)0;\n"
+        "}\n"
+        "static int use_item(Item *item) { return item->value; }\n"
+        "static int item_exists(int index) {\n"
+        "    return find_item(index) != (void *)0;\n"
+        "}\n"
+        "static int get_item_value(int index) {\n"
+        "    Item *item = find_item(index);\n"
+        "    if (item) return use_item(item);\n"
+        "    return 0;\n"
         "}\n",
         encoding="utf-8",
     )
@@ -38,3 +47,12 @@ def test_rewritten_pointer_return_type_is_separated_from_function_name(root, tmp
 
     assert transformed.count("static int find_item(int index)") == 2
     assert "intfind_item" not in transformed
+    assert "find_item(index) != -1" in transformed
+    assert "return use_item(&items[item]);" in transformed
+
+    hermetic.run(
+        [clang, "-std=c11", "-x", "c", "-fsyntax-only", "-"],
+        input=result.stdout,
+        check=True,
+        capture_output=True,
+    )

--- a/xj-prepare-pointertransform/FunctionAccessAnalyzer.cpp
+++ b/xj-prepare-pointertransform/FunctionAccessAnalyzer.cpp
@@ -2673,6 +2673,72 @@ void FunctionAccessAnalyzer::fixReturnTypeChanges(ASTContext &Ctx) {
                           << FD->getNameAsString() << "\n";
     }
 
+    // Calls whose return value is consumed directly do not have a receiving
+    // variable for Part D to rewrite.  Fix pointer-null comparisons in place
+    // now that the callee returns -1 for null.
+    class GlobalReturnDirectCallTransformer
+        : public RecursiveASTVisitor<GlobalReturnDirectCallTransformer> {
+    public:
+        Rewriter &Rewrite;
+        SourceManager &SM;
+        const LangOptions &LO;
+
+        GlobalReturnDirectCallTransformer(Rewriter &R, SourceManager &SM,
+                                          const LangOptions &LO)
+            : Rewrite(R), SM(SM), LO(LO) {}
+
+        bool VisitBinaryOperator(BinaryOperator *BO) {
+            if (BO->getOpcode() != BO_EQ && BO->getOpcode() != BO_NE)
+                return true;
+
+            const Expr *LHS = BO->getLHS()->IgnoreParenImpCasts();
+            const Expr *RHS = BO->getRHS()->IgnoreParenImpCasts();
+            const Expr *NullExpr = nullptr;
+            if (isGlobalReturnCall(LHS) && isNullLike(RHS))
+                NullExpr = BO->getRHS();
+            else if (isGlobalReturnCall(RHS) && isNullLike(LHS))
+                NullExpr = BO->getLHS();
+
+            if (!NullExpr)
+                return true;
+
+            SourceLocation Start = NullExpr->getBeginLoc();
+            SourceLocation End = NullExpr->getEndLoc();
+            if (Start.isMacroID() || End.isMacroID()) {
+                auto Expansion = SM.getExpansionRange(NullExpr->getSourceRange());
+                Start = Expansion.getBegin();
+                End = Expansion.getEnd();
+            }
+            End = Lexer::getLocForEndOfToken(End, 0, SM, LO);
+            Rewrite.ReplaceText(Start, SM.getFileOffset(End) - SM.getFileOffset(Start), "-1");
+            return true;
+        }
+
+    private:
+        static bool isGlobalReturnCall(const Expr *E) {
+            const auto *CE = dyn_cast<CallExpr>(E);
+            if (!CE)
+                return false;
+            const FunctionDecl *Callee = CE->getDirectCallee();
+            return Callee &&
+                g_global_return_functions.count(Callee->getCanonicalDecl());
+        }
+
+        static bool isNullLike(const Expr *E) {
+            E = E->IgnoreParenImpCasts();
+            if (const auto *IL = dyn_cast<IntegerLiteral>(E))
+                return IL->getValue() == 0;
+            if (isa<GNUNullExpr>(E))
+                return true;
+            if (const auto *CE = dyn_cast<CStyleCastExpr>(E))
+                return isNullLike(CE->getSubExpr());
+            return false;
+        }
+    };
+
+    GlobalReturnDirectCallTransformer directCallTransformer(TheRewriter, SM, LO);
+    directCallTransformer.TraverseDecl(Ctx.getTranslationUnitDecl());
+
     // Part D: Transform callers of global-return functions
     // Find all calls and their receiving variables
     class GlobalReturnCallFinder : public RecursiveASTVisitor<GlobalReturnCallFinder> {
@@ -2916,6 +2982,23 @@ void FunctionAccessAnalyzer::fixReturnTypeChanges(ASTContext &Ctx) {
                             Rewrite.ReplaceText(Start, len, varName + " != -1");
                             return true;
                         }
+                    }
+                }
+
+                // The variable now stores an index, but an unchanged callee
+                // still expects the pointer produced by the original helper.
+                // Reconstruct that pointer at the argument boundary.
+                if (const auto *CE = dyn_cast<CallExpr>(Parent)) {
+                    for (const Expr *Arg : CE->arguments()) {
+                        if (Arg->IgnoreParenImpCasts() != DRE)
+                            continue;
+                        SourceLocation Start = DRE->getBeginLoc();
+                        SourceLocation End = Lexer::getLocForEndOfToken(
+                            DRE->getEndLoc(), 0, SM, LO);
+                        unsigned len = SM.getFileOffset(End) - SM.getFileOffset(Start);
+                        Rewrite.ReplaceText(Start, len,
+                            "&" + GlobalArray + "[" + varName + "]");
+                        return true;
                     }
                 }
 


### PR DESCRIPTION
Clanker sez:
- Rewrite direct null comparisons to use the -1 index sentinel
- Reconstruct pointers when transformed indices are passed to unchanged pointer parameters