### PR TITLE
Emit pointer/index metadata from xj-prepare-pointertransform

### DIFF
--- a/tests/pointer_transform_cases/get_bits/expected_combined/get_bits.c
+++ b/tests/pointer_transform_cases/get_bits/expected_combined/get_bits.c
@@ -1,0 +1,21 @@
+#include <stdint.h>
+#include <stdio.h>
+
+static uint32_t get_bits(const uint8_t *p, int n) {
+    int p_index_xj = 0;
+    uint32_t next, cache = 0, s = n & 7;
+    int shl = n + s;
+    next = p[p_index_xj++] & (255 >> s);
+    while ((shl -= 8) > 0) {
+        cache |= next << shl;
+        next = p[p_index_xj++];
+    }
+    return cache | (next >> -shl);
+}
+
+int main(void) {
+    uint8_t data[4] = {0xde, 0xad, 0xbe, 0xef};
+    printf("%u\n", get_bits(data, 16));
+    printf("%u\n", get_bits(data, 12));
+    return 0;
+}

--- a/tests/pointer_transform_cases/get_bits/expected_metadata.json
+++ b/tests/pointer_transform_cases/get_bits/expected_metadata.json
@@ -1,0 +1,26 @@
+{
+  "functions": {
+    "get_bits": {
+      "file": "get_bits.c",
+      "pointers": [
+        {
+          "base_text": "p",
+          "compared_against": [],
+          "dereferenced": false,
+          "handle_source": "",
+          "index_var": "p_index_xj",
+          "max_offset": 0,
+          "min_offset": 0,
+          "moved": true,
+          "name": "p",
+          "param_index": 0,
+          "returned_at_offset": false,
+          "variable_offsets": false
+        }
+      ]
+    }
+  },
+  "global_return_functions": {},
+  "globals": [],
+  "version": 1
+}

--- a/tests/pointer_transform_cases/get_bits/input/get_bits.c
+++ b/tests/pointer_transform_cases/get_bits/input/get_bits.c
@@ -1,0 +1,20 @@
+#include <stdint.h>
+#include <stdio.h>
+
+static uint32_t get_bits(const uint8_t *p, int n) {
+    uint32_t next, cache = 0, s = n & 7;
+    int shl = n + s;
+    next = *p++ & (255 >> s);
+    while ((shl -= 8) > 0) {
+        cache |= next << shl;
+        next = *p++;
+    }
+    return cache | (next >> -shl);
+}
+
+int main(void) {
+    uint8_t data[4] = {0xde, 0xad, 0xbe, 0xef};
+    printf("%u\n", get_bits(data, 16));
+    printf("%u\n", get_bits(data, 12));
+    return 0;
+}

--- a/tests/pointer_transform_cases/nonconst_bound/expected_combined/nonconst_bound.c
+++ b/tests/pointer_transform_cases/nonconst_bound/expected_combined/nonconst_bound.c
@@ -1,0 +1,21 @@
+#include <stdio.h>
+
+/* The bound expression `buf + n - 1` is not a recognized slice shape, so
+ * the function keeps its (ptr, len) signature; the iterating pointer is
+ * still rewritten to an index. */
+static int adjacent_pairs(const int *buf, int n) {
+    int p_index_xj = 0;
+    int count = 0;
+    while (p_index_xj < (buf + n - 1 - buf)) {
+        if (buf[p_index_xj] < buf[p_index_xj + 1])
+            count++;
+        p_index_xj++;
+    }
+    return count;
+}
+
+int main(void) {
+    int d[6] = {1, 3, 2, 5, 4, 6};
+    printf("%d\n", adjacent_pairs(d, 6));
+    return 0;
+}

--- a/tests/pointer_transform_cases/nonconst_bound/expected_metadata.json
+++ b/tests/pointer_transform_cases/nonconst_bound/expected_metadata.json
@@ -1,0 +1,26 @@
+{
+  "functions": {
+    "adjacent_pairs": {
+      "file": "nonconst_bound.c",
+      "pointers": [
+        {
+          "base_text": "buf",
+          "compared_against": [],
+          "dereferenced": false,
+          "handle_source": "",
+          "index_var": "p_index_xj",
+          "max_offset": 0,
+          "min_offset": 0,
+          "moved": true,
+          "name": "p",
+          "param_index": -1,
+          "returned_at_offset": false,
+          "variable_offsets": false
+        }
+      ]
+    }
+  },
+  "global_return_functions": {},
+  "globals": [],
+  "version": 1
+}

--- a/tests/pointer_transform_cases/nonconst_bound/input/nonconst_bound.c
+++ b/tests/pointer_transform_cases/nonconst_bound/input/nonconst_bound.c
@@ -1,0 +1,21 @@
+#include <stdio.h>
+
+/* The bound expression `buf + n - 1` is not a recognized slice shape, so
+ * the function keeps its (ptr, len) signature; the iterating pointer is
+ * still rewritten to an index. */
+static int adjacent_pairs(const int *buf, int n) {
+    const int *p = buf;
+    int count = 0;
+    while (p < buf + n - 1) {
+        if (p[0] < p[1])
+            count++;
+        p++;
+    }
+    return count;
+}
+
+int main(void) {
+    int d[6] = {1, 3, 2, 5, 4, 6};
+    printf("%d\n", adjacent_pairs(d, 6));
+    return 0;
+}

--- a/tests/pointer_transform_cases/strchr_wrapper/expected_combined/strchr_wrapper.c
+++ b/tests/pointer_transform_cases/strchr_wrapper/expected_combined/strchr_wrapper.c
@@ -1,0 +1,27 @@
+#include <stdio.h>
+#include <string.h>
+
+static int strchr_index_xj(const char *base, int start, int c) {
+    const char *result = strchr(base + start, c);
+    if (!result) return -1;
+    return (int)(result - base);
+}
+
+static int count_commas(const char *s) {
+    int p_index_xj = 0;
+    int count = 0;
+    while (1) {
+        p_index_xj = strchr_index_xj(s, p_index_xj, ',');
+        if (p_index_xj == -1)
+            break;
+        count++;
+        p_index_xj++;
+    }
+    return count;
+}
+
+int main(void) {
+    printf("%d\n", count_commas("a,b,c,d"));
+    printf("%d\n", count_commas("nothing here"));
+    return 0;
+}

--- a/tests/pointer_transform_cases/strchr_wrapper/expected_metadata.json
+++ b/tests/pointer_transform_cases/strchr_wrapper/expected_metadata.json
@@ -1,0 +1,26 @@
+{
+  "functions": {
+    "count_commas": {
+      "file": "strchr_wrapper.c",
+      "pointers": [
+        {
+          "base_text": "s",
+          "compared_against": [],
+          "dereferenced": false,
+          "handle_source": "",
+          "index_var": "p_index_xj",
+          "max_offset": 0,
+          "min_offset": 0,
+          "moved": true,
+          "name": "p",
+          "param_index": -1,
+          "returned_at_offset": false,
+          "variable_offsets": false
+        }
+      ]
+    }
+  },
+  "global_return_functions": {},
+  "globals": [],
+  "version": 1
+}

--- a/tests/pointer_transform_cases/strchr_wrapper/input/strchr_wrapper.c
+++ b/tests/pointer_transform_cases/strchr_wrapper/input/strchr_wrapper.c
@@ -1,0 +1,21 @@
+#include <stdio.h>
+#include <string.h>
+
+static int count_commas(const char *s) {
+    const char *p = s;
+    int count = 0;
+    while (1) {
+        p = strchr(p, ',');
+        if (!p)
+            break;
+        count++;
+        p++;
+    }
+    return count;
+}
+
+int main(void) {
+    printf("%d\n", count_commas("a,b,c,d"));
+    printf("%d\n", count_commas("nothing here"));
+    return 0;
+}

--- a/tests/ptr_slice_fixture_harness.py
+++ b/tests/ptr_slice_fixture_harness.py
@@ -1,0 +1,150 @@
+"""Shared driver for the pointer-transform fixture tests.
+
+Each fixture directory looks like:
+
+    <case>/
+      input/                  # source files (.c / .h)
+      expected_combined/      # golden: after xj-prepare-pointertransform
+      expected_metadata.json  # golden: the --metadata-out side-file
+
+The driver runs the tool over a scratch copy of input/ and checks:
+
+  1. the output and metadata match the stored goldens (mismatches
+     auto-rewrite the golden and fail, mirroring the repo's snapshot-test
+     convention: inspect with git diff and keep or revert);
+  2. the output still parses (clang -fsyntax-only);
+  3. the program still compiles and behaves identically (stdout + exit
+     code) to the untransformed input.
+
+The golden output directory is named expected_combined (rather than
+expected_output) because the tool currently performs both the
+pointer-to-index rewriting and the RustSlice signature reshaping; the
+planned split into two chained tools will add intermediate goldens
+alongside while these final-output goldens stay byte-stable.
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import hermetic
+
+EXTRA_ARGS = [
+    "--extra-arg=-Wno-zero-length-array",
+    "--extra-arg=-Wno-implicit-int-conversion",
+    "--extra-arg=-Wno-unused-function",
+]
+
+
+def _clang(root: Path) -> Path:
+    return root / "_local" / "xj-llvm" / "bin" / "clang"
+
+
+def _write_compdb(root: Path, workdir: Path, sources: list[Path]) -> None:
+    entries = [
+        {
+            "directory": workdir.as_posix(),
+            "file": src.as_posix(),
+            "arguments": [_clang(root).as_posix(), "-std=c11", "-c", src.as_posix()],
+        }
+        for src in sources
+    ]
+    (workdir / "compile_commands.json").write_text(json.dumps(entries, indent=2), encoding="utf-8")
+
+
+def _compile_and_run(root: Path, workdir: Path, sources: list[Path], exe_name: str):
+    exe = workdir / exe_name
+    hermetic.run(
+        [_clang(root), "-std=c11", "-o", exe, *sources],
+        check=True,
+        capture_output=True,
+    )
+    r = subprocess.run([exe.as_posix()], capture_output=True, text=True, timeout=60, check=False)
+    return r.returncode, r.stdout
+
+
+def _run_tool(root: Path, tool: Path, workdir: Path, sources: list[Path], extra: list[str]):
+    resource_dir = (
+        hermetic.run(["clang", "-print-resource-dir"], capture_output=True, check=True)
+        .stdout.decode()
+        .strip()
+    )
+    hermetic.run(
+        [
+            tool,
+            "--inplace",
+            "-p",
+            workdir,
+            *EXTRA_ARGS,
+            f"--extra-arg=-resource-dir={resource_dir}",
+            *extra,
+            *sources,
+        ],
+        check=True,
+        capture_output=True,
+        cwd=workdir,
+    )
+
+
+def _check_syntax(root: Path, sources: list[Path]) -> None:
+    for src in sources:
+        hermetic.run(
+            [_clang(root), "-std=c11", "-fsyntax-only", src],
+            check=True,
+            capture_output=True,
+        )
+
+
+def _compare_with_golden(case_dir: Path, golden_subdir: str, workdir: Path, filenames: list[str]):
+    """Diff workdir outputs against the stored golden tree; on mismatch,
+    rewrite the golden and fail (accept the new golden via git diff)."""
+    golden_dir = case_dir / golden_subdir
+    golden_dir.mkdir(exist_ok=True)
+    stale = []
+    for name in filenames:
+        got = (workdir / name).read_text(encoding="utf-8")
+        golden_file = golden_dir / name
+        want = golden_file.read_text(encoding="utf-8") if golden_file.exists() else None
+        if got != want:
+            golden_file.write_text(got, encoding="utf-8")
+            stale.append(name)
+    assert not stale, (
+        f"{case_dir.name}: output changed for {stale} — golden files under "
+        f"{golden_dir} were updated; inspect with git diff and keep or revert"
+    )
+
+
+def _compare_metadata_golden(case_dir: Path, golden_name: str, got_path: Path) -> None:
+    got = got_path.read_text(encoding="utf-8")
+    golden = case_dir / golden_name
+    if not golden.exists() or golden.read_text(encoding="utf-8") != got:
+        golden.write_text(got, encoding="utf-8")
+        raise AssertionError(
+            f"{case_dir.name}: metadata changed — {golden} updated; "
+            "inspect with git diff and keep or revert"
+        )
+
+
+def run_case(root: Path, tmp_path: Path, case_dir: Path) -> None:
+    ptr_tool = root / "_local" / "_build_pointertransform" / "xj-prepare-pointertransform"
+
+    input_files = sorted(p.name for p in (case_dir / "input").iterdir())
+    workdir = tmp_path / "codebase"
+    workdir.mkdir()
+    for name in input_files:
+        shutil.copy(case_dir / "input" / name, workdir / name)
+    sources = [workdir / n for n in input_files if n.endswith(".c")]
+    _write_compdb(root, workdir, sources)
+
+    baseline = _compile_and_run(root, workdir, sources, "orig")
+
+    metadata_path = workdir / "metadata.json"
+    _run_tool(root, ptr_tool, workdir, sources, [f"--metadata-out={metadata_path}"])
+
+    _check_syntax(root, sources)
+    _compare_with_golden(case_dir, "expected_combined", workdir, input_files)
+    _compare_metadata_golden(case_dir, "expected_metadata.json", metadata_path)
+
+    final = _compile_and_run(root, workdir, sources, "final")
+    assert final == baseline, f"final output behaves differently: {final} vs {baseline}"

--- a/tests/slice_transform_cases/callgraph_propagation/expected_combined/callgraph_propagation.c
+++ b/tests/slice_transform_cases/callgraph_propagation/expected_combined/callgraph_propagation.c
@@ -1,0 +1,23 @@
+#include <stdio.h>
+
+typedef struct { int *ptr; size_t len; } RustSlice_int;
+
+static int sum_range(RustSlice_int arr) {
+    int total = 0;
+    int p_index_xj = 0;
+    while (p_index_xj < arr.len) {
+        total += arr.ptr[p_index_xj];
+        p_index_xj++;
+    }
+    return total;
+}
+
+static int sum_all(RustSlice_int arr) {
+    return sum_range(arr);
+}
+
+int main(void) {
+    int d[5] = {1, 2, 3, 4, 5};
+    printf("%d\n", sum_all((RustSlice_int){d, 5}));
+    return 0;
+}

--- a/tests/slice_transform_cases/callgraph_propagation/expected_metadata.json
+++ b/tests/slice_transform_cases/callgraph_propagation/expected_metadata.json
@@ -1,0 +1,26 @@
+{
+  "functions": {
+    "sum_range": {
+      "file": "callgraph_propagation.c",
+      "pointers": [
+        {
+          "base_text": "lo",
+          "compared_against": [],
+          "dereferenced": false,
+          "handle_source": "",
+          "index_var": "p_index_xj",
+          "max_offset": 0,
+          "min_offset": 0,
+          "moved": true,
+          "name": "p",
+          "param_index": -1,
+          "returned_at_offset": false,
+          "variable_offsets": false
+        }
+      ]
+    }
+  },
+  "global_return_functions": {},
+  "globals": [],
+  "version": 1
+}

--- a/tests/slice_transform_cases/callgraph_propagation/input/callgraph_propagation.c
+++ b/tests/slice_transform_cases/callgraph_propagation/input/callgraph_propagation.c
@@ -1,0 +1,21 @@
+#include <stdio.h>
+
+static int sum_range(int *lo, int *hi) {
+    int total = 0;
+    int *p = lo;
+    while (p < hi) {
+        total += *p;
+        p++;
+    }
+    return total;
+}
+
+static int sum_all(int *lo, int *hi) {
+    return sum_range(lo, hi);
+}
+
+int main(void) {
+    int d[5] = {1, 2, 3, 4, 5};
+    printf("%d\n", sum_all(d, d + 5));
+    return 0;
+}

--- a/tests/slice_transform_cases/global_return/expected_combined/global_return.c
+++ b/tests/slice_transform_cases/global_return/expected_combined/global_return.c
@@ -1,0 +1,36 @@
+#include <stdio.h>
+
+typedef struct {
+    int value;
+} Item;
+
+static Item items[2] = {{41}, {42}};
+
+static int find_item(int index);
+
+static int find_item(int index) {
+    if (index >= 0 && index < 2)
+        return index;
+    return -1;
+}
+
+static int use_item(Item *item) {
+    return item->value;
+}
+
+static int item_exists(int index) {
+    return find_item(index) != -1;
+}
+
+static int get_item_value(int index) {
+    int item = find_item(index);
+    if (item != -1)
+        return use_item(&items[item]);
+    return 0;
+}
+
+int main(void) {
+    printf("%d %d %d %d\n", get_item_value(0), get_item_value(1), get_item_value(5),
+           item_exists(1));
+    return 0;
+}

--- a/tests/slice_transform_cases/global_return/expected_metadata.json
+++ b/tests/slice_transform_cases/global_return/expected_metadata.json
@@ -1,0 +1,6 @@
+{
+  "functions": {},
+  "global_return_functions": {},
+  "globals": [],
+  "version": 1
+}

--- a/tests/slice_transform_cases/global_return/input/global_return.c
+++ b/tests/slice_transform_cases/global_return/input/global_return.c
@@ -1,0 +1,36 @@
+#include <stdio.h>
+
+typedef struct {
+    int value;
+} Item;
+
+static Item items[2] = {{41}, {42}};
+
+static Item *find_item(int index);
+
+static Item *find_item(int index) {
+    if (index >= 0 && index < 2)
+        return &items[index];
+    return (void *)0;
+}
+
+static int use_item(Item *item) {
+    return item->value;
+}
+
+static int item_exists(int index) {
+    return find_item(index) != (void *)0;
+}
+
+static int get_item_value(int index) {
+    Item *item = find_item(index);
+    if (item)
+        return use_item(item);
+    return 0;
+}
+
+int main(void) {
+    printf("%d %d %d %d\n", get_item_value(0), get_item_value(1), get_item_value(5),
+           item_exists(1));
+    return 0;
+}

--- a/tests/slice_transform_cases/header_fwd_decl/expected_combined/header_fwd_decl.c
+++ b/tests/slice_transform_cases/header_fwd_decl/expected_combined/header_fwd_decl.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+
+#include "lib.h"
+
+int sum(RustSlice_int arr) {
+    int p_index_xj = 0;
+    int s = 0;
+    while (p_index_xj < arr.len) {
+        s += arr.ptr[p_index_xj++];
+    }
+    return s;
+}
+
+int main(void) {
+    int d[5] = {2, 4, 6, 8, 10};
+    printf("%d\n", sum((RustSlice_int){d, 5}));
+    return 0;
+}

--- a/tests/slice_transform_cases/header_fwd_decl/expected_combined/lib.h
+++ b/tests/slice_transform_cases/header_fwd_decl/expected_combined/lib.h
@@ -1,0 +1,8 @@
+#ifndef LIB_H
+#define LIB_H
+
+typedef struct { int *ptr; size_t len; } RustSlice_int;
+
+int sum(RustSlice_int arr);
+
+#endif

--- a/tests/slice_transform_cases/header_fwd_decl/expected_metadata.json
+++ b/tests/slice_transform_cases/header_fwd_decl/expected_metadata.json
@@ -1,0 +1,26 @@
+{
+  "functions": {
+    "sum": {
+      "file": "header_fwd_decl.c",
+      "pointers": [
+        {
+          "base_text": "buf",
+          "compared_against": [],
+          "dereferenced": false,
+          "handle_source": "",
+          "index_var": "p_index_xj",
+          "max_offset": 0,
+          "min_offset": 0,
+          "moved": true,
+          "name": "p",
+          "param_index": -1,
+          "returned_at_offset": false,
+          "variable_offsets": false
+        }
+      ]
+    }
+  },
+  "global_return_functions": {},
+  "globals": [],
+  "version": 1
+}

--- a/tests/slice_transform_cases/header_fwd_decl/input/header_fwd_decl.c
+++ b/tests/slice_transform_cases/header_fwd_decl/input/header_fwd_decl.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+
+#include "lib.h"
+
+int sum(int *buf, int n) {
+    int *p = buf;
+    int s = 0;
+    while (p < buf + n) {
+        s += *p++;
+    }
+    return s;
+}
+
+int main(void) {
+    int d[5] = {2, 4, 6, 8, 10};
+    printf("%d\n", sum(d, 5));
+    return 0;
+}

--- a/tests/slice_transform_cases/header_fwd_decl/input/lib.h
+++ b/tests/slice_transform_cases/header_fwd_decl/input/lib.h
@@ -1,0 +1,6 @@
+#ifndef LIB_H
+#define LIB_H
+
+int sum(int *buf, int n);
+
+#endif

--- a/tests/slice_transform_cases/lo_hi_quicksort/expected_combined/lo_hi_quicksort.c
+++ b/tests/slice_transform_cases/lo_hi_quicksort/expected_combined/lo_hi_quicksort.c
@@ -1,0 +1,39 @@
+#include <stdio.h>
+
+typedef struct { int *ptr; size_t len; } RustSlice_int;
+
+int partition(RustSlice_int arr) {
+    int pivot = arr.ptr[(arr.len - 1)];
+    int i_index_xj = 0;
+    int j_index_xj = 0;
+    while (j_index_xj < arr.len - 1) {
+        if (arr.ptr[j_index_xj] < pivot) {
+            int t = arr.ptr[i_index_xj];
+            arr.ptr[i_index_xj] = arr.ptr[j_index_xj];
+            arr.ptr[j_index_xj] = t;
+            i_index_xj++;
+        }
+        j_index_xj++;
+    }
+    int t = arr.ptr[i_index_xj];
+    arr.ptr[i_index_xj] = arr.ptr[(arr.len - 1)];
+    arr.ptr[(arr.len - 1)] = t;
+    return i_index_xj;
+}
+
+static void quick_sort(RustSlice_int arr) {
+    if (arr.len > 1) {
+        int p = partition(arr);
+        quick_sort((RustSlice_int){arr.ptr, p});
+        quick_sort((RustSlice_int){arr.ptr + p + 1, arr.len - (p + 1)});
+    }
+}
+
+int main(void) {
+    int d[7] = {3, 7, 1, 6, 2, 5, 4};
+    quick_sort((RustSlice_int){d, 6 + 1});
+    for (int i = 0; i < 7; i++)
+        printf("%d ", d[i]);
+    printf("\n");
+    return 0;
+}

--- a/tests/slice_transform_cases/lo_hi_quicksort/expected_metadata.json
+++ b/tests/slice_transform_cases/lo_hi_quicksort/expected_metadata.json
@@ -1,0 +1,40 @@
+{
+  "functions": {
+    "partition": {
+      "file": "lo_hi_quicksort.c",
+      "pointers": [
+        {
+          "base_text": "lo",
+          "compared_against": [],
+          "dereferenced": false,
+          "handle_source": "",
+          "index_var": "i_index_xj",
+          "max_offset": 0,
+          "min_offset": 0,
+          "moved": true,
+          "name": "i",
+          "param_index": -1,
+          "returned_at_offset": false,
+          "variable_offsets": false
+        },
+        {
+          "base_text": "lo",
+          "compared_against": [],
+          "dereferenced": false,
+          "handle_source": "",
+          "index_var": "j_index_xj",
+          "max_offset": 0,
+          "min_offset": 0,
+          "moved": true,
+          "name": "j",
+          "param_index": -1,
+          "returned_at_offset": false,
+          "variable_offsets": false
+        }
+      ]
+    }
+  },
+  "global_return_functions": {},
+  "globals": [],
+  "version": 1
+}

--- a/tests/slice_transform_cases/lo_hi_quicksort/input/lo_hi_quicksort.c
+++ b/tests/slice_transform_cases/lo_hi_quicksort/input/lo_hi_quicksort.c
@@ -1,0 +1,37 @@
+#include <stdio.h>
+
+static int *partition(int *lo, int *hi) {
+    int pivot = *hi;
+    int *i = lo;
+    int *j = lo;
+    while (j < hi) {
+        if (*j < pivot) {
+            int t = *i;
+            *i = *j;
+            *j = t;
+            i++;
+        }
+        j++;
+    }
+    int t = *i;
+    *i = *hi;
+    *hi = t;
+    return i;
+}
+
+static void quick_sort(int *lo, int *hi) {
+    if (lo < hi) {
+        int *p = partition(lo, hi);
+        quick_sort(lo, p - 1);
+        quick_sort(p + 1, hi);
+    }
+}
+
+int main(void) {
+    int d[7] = {3, 7, 1, 6, 2, 5, 4};
+    quick_sort(d, d + 6);
+    for (int i = 0; i < 7; i++)
+        printf("%d ", d[i]);
+    printf("\n");
+    return 0;
+}

--- a/tests/slice_transform_cases/lookaround/expected_combined/lookaround.c
+++ b/tests/slice_transform_cases/lookaround/expected_combined/lookaround.c
@@ -1,0 +1,25 @@
+#include <stdio.h>
+
+/* Exercises lookback (via *(p - 1)) and lookahead (via *(p + 1)): the
+ * constructed slice at the call site must be widened on both sides. */
+typedef struct { int *ptr; size_t len; } RustSlice_int;
+
+static int lookaround(RustSlice_int arr) {
+    int p_index_xj = 1 + 1;
+    int i = 1;
+    int total = 0;
+    while (p_index_xj < arr.len - 1) {
+        total += arr.ptr[p_index_xj - 1];
+        if (i + 1 < (arr.len - 2))
+            total += arr.ptr[p_index_xj + 1];
+        i++;
+        p_index_xj++;
+    }
+    return total;
+}
+
+int main(void) {
+    int d[5] = {1, 2, 3, 4, 5};
+    printf("%d\n", lookaround((RustSlice_int){d - 1, 5 + 1 + 1}));
+    return 0;
+}

--- a/tests/slice_transform_cases/lookaround/expected_metadata.json
+++ b/tests/slice_transform_cases/lookaround/expected_metadata.json
@@ -1,0 +1,26 @@
+{
+  "functions": {
+    "lookaround": {
+      "file": "lookaround.c",
+      "pointers": [
+        {
+          "base_text": "buf",
+          "compared_against": [],
+          "dereferenced": false,
+          "handle_source": "",
+          "index_var": "p_index_xj",
+          "max_offset": 1,
+          "min_offset": -1,
+          "moved": true,
+          "name": "p",
+          "param_index": -1,
+          "returned_at_offset": false,
+          "variable_offsets": false
+        }
+      ]
+    }
+  },
+  "global_return_functions": {},
+  "globals": [],
+  "version": 1
+}

--- a/tests/slice_transform_cases/lookaround/input/lookaround.c
+++ b/tests/slice_transform_cases/lookaround/input/lookaround.c
@@ -1,0 +1,23 @@
+#include <stdio.h>
+
+/* Exercises lookback (via *(p - 1)) and lookahead (via *(p + 1)): the
+ * constructed slice at the call site must be widened on both sides. */
+static int lookaround(const int *buf, int n) {
+    const int *p = buf + 1;
+    int i = 1;
+    int total = 0;
+    while (p < buf + n) {
+        total += *(p - 1);
+        if (i + 1 < n)
+            total += *(p + 1);
+        i++;
+        p++;
+    }
+    return total;
+}
+
+int main(void) {
+    int d[5] = {1, 2, 3, 4, 5};
+    printf("%d\n", lookaround(d, 5));
+    return 0;
+}

--- a/tests/slice_transform_cases/ptr_len_root/expected_combined/ptr_len_root.c
+++ b/tests/slice_transform_cases/ptr_len_root/expected_combined/ptr_len_root.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+
+typedef struct { int *ptr; size_t len; } RustSlice_int;
+
+static int sum(RustSlice_int arr) {
+    int p_index_xj = 0;
+    int s = 0;
+    while (p_index_xj < arr.len) {
+        s += arr.ptr[p_index_xj++];
+    }
+    return s;
+}
+
+int main(void) {
+    int data[5] = {1, 2, 3, 4, 5};
+    printf("%d\n", sum((RustSlice_int){data, 5}));
+    return 0;
+}

--- a/tests/slice_transform_cases/ptr_len_root/expected_metadata.json
+++ b/tests/slice_transform_cases/ptr_len_root/expected_metadata.json
@@ -1,0 +1,26 @@
+{
+  "functions": {
+    "sum": {
+      "file": "ptr_len_root.c",
+      "pointers": [
+        {
+          "base_text": "buf",
+          "compared_against": [],
+          "dereferenced": false,
+          "handle_source": "",
+          "index_var": "p_index_xj",
+          "max_offset": 0,
+          "min_offset": 0,
+          "moved": true,
+          "name": "p",
+          "param_index": -1,
+          "returned_at_offset": false,
+          "variable_offsets": false
+        }
+      ]
+    }
+  },
+  "global_return_functions": {},
+  "globals": [],
+  "version": 1
+}

--- a/tests/slice_transform_cases/ptr_len_root/input/ptr_len_root.c
+++ b/tests/slice_transform_cases/ptr_len_root/input/ptr_len_root.c
@@ -1,0 +1,16 @@
+#include <stdio.h>
+
+static int sum(int *buf, int n) {
+    int *p = buf;
+    int s = 0;
+    while (p < buf + n) {
+        s += *p++;
+    }
+    return s;
+}
+
+int main(void) {
+    int data[5] = {1, 2, 3, 4, 5};
+    printf("%d\n", sum(data, 5));
+    return 0;
+}

--- a/tests/slice_transform_cases/return_index/expected_combined/return_index.c
+++ b/tests/slice_transform_cases/return_index/expected_combined/return_index.c
@@ -1,0 +1,25 @@
+#include <stddef.h>
+#include <stdio.h>
+
+typedef struct { int *ptr; size_t len; } RustSlice_int;
+
+int find(RustSlice_int arr, int target) {
+    int p_index_xj = 0;
+    while (p_index_xj < arr.len) {
+        if (arr.ptr[p_index_xj] == target)
+            return p_index_xj;
+        p_index_xj++;
+    }
+    return -1;
+}
+
+int main(void) {
+    int d[5] = {10, 20, 30, 40, 50};
+    int q = find((RustSlice_int){d, 5}, 30);
+    if (q != -1)
+        printf("found %d\n", d[q]);
+    int r = find((RustSlice_int){d, 5}, 99);
+    if (r == -1)
+        printf("missing\n");
+    return 0;
+}

--- a/tests/slice_transform_cases/return_index/expected_metadata.json
+++ b/tests/slice_transform_cases/return_index/expected_metadata.json
@@ -1,0 +1,26 @@
+{
+  "functions": {
+    "find": {
+      "file": "return_index.c",
+      "pointers": [
+        {
+          "base_text": "buf",
+          "compared_against": [],
+          "dereferenced": false,
+          "handle_source": "",
+          "index_var": "p_index_xj",
+          "max_offset": 0,
+          "min_offset": 0,
+          "moved": true,
+          "name": "p",
+          "param_index": -1,
+          "returned_at_offset": false,
+          "variable_offsets": false
+        }
+      ]
+    }
+  },
+  "global_return_functions": {},
+  "globals": [],
+  "version": 1
+}

--- a/tests/slice_transform_cases/return_index/input/return_index.c
+++ b/tests/slice_transform_cases/return_index/input/return_index.c
@@ -1,0 +1,23 @@
+#include <stddef.h>
+#include <stdio.h>
+
+static int *find(int *buf, int n, int target) {
+    int *p = buf;
+    while (p < buf + n) {
+        if (*p == target)
+            return p;
+        p++;
+    }
+    return NULL;
+}
+
+int main(void) {
+    int d[5] = {10, 20, 30, 40, 50};
+    int *q = find(d, 5, 30);
+    if (q)
+        printf("found %d\n", *q);
+    int *r = find(d, 5, 99);
+    if (!r)
+        printf("missing\n");
+    return 0;
+}

--- a/tests/slice_transform_cases/singleton_swap/expected_combined/singleton_swap.c
+++ b/tests/slice_transform_cases/singleton_swap/expected_combined/singleton_swap.c
@@ -1,0 +1,37 @@
+#include <stdio.h>
+
+typedef struct { int *ptr; size_t len; } RustSlice_int;
+
+static void swap(RustSlice_int arr, int a, int b) {
+    int t = arr.ptr[a];
+    arr.ptr[a] = arr.ptr[b];
+    arr.ptr[b] = t;
+}
+
+static void sort(RustSlice_int arr) {
+    int done = 0;
+    while (!done) {
+        done = 1;
+        int i = 0;
+        int p_index_xj = 0;
+        while (p_index_xj < arr.len) {
+            if (i > 0) {
+                if (arr.ptr[p_index_xj + -1] > arr.ptr[p_index_xj]) {
+                    swap(arr, p_index_xj - 1, p_index_xj);
+                    done = 0;
+                }
+            }
+            i++;
+            p_index_xj++;
+        }
+    }
+}
+
+int main(void) {
+    int d[6] = {3, 1, 4, 1, 5, 9};
+    sort((RustSlice_int){d, 6});
+    for (int i = 0; i < 6; i++)
+        printf("%d ", d[i]);
+    printf("\n");
+    return 0;
+}

--- a/tests/slice_transform_cases/singleton_swap/expected_metadata.json
+++ b/tests/slice_transform_cases/singleton_swap/expected_metadata.json
@@ -1,0 +1,26 @@
+{
+  "functions": {
+    "sort": {
+      "file": "singleton_swap.c",
+      "pointers": [
+        {
+          "base_text": "buf",
+          "compared_against": [],
+          "dereferenced": false,
+          "handle_source": "",
+          "index_var": "p_index_xj",
+          "max_offset": 0,
+          "min_offset": 0,
+          "moved": true,
+          "name": "p",
+          "param_index": -1,
+          "returned_at_offset": false,
+          "variable_offsets": false
+        }
+      ]
+    }
+  },
+  "global_return_functions": {},
+  "globals": [],
+  "version": 1
+}

--- a/tests/slice_transform_cases/singleton_swap/input/singleton_swap.c
+++ b/tests/slice_transform_cases/singleton_swap/input/singleton_swap.c
@@ -1,0 +1,35 @@
+#include <stdio.h>
+
+static void swap(int *a, int *b) {
+    int t = *a;
+    *a = *b;
+    *b = t;
+}
+
+static void sort(int *buf, int n) {
+    int done = 0;
+    while (!done) {
+        done = 1;
+        int i = 0;
+        int *p = buf;
+        while (p < buf + n) {
+            if (i > 0) {
+                if (p[-1] > p[0]) {
+                    swap(p - 1, p);
+                    done = 0;
+                }
+            }
+            i++;
+            p++;
+        }
+    }
+}
+
+int main(void) {
+    int d[6] = {3, 1, 4, 1, 5, 9};
+    sort(d, 6);
+    for (int i = 0; i < 6; i++)
+        printf("%d ", d[i]);
+    printf("\n");
+    return 0;
+}

--- a/tests/slice_transform_cases/typedef_dedup/expected_combined/typedef_dedup.c
+++ b/tests/slice_transform_cases/typedef_dedup/expected_combined/typedef_dedup.c
@@ -1,0 +1,45 @@
+#include <stdio.h>
+
+/* Two int-slice functions must share one RustSlice_int typedef; the char
+ * function gets its own RustSlice_char typedef. */
+typedef struct { int *ptr; size_t len; } RustSlice_int;
+
+static int sum_ints(RustSlice_int arr) {
+    int p_index_xj = 0;
+    int s = 0;
+    while (p_index_xj < arr.len) {
+        s += arr.ptr[p_index_xj++];
+    }
+    return s;
+}
+
+static int max_int(RustSlice_int arr) {
+    int p_index_xj = 0;
+    int best = -1000000;
+    while (p_index_xj < arr.len) {
+        if (arr.ptr[p_index_xj] > best)
+            best = arr.ptr[p_index_xj];
+        p_index_xj++;
+    }
+    return best;
+}
+
+typedef struct { char *ptr; size_t len; } RustSlice_char;
+
+static int count_upper(RustSlice_char arr) {
+    int p_index_xj = 0;
+    int count = 0;
+    while (p_index_xj < arr.len) {
+        if (arr.ptr[p_index_xj] >= 'A' && arr.ptr[p_index_xj] <= 'Z')
+            count++;
+        p_index_xj++;
+    }
+    return count;
+}
+
+int main(void) {
+    int d[4] = {4, 8, 15, 16};
+    char s[5] = {'a', 'B', 'c', 'D', 'e'};
+    printf("%d %d %d\n", sum_ints((RustSlice_int){d, 4}), max_int((RustSlice_int){d, 4}), count_upper((RustSlice_char){s, 5}));
+    return 0;
+}

--- a/tests/slice_transform_cases/typedef_dedup/expected_metadata.json
+++ b/tests/slice_transform_cases/typedef_dedup/expected_metadata.json
@@ -1,0 +1,64 @@
+{
+  "functions": {
+    "count_upper": {
+      "file": "typedef_dedup.c",
+      "pointers": [
+        {
+          "base_text": "buf",
+          "compared_against": [],
+          "dereferenced": false,
+          "handle_source": "",
+          "index_var": "p_index_xj",
+          "max_offset": 0,
+          "min_offset": 0,
+          "moved": true,
+          "name": "p",
+          "param_index": -1,
+          "returned_at_offset": false,
+          "variable_offsets": false
+        }
+      ]
+    },
+    "max_int": {
+      "file": "typedef_dedup.c",
+      "pointers": [
+        {
+          "base_text": "buf",
+          "compared_against": [],
+          "dereferenced": false,
+          "handle_source": "",
+          "index_var": "p_index_xj",
+          "max_offset": 0,
+          "min_offset": 0,
+          "moved": true,
+          "name": "p",
+          "param_index": -1,
+          "returned_at_offset": false,
+          "variable_offsets": false
+        }
+      ]
+    },
+    "sum_ints": {
+      "file": "typedef_dedup.c",
+      "pointers": [
+        {
+          "base_text": "buf",
+          "compared_against": [],
+          "dereferenced": false,
+          "handle_source": "",
+          "index_var": "p_index_xj",
+          "max_offset": 0,
+          "min_offset": 0,
+          "moved": true,
+          "name": "p",
+          "param_index": -1,
+          "returned_at_offset": false,
+          "variable_offsets": false
+        }
+      ]
+    }
+  },
+  "global_return_functions": {},
+  "globals": [],
+  "version": 1
+}

--- a/tests/slice_transform_cases/typedef_dedup/input/typedef_dedup.c
+++ b/tests/slice_transform_cases/typedef_dedup/input/typedef_dedup.c
@@ -1,0 +1,41 @@
+#include <stdio.h>
+
+/* Two int-slice functions must share one RustSlice_int typedef; the char
+ * function gets its own RustSlice_char typedef. */
+static int sum_ints(int *buf, int n) {
+    int *p = buf;
+    int s = 0;
+    while (p < buf + n) {
+        s += *p++;
+    }
+    return s;
+}
+
+static int max_int(int *buf, int n) {
+    int *p = buf;
+    int best = -1000000;
+    while (p < buf + n) {
+        if (*p > best)
+            best = *p;
+        p++;
+    }
+    return best;
+}
+
+static int count_upper(char *buf, int n) {
+    char *p = buf;
+    int count = 0;
+    while (p < buf + n) {
+        if (*p >= 'A' && *p <= 'Z')
+            count++;
+        p++;
+    }
+    return count;
+}
+
+int main(void) {
+    int d[4] = {4, 8, 15, 16};
+    char s[5] = {'a', 'B', 'c', 'D', 'e'};
+    printf("%d %d %d\n", sum_ints(d, 4), max_int(d, 4), count_upper(s, 5));
+    return 0;
+}

--- a/tests/snapshotted/assorted_guidance/_xj_snapshot/00_out/Cargo.lock
+++ b/tests/snapshotted/assorted_guidance/_xj_snapshot/00_out/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "bytemuck"
-version = "1.25.1"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 dependencies = [
  "bytemuck_derive",
 ]

--- a/tests/snapshotted/assorted_guidance/_xj_snapshot/final/Cargo.lock
+++ b/tests/snapshotted/assorted_guidance/_xj_snapshot/final/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "bytemuck"
-version = "1.25.1"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 dependencies = [
  "bytemuck_derive",
 ]

--- a/tests/snapshotted/errno_localization/time/_xj_snapshot/final/Cargo.lock
+++ b/tests/snapshotted/errno_localization/time/_xj_snapshot/final/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "main"

--- a/tests/test_pointer_transform.py
+++ b/tests/test_pointer_transform.py
@@ -1,6 +1,18 @@
 import json
+from pathlib import Path
+
+import pytest
 
 import hermetic
+from ptr_slice_fixture_harness import run_case
+
+_CASES_DIR = Path(__file__).parent / "pointer_transform_cases"
+_CASES = sorted(p.name for p in _CASES_DIR.iterdir() if p.is_dir())
+
+
+@pytest.mark.parametrize("case", _CASES)
+def test_pointer_transform_case(root, test_tmp_dir, case):
+    run_case(root, test_tmp_dir, _CASES_DIR / case)
 
 
 def test_rewritten_pointer_return_type_is_separated_from_function_name(root, tmp_codebase):

--- a/tests/test_slice_transform.py
+++ b/tests/test_slice_transform.py
@@ -1,0 +1,19 @@
+"""Golden fixture tests for xj-prepare-pointertransform over cases that
+exercise the RustSlice signature reshaping specifically (root (ptr,len)
+and (lo,hi) functions, singleton callees, call-graph propagation,
+T*->int return collapsing, typedef/forward-decl handling). Cases that
+only exercise the index rewriting live in test_pointer_transform.py."""
+
+from pathlib import Path
+
+import pytest
+
+from ptr_slice_fixture_harness import run_case
+
+_CASES_DIR = Path(__file__).parent / "slice_transform_cases"
+_CASES = sorted(p.name for p in _CASES_DIR.iterdir() if p.is_dir())
+
+
+@pytest.mark.parametrize("case", _CASES)
+def test_slice_transform_case(root, test_tmp_dir, case):
+    run_case(root, test_tmp_dir, _CASES_DIR / case)

--- a/xj-prepare-pointertransform/CMakeLists.txt
+++ b/xj-prepare-pointertransform/CMakeLists.txt
@@ -2,8 +2,9 @@ cmake_minimum_required(VERSION 3.17)
 project(xj-prepare-pointertransform)
 
 set(XJ_LLVM_ROOT "${CMAKE_CURRENT_LIST_DIR}/../_local/xj-llvm")
+set(XJ_SUPPORT_DIR "${CMAKE_CURRENT_LIST_DIR}/../xj-prepare-support")
 
-include_directories("${XJ_LLVM_ROOT}/include")
+include_directories("${XJ_LLVM_ROOT}/include" "${XJ_SUPPORT_DIR}")
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
 
@@ -15,6 +16,7 @@ add_executable(xj-prepare-pointertransform
     ValidationMethods.cpp
     TransformationMethods.cpp
     PointerTransformAction.cpp
+    "${XJ_SUPPORT_DIR}/PtrIndexMetadata.cpp"
 )
 
 set_target_properties(xj-prepare-pointertransform PROPERTIES

--- a/xj-prepare-pointertransform/Common.cpp
+++ b/xj-prepare-pointertransform/Common.cpp
@@ -32,6 +32,9 @@ std::set<std::string> g_emitted_typedefs;
 std::map<const FunctionDecl *, FunctionAnalysis> g_function_analyses;
 std::set<const VarDecl *> g_index_return_vars;
 std::map<const FunctionDecl *, GlobalReturnInfo> g_global_return_functions;
+xj::PtrIndexMetadata g_metadata;
+std::string g_metadata_out;
+std::map<const VarDecl *, std::string> g_pre_slice_base_text;
 
 // ============================================================================
 // Helpers

--- a/xj-prepare-pointertransform/Common.h
+++ b/xj-prepare-pointertransform/Common.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include "PtrIndexMetadata.h"
+
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/ParentMapContext.h"
 #include "clang/AST/RecursiveASTVisitor.h"
@@ -292,6 +294,18 @@ extern std::set<const VarDecl *> g_index_return_vars;
 
 // Functions whose return type was rewritten from T* to int.
 extern std::map<const FunctionDecl *, GlobalReturnInfo> g_global_return_functions;
+
+// Metadata accumulated across every TU in this run, written to
+// g_metadata_out (if set) after the last file is processed. See
+// xj-prepare-support/PtrIndexMetadata.h.
+extern xj::PtrIndexMetadata g_metadata;
+extern std::string g_metadata_out; // --metadata-out CLI flag ("" = don't write)
+
+// The RustSlice pointer-pair path retargets a candidate's base to
+// arr.ptr before rewriting it. The metadata records the *original* base
+// (the fact about the input C), so the original text is stashed here at
+// the retarget site, keyed by the pointer's VarDecl.
+extern std::map<const VarDecl *, std::string> g_pre_slice_base_text;
 
 // ============================================================================
 // Edit — one pending source-text rewrite

--- a/xj-prepare-pointertransform/FunctionAccessAnalyzer.cpp
+++ b/xj-prepare-pointertransform/FunctionAccessAnalyzer.cpp
@@ -14,6 +14,8 @@
 
 #include "FunctionAccessAnalyzer.h"
 
+#include "llvm/Support/Path.h"
+
 namespace {
 
 // Replacing a pointer return type's token range does not necessarily leave a
@@ -230,6 +232,17 @@ void FunctionAccessAnalyzer::onEndOfTranslationUnit() {
                 SM.getSpellingLineNumber(Loc),
                 SM.getSpellingColumnNumber(Loc)
             });
+
+            xj::PtrIndexPointerRecord rec;
+            rec.name = VD->getNameAsString();
+            rec.index_var = rec.name + "_index_xj";
+            rec.param_index = -1;
+            rec.moved = true;
+            rec.base_text = state.candidate.base_array_text;
+            rec.min_offset = state.candidate.min_relative_offset;
+            rec.max_offset = state.candidate.max_relative_offset;
+            rec.variable_offsets = !state.candidate.constant_offsets;
+            g_metadata.globals.push_back(std::move(rec));
         }
     }
 }
@@ -3097,7 +3110,55 @@ void FunctionAccessAnalyzer::transformPointerVar(const FunctionDecl *FD,
             SM.getSpellingLineNumber(Loc),
             SM.getSpellingColumnNumber(Loc)
         });
+
+        // Record the transformed pointer in the metadata side-file so
+        // downstream consumers know which index variables exist and what
+        // they index into.
+        if (FD) {
+            if (xj::PtrIndexFunctionRecord *fnRec = metadataRecordFor(FD, Ctx)) {
+                xj::PtrIndexPointerRecord rec;
+                rec.name = PtrVar->getNameAsString();
+                rec.index_var = rec.name + "_index_xj";
+                rec.param_index = -1;
+                if (const auto *PD = dyn_cast<ParmVarDecl>(PtrVar))
+                    rec.param_index = static_cast<int>(PD->getFunctionScopeIndex());
+                rec.moved = true;
+                auto ob = g_pre_slice_base_text.find(PtrVar);
+                rec.base_text = ob != g_pre_slice_base_text.end()
+                                    ? ob->second
+                                    : candidate.base_array_text;
+                rec.min_offset = candidate.min_relative_offset;
+                rec.max_offset = candidate.max_relative_offset;
+                rec.variable_offsets = !candidate.constant_offsets;
+                fnRec->pointers.push_back(std::move(rec));
+            }
+        }
     }
+}
+
+// Return the metadata record for `FD`, creating it (with the right
+// source file stamped) on first use. Returns nullptr when a function of
+// the same name from a *different* file already claimed the record —
+// uniquify_statics runs after this pass, so distinct static functions
+// can still share a name here.
+xj::PtrIndexFunctionRecord *
+FunctionAccessAnalyzer::metadataRecordFor(const FunctionDecl *FD, ASTContext &Ctx) {
+    SourceManager &SM = Ctx.getSourceManager();
+    std::string name = FD->getNameAsString();
+    std::string file;
+    if (auto FE = SM.getFileEntryRefForID(
+            SM.getFileID(SM.getSpellingLoc(FD->getLocation()))))
+        file = llvm::sys::path::filename(FE->getName()).str();
+
+    auto it = g_metadata.functions.find(name);
+    if (it == g_metadata.functions.end()) {
+        xj::PtrIndexFunctionRecord rec;
+        rec.file = file;
+        it = g_metadata.functions.emplace(name, std::move(rec)).first;
+    } else if (it->second.file != file) {
+        return nullptr;
+    }
+    return &it->second;
 }
 
 // Push a vector<Edit> through the Rewriter. Edits are applied

--- a/xj-prepare-pointertransform/FunctionAccessAnalyzer.h
+++ b/xj-prepare-pointertransform/FunctionAccessAnalyzer.h
@@ -102,6 +102,12 @@ class FunctionAccessAnalyzer : public MatchFinder::MatchCallback {
     // and skipping any that overlap an already-edited range.
     void applyEdits(std::vector<Edit> &edits, SourceManager &SM);
 
+    // ---- Metadata export (--metadata-out) -----------------------------
+    // Look up (or create) the metadata record for FD; nullptr when a
+    // same-named function from another file already owns the record.
+    xj::PtrIndexFunctionRecord *metadataRecordFor(const FunctionDecl *FD,
+                                                  ASTContext &Ctx);
+
     // ---- Cross-function transformation phases -------------------------
     void detectAllTransformations(ASTContext &Ctx);
     void transformAllFunctions(ASTContext &Ctx);

--- a/xj-prepare-pointertransform/PointerTransformAction.cpp
+++ b/xj-prepare-pointertransform/PointerTransformAction.cpp
@@ -20,6 +20,9 @@ bool PointerTransformAction::BeginSourceFileAction(CompilerInstance &CI) {
     g_function_analyses.clear();
     g_index_return_vars.clear();
     g_global_return_functions.clear();
+    g_pre_slice_base_text.clear();
+    // (g_metadata is intentionally NOT cleared: it accumulates records
+    // across every TU and is flushed once at the end of the run.)
     // NOTE: do NOT clear g_allowed_funcs — it's static configuration
     // (names of library functions we have wrappers for, e.g. strchr,
     // sscanf), initialized once in Common.cpp. Clearing it leaves an

--- a/xj-prepare-pointertransform/TransformationMethods.cpp
+++ b/xj-prepare-pointertransform/TransformationMethods.cpp
@@ -1949,6 +1949,7 @@ bool FunctionAccessAnalyzer::generatePointerPairTransformation(
 
         if (candidate.base_array_text ==
             FD->getParamDecl(base_idx)->getNameAsString()) {
+            g_pre_slice_base_text[PtrVar] = candidate.base_array_text;
             candidate.base_array_text = arr_name + ".ptr";
         }
 

--- a/xj-prepare-pointertransform/main.cpp
+++ b/xj-prepare-pointertransform/main.cpp
@@ -26,6 +26,16 @@ static cl::opt<bool> VerboseOpt(
     cl::init(false),
     cl::cat(MyToolCategory));
 
+// --metadata-out: path where the pointer/index metadata side-file is
+// written (accumulated over every processed TU). Records the facts about
+// each rewritten pointer for downstream consumers; see
+// xj-prepare-support/PtrIndexMetadata.h.
+static cl::opt<std::string> MetadataOutOpt(
+    "metadata-out",
+    cl::desc("Path to write pointer/index metadata JSON"),
+    cl::init(""),
+    cl::cat(MyToolCategory));
+
 int main(int argc, const char **argv) {
     auto ExpectedParser = CommonOptionsParser::create(argc, argv, MyToolCategory);
     if (!ExpectedParser) {
@@ -37,6 +47,7 @@ int main(int argc, const char **argv) {
     // Publish CLI flags to the rest of the tool through Common.cpp globals.
     g_inplace = InplaceOpt;
     g_verbose = VerboseOpt;
+    g_metadata_out = MetadataOutOpt;
 
     // Process each source file with its OWN ClangTool, and therefore a fresh
     // FileManager, rather than one ClangTool over the whole source list.
@@ -58,6 +69,14 @@ int main(int argc, const char **argv) {
         int r = Tool.run(newFrontendActionFactory<PointerTransformAction>().get());
         if (r != 0)
             rc = r;
+    }
+
+    // g_metadata accumulated one function/pointer record set per TU as
+    // files were processed; flush it once at the end of the run.
+    if (!g_metadata_out.empty() && !g_metadata.writeToFile(g_metadata_out)) {
+        llvm::errs() << "xj-prepare-pointertransform: failed to write metadata to "
+                     << g_metadata_out << "\n";
+        rc = 1;
     }
     return rc;
 }

--- a/xj-prepare-support/PtrIndexMetadata.cpp
+++ b/xj-prepare-support/PtrIndexMetadata.cpp
@@ -1,0 +1,214 @@
+#include "PtrIndexMetadata.h"
+
+#include "llvm/Support/JSON.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <system_error>
+
+namespace xj {
+
+static llvm::json::Object pointerToJson(const PtrIndexPointerRecord &R) {
+    llvm::json::Object O;
+    O["name"] = R.name;
+    O["index_var"] = R.index_var;
+    O["param_index"] = R.param_index;
+    O["moved"] = R.moved;
+    O["base_text"] = R.base_text;
+    O["min_offset"] = static_cast<int64_t>(R.min_offset);
+    O["max_offset"] = static_cast<int64_t>(R.max_offset);
+    O["variable_offsets"] = R.variable_offsets;
+    O["handle_source"] = R.handle_source;
+    O["returned_at_offset"] = R.returned_at_offset;
+    O["dereferenced"] = R.dereferenced;
+    llvm::json::Array Compared;
+    for (const auto &C : R.compared_against)
+        Compared.push_back(C);
+    O["compared_against"] = std::move(Compared);
+    return O;
+}
+
+static bool pointerFromJson(const llvm::json::Object &O,
+                            PtrIndexPointerRecord &R) {
+    auto Name = O.getString("name");
+    auto IndexVar = O.getString("index_var");
+    if (!Name || !IndexVar)
+        return false;
+    R.name = Name->str();
+    R.index_var = IndexVar->str();
+    R.param_index = static_cast<int>(O.getInteger("param_index").value_or(-1));
+    R.moved = O.getBoolean("moved").value_or(false);
+    R.base_text = O.getString("base_text").value_or("").str();
+    R.min_offset = static_cast<long>(O.getInteger("min_offset").value_or(0));
+    R.max_offset = static_cast<long>(O.getInteger("max_offset").value_or(0));
+    R.variable_offsets = O.getBoolean("variable_offsets").value_or(false);
+    R.handle_source = O.getString("handle_source").value_or("").str();
+    R.returned_at_offset = O.getBoolean("returned_at_offset").value_or(false);
+    R.dereferenced = O.getBoolean("dereferenced").value_or(false);
+    if (const llvm::json::Array *Compared = O.getArray("compared_against")) {
+        for (const auto &V : *Compared) {
+            if (auto S = V.getAsString())
+                R.compared_against.push_back(S->str());
+        }
+    }
+    return true;
+}
+
+static llvm::json::Object sliceToJson(const PtrIndexSliceRecord &S) {
+    llvm::json::Object O;
+    O["slice_param_name"] = S.slice_param_name;
+    O["slice_type"] = S.slice_type;
+    O["pointee_type"] = S.pointee_type;
+    O["base_param_index"] = S.base_param_index;
+    O["end_param_index"] = S.end_param_index;
+    O["len_param_index"] = S.len_param_index;
+    O["lookback"] = static_cast<int64_t>(S.lookback);
+    O["lookahead"] = static_cast<int64_t>(S.lookahead);
+    O["inclusive_end"] = S.inclusive_end;
+    O["return_type_changed"] = S.return_type_changed;
+    llvm::json::Array Singletons;
+    for (int I : S.singleton_param_indices)
+        Singletons.push_back(I);
+    O["singleton_param_indices"] = std::move(Singletons);
+    return O;
+}
+
+static bool sliceFromJson(const llvm::json::Object &O, PtrIndexSliceRecord &S) {
+    auto SliceType = O.getString("slice_type");
+    auto PointeeType = O.getString("pointee_type");
+    if (!SliceType || !PointeeType)
+        return false;
+    S.present = true;
+    S.slice_param_name = O.getString("slice_param_name").value_or("arr").str();
+    S.slice_type = SliceType->str();
+    S.pointee_type = PointeeType->str();
+    S.base_param_index =
+        static_cast<int>(O.getInteger("base_param_index").value_or(-1));
+    S.end_param_index =
+        static_cast<int>(O.getInteger("end_param_index").value_or(-1));
+    S.len_param_index =
+        static_cast<int>(O.getInteger("len_param_index").value_or(-1));
+    S.lookback = static_cast<long>(O.getInteger("lookback").value_or(0));
+    S.lookahead = static_cast<long>(O.getInteger("lookahead").value_or(0));
+    S.inclusive_end = O.getBoolean("inclusive_end").value_or(false);
+    S.return_type_changed = O.getBoolean("return_type_changed").value_or(false);
+    if (const llvm::json::Array *Singletons =
+            O.getArray("singleton_param_indices")) {
+        for (const auto &V : *Singletons) {
+            if (auto I = V.getAsInteger())
+                S.singleton_param_indices.push_back(static_cast<int>(*I));
+        }
+    }
+    return true;
+}
+
+bool PtrIndexMetadata::writeToFile(const std::string &path) const {
+    llvm::json::Object Root;
+    Root["version"] = XJ_PTR_INDEX_METADATA_VERSION;
+
+    llvm::json::Object Functions;
+    for (const auto &[FnName, FnRec] : functions) {
+        llvm::json::Array Pointers;
+        for (const auto &P : FnRec.pointers)
+            Pointers.push_back(pointerToJson(P));
+        llvm::json::Object FnObj;
+        FnObj["file"] = FnRec.file;
+        FnObj["pointers"] = std::move(Pointers);
+        if (FnRec.slice.present)
+            FnObj["slice"] = sliceToJson(FnRec.slice);
+        Functions[FnName] = std::move(FnObj);
+    }
+    Root["functions"] = std::move(Functions);
+
+    llvm::json::Object GlobalReturns;
+    for (const auto &[FnName, GR] : global_return_functions) {
+        llvm::json::Object GRObj;
+        GRObj["file"] = GR.file;
+        GRObj["global_array_name"] = GR.global_array_name;
+        GRObj["pointee_type"] = GR.pointee_type;
+        GlobalReturns[FnName] = std::move(GRObj);
+    }
+    Root["global_return_functions"] = std::move(GlobalReturns);
+
+    llvm::json::Array Globals;
+    for (const auto &G : globals)
+        Globals.push_back(pointerToJson(G));
+    Root["globals"] = std::move(Globals);
+
+    std::error_code EC;
+    llvm::raw_fd_ostream OS(path, EC);
+    if (EC)
+        return false;
+    OS << llvm::formatv("{0:2}", llvm::json::Value(std::move(Root)));
+    return !OS.has_error();
+}
+
+bool PtrIndexMetadata::readFromFile(const std::string &path) {
+    auto BufOrErr = llvm::MemoryBuffer::getFile(path);
+    if (!BufOrErr)
+        return false;
+    auto Parsed = llvm::json::parse((*BufOrErr)->getBuffer());
+    if (!Parsed) {
+        llvm::consumeError(Parsed.takeError());
+        return false;
+    }
+    const llvm::json::Object *Root = Parsed->getAsObject();
+    if (!Root)
+        return false;
+    if (Root->getInteger("version").value_or(0) != XJ_PTR_INDEX_METADATA_VERSION)
+        return false;
+
+    functions.clear();
+    global_return_functions.clear();
+    globals.clear();
+
+    if (const llvm::json::Object *Functions = Root->getObject("functions")) {
+        for (const auto &[Key, Val] : *Functions) {
+            const llvm::json::Object *FnObj = Val.getAsObject();
+            if (!FnObj)
+                return false;
+            PtrIndexFunctionRecord FnRec;
+            FnRec.file = FnObj->getString("file").value_or("").str();
+            if (const llvm::json::Array *Pointers = FnObj->getArray("pointers")) {
+                for (const auto &PV : *Pointers) {
+                    const llvm::json::Object *PO = PV.getAsObject();
+                    PtrIndexPointerRecord R;
+                    if (!PO || !pointerFromJson(*PO, R))
+                        return false;
+                    FnRec.pointers.push_back(std::move(R));
+                }
+            }
+            if (const llvm::json::Object *SliceObj = FnObj->getObject("slice")) {
+                if (!sliceFromJson(*SliceObj, FnRec.slice))
+                    return false;
+            }
+            functions[Key.str()] = std::move(FnRec);
+        }
+    }
+    if (const llvm::json::Object *GlobalReturns =
+            Root->getObject("global_return_functions")) {
+        for (const auto &[Key, Val] : *GlobalReturns) {
+            const llvm::json::Object *GRObj = Val.getAsObject();
+            if (!GRObj)
+                return false;
+            PtrIndexGlobalReturnRecord GR;
+            GR.file = GRObj->getString("file").value_or("").str();
+            GR.global_array_name =
+                GRObj->getString("global_array_name").value_or("").str();
+            GR.pointee_type = GRObj->getString("pointee_type").value_or("").str();
+            global_return_functions[Key.str()] = std::move(GR);
+        }
+    }
+    if (const llvm::json::Array *Globals = Root->getArray("globals")) {
+        for (const auto &GV : *Globals) {
+            const llvm::json::Object *GO = GV.getAsObject();
+            PtrIndexPointerRecord R;
+            if (!GO || !pointerFromJson(*GO, R))
+                return false;
+            globals.push_back(std::move(R));
+        }
+    }
+    return true;
+}
+
+} // namespace xj

--- a/xj-prepare-support/PtrIndexMetadata.h
+++ b/xj-prepare-support/PtrIndexMetadata.h
@@ -1,0 +1,117 @@
+// Metadata written by xj-prepare-pointertransform (--metadata-out) as a
+// JSON side-file, describing the pointer-to-index rewrites it performed.
+//
+// For every pointer it rewrote as an index, the tool records the facts
+// that identify the rewrite in the transformed source: the synthesized
+// index variable, the base it indexes into, and the constant offset
+// bounds observed. These are cheap to record during analysis but fragile
+// to reconstruct from the rewritten text alone.
+//
+// The schema also reserves per-function slice records and a
+// global-return map: the RustSlice signature reshaping is being split
+// out of this tool into a separate pass, which will detect candidates
+// from the transformed source plus these per-pointer facts and record
+// its decisions in those sections. Nothing fills them yet. Any consumer
+// must treat every fact here as a hint and re-verify it against the AST
+// before acting on it.
+
+#ifndef XJ_PREPARE_SUPPORT_PTR_INDEX_METADATA_H
+#define XJ_PREPARE_SUPPORT_PTR_INDEX_METADATA_H
+
+#include <map>
+#include <string>
+#include <vector>
+
+namespace xj {
+
+constexpr const char *XJ_PTR_INDEX_METADATA_FILENAME =
+    "tenjin_ptr_index_metadata.json";
+constexpr int XJ_PTR_INDEX_METADATA_VERSION = 1;
+
+struct PtrIndexPointerRecord {
+    std::string name;      // pointer variable name
+    std::string index_var; // companion index variable name, "" if none
+    int param_index = -1;  // position among the function's params, -1 if local
+    bool moved = false;    // pointer had movement and was index-transformed
+    // Source text of the base array this pointer indexes into (e.g. "buf",
+    // "bs->buf"). Empty when the pointer is its own base (a parameter).
+    std::string base_text;
+    // Range of constant offsets seen relative to the index position
+    // (e.g. p[-1] => min_offset = -1). Used for slice lookback/lookahead.
+    long min_offset = 0;
+    long max_offset = 0;
+    // A non-constant offset (e.g. *(p + n)) was applied to this pointer.
+    // Legal for the index transform, but disqualifies slice reshaping.
+    bool variable_offsets = false;
+    // Name of the single variable this pointer's handle was derived from
+    // (sole reseat source), "" if none/multiple.
+    std::string handle_source;
+    // Some `return` statement returns this pointer (at its index offset).
+    bool returned_at_offset = false;
+    // Non-pointer variables this pointer's position was compared against
+    // (candidates for the `len` of a slice).
+    std::vector<std::string> compared_against;
+    // The pointer (at fixed offset) is dereferenced but never moved;
+    // relevant for (lo,hi) pointer-pair inclusive-end detection.
+    bool dereferenced = false;
+};
+
+// How a function is to be reshaped into a RustSlice signature. Reserved
+// for the downstream slice-reshaping pass; not written by
+// xj-prepare-pointertransform.
+struct PtrIndexSliceRecord {
+    bool present = false; // false => no slice reshaping for this function
+
+    std::string slice_param_name; // name of the new slice param, e.g. "arr"
+    std::string slice_type;       // generated typedef name, e.g. "RustSlice_int"
+    std::string pointee_type;     // element type, e.g. "int"
+
+    // Indices into the *original* parameter list.
+    int base_param_index = -1; // pointer parameter that becomes arr.ptr
+    int end_param_index = -1;  // end pointer ((lo,hi) form); -1 otherwise
+    int len_param_index = -1;  // length parameter (ptr+len form); -1 otherwise
+
+    long lookback = 0;  // slice widening below the base (from *(p - k))
+    long lookahead = 0; // slice widening past the bound (from *(p + k))
+
+    bool inclusive_end = false;       // [lo, hi] with hi dereferenced
+    bool return_type_changed = false; // T* return rewritten to int
+
+    // Pointer params that don't iterate but are dereferenced (e.g.
+    // swap's a,b). They become int indices alongside the slice.
+    std::vector<int> singleton_param_indices;
+};
+
+// A function whose every return is NULL or &global_array[i]: its return
+// type is rewritten from T* to int and callers index the array directly.
+// Reserved for the downstream slice-reshaping pass.
+struct PtrIndexGlobalReturnRecord {
+    std::string file;              // basename of the definition's file
+    std::string global_array_name; // e.g. "node_storage"
+    std::string pointee_type;      // e.g. "Node"
+};
+
+struct PtrIndexFunctionRecord {
+    // Basename of the file containing the function's definition. Guards
+    // against name collisions between static functions in different TUs
+    // (uniquify_statics runs after this pass).
+    std::string file;
+    std::vector<PtrIndexPointerRecord> pointers;
+    PtrIndexSliceRecord slice;
+};
+
+struct PtrIndexMetadata {
+    // Keyed by function name.
+    std::map<std::string, PtrIndexFunctionRecord> functions;
+    std::map<std::string, PtrIndexGlobalReturnRecord> global_return_functions;
+    std::vector<PtrIndexPointerRecord> globals;
+
+    // Serialize to `path`, overwriting. Returns false on I/O error.
+    bool writeToFile(const std::string &path) const;
+    // Parse from `path`. Returns false on I/O or schema error.
+    bool readFromFile(const std::string &path);
+};
+
+} // namespace xj
+
+#endif // XJ_PREPARE_SUPPORT_PTR_INDEX_METADATA_H


### PR DESCRIPTION
Emit metadata for all transformed pointers + tests.