### PR TITLE
Drop `macos-14` from CI runner matrix

### DIFF
--- a/.github/workflows/nrsr.yaml
+++ b/.github/workflows/nrsr.yaml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [ubuntu-latest, macos-14, macos-15]
+        runner: [ubuntu-latest, macos-15]
     runs-on: ${{ matrix.runner }}
     defaults:
       run:


### PR DESCRIPTION
It is deprecated, and will be sunsetted by GitHub in a few months.