### PR TITLE
Split transformAllFunctions into named pipeline stages

### DIFF
--- a/tests/pointer_transform/pointer_transform_cases/init_conflict_param_bounded_iterating/expected/init_conflict_param_bounded_iterating.c
+++ b/tests/pointer_transform/pointer_transform_cases/init_conflict_param_bounded_iterating/expected/init_conflict_param_bounded_iterating.c
@@ -1,0 +1,64 @@
+#include <stdio.h>
+
+/* A param-bounded pointer whose offset text names another pointer that is
+ * itself rewritten.
+ *
+ * `p`'s offset is source text snapshotted at collect time and pasted back
+ * out. It names `q`, and `q` collapses — its declaration is deleted — so the
+ * pasted text refers to a variable that no longer exists. The stale-offset
+ * step catches exactly this and drops `p`.
+ *
+ * The catch is that `p` is *param-bounded*: its base is the parameter `buf`
+ * and `p < buf + n` resolves against it, which used to mean `p` was emitted
+ * without consulting the verdict at all. Re-validation inside
+ * transformPointerVar does not save it, because the reason `p` was dropped —
+ * a conflict with another pointer's rewrite — is not a fact validation can
+ * see. The result was `int p_index_xj = q[0];` with `q` gone: the prepared
+ * file does not compile, and a file that does not compile costs the whole
+ * codebase its pointer rewrites when the pass rolls back.
+ *
+ * This differs from init_conflict_param_bounded in one respect, and that is
+ * the whole point: there `q` never moves, so it is rejected as non-iterating,
+ * never transformed, and the conflict never fires. Here `q++` makes it
+ * iterate.
+ *
+ * The offset is a subscript rather than `q - buf` deliberately. A pointer
+ * difference reaches the Unknown catch-all and rejects `q` outright, which
+ * also prevents the conflict — masking the bug rather than exercising it.
+ *
+ * Both shapes that carry an offset are covered: the initializer and a
+ * post-declaration assignment. */
+
+/* Initializer form. */
+static int init_form(int *buf, int n) {
+    int q_index_xj = 1;
+    int *p = buf + buf[q_index_xj];
+    int s = 0;
+    while (p < buf + n) {
+        s += *p;
+        p++;
+    }
+    q_index_xj++;
+    return s + buf[q_index_xj];
+}
+
+/* Assignment form: the offset arrives after the declaration. */
+static int assign_form(int *buf, int n) {
+    int q_index_xj = 1;
+    int *p;
+    int s = 0;
+    p = buf + buf[q_index_xj];
+    while (p < buf + n) {
+        s += *p;
+        p++;
+    }
+    q_index_xj++;
+    return s + buf[q_index_xj];
+}
+
+int main(void) {
+    int a[8] = {0, 1, 2, 4, 8, 16, 32, 64};
+    int b[8] = {0, 1, 2, 4, 8, 16, 32, 64};
+    printf("%d %d\n", init_form(a, 5), assign_form(b, 5));
+    return 0;
+}

--- a/tests/pointer_transform/pointer_transform_cases/init_conflict_param_bounded_iterating/expected_metadata.json
+++ b/tests/pointer_transform/pointer_transform_cases/init_conflict_param_bounded_iterating/expected_metadata.json
@@ -1,0 +1,26 @@
+{
+  "functions": {
+    "assign_form@init_conflict_param_bounded_iterating.c": {
+      "file": "init_conflict_param_bounded_iterating.c",
+      "pointers": [
+        {
+          "base_text": "buf",
+          "index_var": "q_index_xj",
+          "name": "q",
+          "param_index": -1
+        }
+      ]
+    },
+    "init_form@init_conflict_param_bounded_iterating.c": {
+      "file": "init_conflict_param_bounded_iterating.c",
+      "pointers": [
+        {
+          "base_text": "buf",
+          "index_var": "q_index_xj",
+          "name": "q",
+          "param_index": -1
+        }
+      ]
+    }
+  }
+}

--- a/tests/pointer_transform/pointer_transform_cases/init_conflict_param_bounded_iterating/expected_ptr/init_conflict_param_bounded_iterating.c
+++ b/tests/pointer_transform/pointer_transform_cases/init_conflict_param_bounded_iterating/expected_ptr/init_conflict_param_bounded_iterating.c
@@ -1,0 +1,64 @@
+#include <stdio.h>
+
+/* A param-bounded pointer whose offset text names another pointer that is
+ * itself rewritten.
+ *
+ * `p`'s offset is source text snapshotted at collect time and pasted back
+ * out. It names `q`, and `q` collapses — its declaration is deleted — so the
+ * pasted text refers to a variable that no longer exists. The stale-offset
+ * step catches exactly this and drops `p`.
+ *
+ * The catch is that `p` is *param-bounded*: its base is the parameter `buf`
+ * and `p < buf + n` resolves against it, which used to mean `p` was emitted
+ * without consulting the verdict at all. Re-validation inside
+ * transformPointerVar does not save it, because the reason `p` was dropped —
+ * a conflict with another pointer's rewrite — is not a fact validation can
+ * see. The result was `int p_index_xj = q[0];` with `q` gone: the prepared
+ * file does not compile, and a file that does not compile costs the whole
+ * codebase its pointer rewrites when the pass rolls back.
+ *
+ * This differs from init_conflict_param_bounded in one respect, and that is
+ * the whole point: there `q` never moves, so it is rejected as non-iterating,
+ * never transformed, and the conflict never fires. Here `q++` makes it
+ * iterate.
+ *
+ * The offset is a subscript rather than `q - buf` deliberately. A pointer
+ * difference reaches the Unknown catch-all and rejects `q` outright, which
+ * also prevents the conflict — masking the bug rather than exercising it.
+ *
+ * Both shapes that carry an offset are covered: the initializer and a
+ * post-declaration assignment. */
+
+/* Initializer form. */
+static int init_form(int *buf, int n) {
+    int q_index_xj = 1;
+    int *p = buf + buf[q_index_xj];
+    int s = 0;
+    while (p < buf + n) {
+        s += *p;
+        p++;
+    }
+    q_index_xj++;
+    return s + buf[q_index_xj];
+}
+
+/* Assignment form: the offset arrives after the declaration. */
+static int assign_form(int *buf, int n) {
+    int q_index_xj = 1;
+    int *p;
+    int s = 0;
+    p = buf + buf[q_index_xj];
+    while (p < buf + n) {
+        s += *p;
+        p++;
+    }
+    q_index_xj++;
+    return s + buf[q_index_xj];
+}
+
+int main(void) {
+    int a[8] = {0, 1, 2, 4, 8, 16, 32, 64};
+    int b[8] = {0, 1, 2, 4, 8, 16, 32, 64};
+    printf("%d %d\n", init_form(a, 5), assign_form(b, 5));
+    return 0;
+}

--- a/tests/pointer_transform/pointer_transform_cases/init_conflict_param_bounded_iterating/input/init_conflict_param_bounded_iterating.c
+++ b/tests/pointer_transform/pointer_transform_cases/init_conflict_param_bounded_iterating/input/init_conflict_param_bounded_iterating.c
@@ -1,0 +1,64 @@
+#include <stdio.h>
+
+/* A param-bounded pointer whose offset text names another pointer that is
+ * itself rewritten.
+ *
+ * `p`'s offset is source text snapshotted at collect time and pasted back
+ * out. It names `q`, and `q` collapses — its declaration is deleted — so the
+ * pasted text refers to a variable that no longer exists. The stale-offset
+ * step catches exactly this and drops `p`.
+ *
+ * The catch is that `p` is *param-bounded*: its base is the parameter `buf`
+ * and `p < buf + n` resolves against it, which used to mean `p` was emitted
+ * without consulting the verdict at all. Re-validation inside
+ * transformPointerVar does not save it, because the reason `p` was dropped —
+ * a conflict with another pointer's rewrite — is not a fact validation can
+ * see. The result was `int p_index_xj = q[0];` with `q` gone: the prepared
+ * file does not compile, and a file that does not compile costs the whole
+ * codebase its pointer rewrites when the pass rolls back.
+ *
+ * This differs from init_conflict_param_bounded in one respect, and that is
+ * the whole point: there `q` never moves, so it is rejected as non-iterating,
+ * never transformed, and the conflict never fires. Here `q++` makes it
+ * iterate.
+ *
+ * The offset is a subscript rather than `q - buf` deliberately. A pointer
+ * difference reaches the Unknown catch-all and rejects `q` outright, which
+ * also prevents the conflict — masking the bug rather than exercising it.
+ *
+ * Both shapes that carry an offset are covered: the initializer and a
+ * post-declaration assignment. */
+
+/* Initializer form. */
+static int init_form(int *buf, int n) {
+    int *q = buf + 1;
+    int *p = buf + q[0];
+    int s = 0;
+    while (p < buf + n) {
+        s += *p;
+        p++;
+    }
+    q++;
+    return s + *q;
+}
+
+/* Assignment form: the offset arrives after the declaration. */
+static int assign_form(int *buf, int n) {
+    int *q = buf + 1;
+    int *p;
+    int s = 0;
+    p = buf + q[0];
+    while (p < buf + n) {
+        s += *p;
+        p++;
+    }
+    q++;
+    return s + *q;
+}
+
+int main(void) {
+    int a[8] = {0, 1, 2, 4, 8, 16, 32, 64};
+    int b[8] = {0, 1, 2, 4, 8, 16, 32, 64};
+    printf("%d %d\n", init_form(a, 5), assign_form(b, 5));
+    return 0;
+}

--- a/xj-prepare-pointertransform/FunctionAccessAnalyzer.cpp
+++ b/xj-prepare-pointertransform/FunctionAccessAnalyzer.cpp
@@ -150,8 +150,8 @@ void FunctionAccessAnalyzer::onEndOfTranslationUnit() {
         printAccesses(VD, state.accesses, Ctx);
 
         std::string error;
-        if (!validatePointerCandidate(VD, state.candidate, state.accesses,
-                                      Ctx, error)) {
+        if (validatePointerCandidate(VD, state.candidate, state.accesses,
+                                     Ctx, error) == TransformMode::Reject) {
             gLog.error = error;
             logFailedPointer(VD, Ctx, error);
             if (VERBOSE)
@@ -189,9 +189,259 @@ void FunctionAccessAnalyzer::onEndOfTranslationUnit() {
 }
 
 // ============================================================================
-// transformAllFunctions — rewrite every local pointer that's safe to
-// rewrite, function by function, in plain (base-param-relative) form.
+// The per-function rewrite pipeline
 // ============================================================================
+//
+// transformAllFunctions walks the analyzed functions; transformFunction runs
+// the pipeline for one of them. The steps were previously one 200-line body;
+// they are the same steps, in the same order, with names.
+//
+//   1. assignIndexNamesInSourceOrder  name every index before anything reads one
+//   2. pointersInEditOrder            decide the order rewrites are emitted in
+//   3. decideTransformModes           judge each pointer
+//   4. resolveCrossPointerComparisons restate comparisons naming another pointer
+//   5. rejectStaleOffsets             drop pointers whose pasted offset would rot
+//   6. emitPointerRewrites            rewrite the survivors
+
+// Step 1. Sorting by source location rather than iterating the map matters:
+// the map is keyed by VarDecl address, which is allocation order and not a
+// property of the source, so the names it hands out would not be reproducible.
+static void assignIndexNamesInSourceOrder(const FunctionAnalysis &analysis,
+                                          ASTContext &Ctx) {
+    SourceManager &SM = Ctx.getSourceManager();
+    std::vector<const VarDecl *> ptrs;
+    for (const auto &pair : analysis.accesses)
+        ptrs.push_back(pair.first);
+    std::sort(ptrs.begin(), ptrs.end(),
+              [&](const VarDecl *A, const VarDecl *B) {
+                  return SM.isBeforeInTranslationUnit(A->getLocation(),
+                                                      B->getLocation());
+              });
+    assignIndexNames(ptrs);
+}
+
+// True when the pointer indexes into one of the function's own pointer
+// parameters and has a comparison that can be resolved against it. Those are
+// the pointers whose rewrite the slice pass can anchor on, so they win any
+// overlap against a pointer rewritten later.
+static bool isParamBounded(const FunctionDecl *FD,
+                           const PointerCandidate &candidate,
+                           const std::vector<PointerAccess> &accesses) {
+    if (candidate.is_parameter || FD->getNumParams() == 0)
+        return false;
+
+    bool base_is_param = false;
+    for (unsigned i = 0; i < FD->getNumParams(); i++) {
+        if (FD->getParamDecl(i)->getNameAsString() == candidate.base_array_text &&
+            FD->getParamDecl(i)->getType()->isPointerType()) {
+            base_is_param = true;
+            break;
+        }
+    }
+    if (!base_is_param)
+        return false;
+
+    for (const auto &acc : accesses) {
+        if (acc.kind == PointerAccessKind::ComparisonExpr)
+            return true;
+    }
+    return false;
+}
+
+// Step 2. See EditOrder for why the two groups stay apart.
+static EditOrder pointersInEditOrder(const FunctionDecl *FD,
+                                     FunctionAnalysis &analysis) {
+    EditOrder order;
+    for (auto &pair : analysis.accesses) {
+        const VarDecl *PtrVar = pair.first;
+        if (isParamBounded(FD, analysis.tracked_pointers[PtrVar], pair.second))
+            order.param_bounded.push_back(PtrVar);
+        else
+            order.rest.push_back(PtrVar);
+    }
+    return order;
+}
+
+// Step 3.
+TransformModeMap
+FunctionAccessAnalyzer::decideTransformModes(FunctionAnalysis &analysis,
+                                             ASTContext &Ctx) {
+    TransformModeMap modes;
+    for (auto &pair : analysis.accesses) {
+        const VarDecl *PtrVar = pair.first;
+        auto &candidate = analysis.tracked_pointers[PtrVar];
+        auto &access_list = pair.second;
+
+        std::string error;
+        TransformMode mode =
+            validatePointerCandidate(PtrVar, candidate, access_list, Ctx, error);
+        if (mode != TransformMode::Reject)
+            modes[PtrVar] = mode;
+    }
+    return modes;
+}
+
+// Step 4. A comparison against another pointer that is *also* being rewritten
+// cannot keep naming that pointer — it is about to be deleted. Restate the
+// operand in reconstructed form, `other_base + other_index`.
+static void resolveCrossPointerComparisons(FunctionAnalysis &analysis,
+                                           const TransformModeMap &modes,
+                                           ASTContext &Ctx) {
+    for (auto &pair : analysis.accesses) {
+        const VarDecl *PtrVar = pair.first;
+        auto &candidate = analysis.tracked_pointers[PtrVar];
+        if (modes.find(PtrVar) == modes.end())
+            continue;
+        for (auto &acc : pair.second) {
+            if (acc.kind != PointerAccessKind::ComparisonExpr)
+                continue;
+            // Check if operand_text is "(other - base)" pattern
+            // and the other is also being transformed
+            if (!acc.field_name.empty() &&
+                acc.field_name != candidate.base_array_text)
+                continue; // shape-5 param reconstruction; leave alone
+            // (pointer-form equality records — field_name == base —
+            // fall through: their operand still names the other
+            // pointer and must be reconstructed below if that
+            // pointer is transformed too)
+            // Look for the other pointer in the comparison's parent
+            const Stmt *P = skipTransparentParents(acc.expr, Ctx);
+            const BinaryOperator *BO = P ? dyn_cast<BinaryOperator>(P) : nullptr;
+            if (!BO) continue;
+            const Expr *LHS = BO->getLHS()->IgnoreParenImpCasts();
+            const Expr *RHS = BO->getRHS()->IgnoreParenImpCasts();
+            const Expr *OtherSide = nullptr;
+            if (const DeclRefExpr *LDRE = dyn_cast<DeclRefExpr>(LHS)) {
+                if (LDRE->getDecl() == PtrVar) OtherSide = RHS;
+            }
+            if (!OtherSide) {
+                if (const DeclRefExpr *RDRE = dyn_cast<DeclRefExpr>(RHS)) {
+                    if (RDRE->getDecl() == PtrVar) OtherSide = LHS;
+                }
+            }
+            if (!OtherSide) continue;
+            // Walk through OtherSide to find a DeclRefExpr to a transformed pointer
+            // Handle both direct refs (e.g., `e`) and expressions (e.g., `buf + len`)
+            const DeclRefExpr *OtherDRE = dyn_cast<DeclRefExpr>(OtherSide);
+            if (!OtherDRE) {
+                // Try to find the pointer in a BinaryOperator (e.g., arr + n)
+                if (const BinaryOperator *AddBO = dyn_cast<BinaryOperator>(OtherSide)) {
+                    OtherDRE = dyn_cast<DeclRefExpr>(AddBO->getLHS()->IgnoreParenImpCasts());
+                }
+            }
+            if (!OtherDRE) continue;
+            const VarDecl *OtherVD = dyn_cast<VarDecl>(OtherDRE->getDecl());
+            if (!OtherVD || modes.find(OtherVD) == modes.end())
+                continue;
+            // Both pointers will be transformed. Use pointer reconstruction:
+            // base + index <op> other_base + other_index
+            auto &other_cand = analysis.tracked_pointers[OtherVD];
+            std::string other_base = other_cand.base_array_text;
+            std::string other_idx = indexNameFor(OtherVD);
+            std::string rhs = other_base.empty() ?
+                other_idx : other_base + " + " + other_idx;
+            acc.field_name = candidate.base_array_text;
+            acc.operand_text = rhs;
+        }
+    }
+}
+
+// Step 5. An offset is source text snapshotted at collect time and pasted
+// back out. If it names another pointer that is also being rewritten, that
+// text describes a variable which will not exist, so this pointer has to be
+// dropped rather than emitted against a stale name.
+void FunctionAccessAnalyzer::rejectStaleOffsets(FunctionAnalysis &analysis,
+                                                TransformModeMap &modes,
+                                                ASTContext &Ctx) {
+    for (auto &pair : analysis.accesses) {
+        const VarDecl *PtrVar = pair.first;
+        if (modes.find(PtrVar) == modes.end())
+            continue;
+        for (const auto &acc : pair.second) {
+            if (acc.kind != PointerAccessKind::InitArrayOffset &&
+                acc.kind != PointerAccessKind::AssignAddrOf &&
+                acc.kind != PointerAccessKind::AssignArrayOffset)
+                continue;
+            // Check if any other transformed pointer appears in the
+            // init expression's subtree
+            const Stmt *InitStmt = acc.enclosing_stmt;
+            if (!InitStmt) {
+                // For declarations, use the VarDecl's init
+                if (PtrVar->hasInit())
+                    InitStmt = PtrVar->getInit();
+            }
+            if (!InitStmt && acc.expr) {
+                // For separate assignments (AssignAddrOf, AssignArrayOffset),
+                // walk up from the DeclRefExpr to find the BinaryOperator
+                // and check its RHS for references to other transformed ptrs
+                const Stmt *P = skipTransparentParents(acc.expr, Ctx);
+                if (const BinaryOperator *BO = dyn_cast_or_null<BinaryOperator>(P))
+                    InitStmt = BO->getRHS();
+            }
+            if (!InitStmt) continue;
+            bool has_conflict = false;
+            // Walk the init to find DeclRefExprs to other transformed pointers
+            std::function<void(const Stmt *)> checkRefs = [&](const Stmt *S) {
+                if (has_conflict || !S) return;
+                if (const DeclRefExpr *DRE = dyn_cast<DeclRefExpr>(S)) {
+                    if (const VarDecl *VD = dyn_cast<VarDecl>(DRE->getDecl())) {
+                        if (VD != PtrVar && modes.count(VD))
+                            has_conflict = true;
+                    }
+                }
+                for (const Stmt *Child : S->children())
+                    checkRefs(Child);
+            };
+            checkRefs(InitStmt);
+            if (has_conflict) {
+                modes.erase(PtrVar);
+                break;
+            }
+        }
+    }
+}
+
+// Step 6.
+//
+// Note the asymmetry between the two groups, which is longstanding behavior
+// and is preserved verbatim: `modes` is consulted for `rest` and not for
+// `param_bounded`. transformPointerVar re-validates the pointer itself, so a
+// param-bounded pointer still cannot be rewritten against a failing verdict —
+// but it *can* be rewritten after rejectStaleOffsets dropped it, since that
+// step's reason is not one validation can see.
+void FunctionAccessAnalyzer::emitPointerRewrites(
+    const FunctionDecl *FD, FunctionAnalysis &analysis,
+    const TransformModeMap &modes, const EditOrder &order, ASTContext &Ctx) {
+    for (const VarDecl *PtrVar : order.param_bounded) {
+        auto &access_list = analysis.accesses[PtrVar];
+        auto &candidate = analysis.tracked_pointers[PtrVar];
+        transformPointerVar(FD, PtrVar, candidate, access_list, Ctx);
+    }
+
+    for (const VarDecl *PtrVar : order.rest) {
+        if (modes.find(PtrVar) == modes.end())
+            continue;
+        auto &access_list = analysis.accesses[PtrVar];
+        auto &candidate = analysis.tracked_pointers[PtrVar];
+        transformPointerVar(FD, PtrVar, candidate, access_list, Ctx);
+    }
+}
+
+void FunctionAccessAnalyzer::transformFunction(const FunctionDecl *FD,
+                                               FunctionAnalysis &analysis,
+                                               ASTContext &Ctx) {
+    assignIndexNamesInSourceOrder(analysis, Ctx);
+
+    EditOrder order = pointersInEditOrder(FD, analysis);
+
+    TransformModeMap modes = decideTransformModes(analysis, Ctx);
+
+    resolveCrossPointerComparisons(analysis, modes, Ctx);
+
+    rejectStaleOffsets(analysis, modes, Ctx);
+
+    emitPointerRewrites(FD, analysis, modes, order, Ctx);
+}
 
 void FunctionAccessAnalyzer::transformAllFunctions(ASTContext &Ctx) {
     for (auto &[FDCanon, analysis] : g_function_analyses) {
@@ -199,203 +449,11 @@ void FunctionAccessAnalyzer::transformAllFunctions(ASTContext &Ctx) {
         if (!FD || !FD->hasBody())
             continue;
 
+        // Overlap tracking is per function: the ranges recorded while
+        // rewriting one function say nothing about the next.
         m_edited_ranges.clear();
 
-        // Name every index up front, in source order so the assignment is
-        // reproducible. Sorting by location rather than iterating the map
-        // matters: the map is keyed by VarDecl address, which is
-        // allocation order and not a property of the source.
-        {
-            SourceManager &SM = Ctx.getSourceManager();
-            std::vector<const VarDecl *> ptrs;
-            for (const auto &pair : analysis.accesses)
-                ptrs.push_back(pair.first);
-            std::sort(ptrs.begin(), ptrs.end(),
-                      [&](const VarDecl *A, const VarDecl *B) {
-                          return SM.isBeforeInTranslationUnit(A->getLocation(),
-                                                              B->getLocation());
-                      });
-            assignIndexNames(ptrs);
-        }
-
-        // Two-pass edit ordering: pointers whose bound comparison
-        // resolves against a parameter are rewritten first, so that when
-        // two pointers' comparison rewrites overlap, the param-bounded
-        // form wins (overlapping later edits are dropped in applyEdits).
-        std::vector<const VarDecl *> rust_slice_candidates;
-        std::vector<const VarDecl *> other_pointers;
-
-        for (auto &pair : analysis.accesses) {
-            const VarDecl *PtrVar = pair.first;
-            auto &candidate = analysis.tracked_pointers[PtrVar];
-            auto &access_list = pair.second;
-
-            bool is_rs_candidate = false;
-            if (!candidate.is_parameter && FD->getNumParams() > 0) {
-                bool base_is_param = false;
-                for (unsigned i = 0; i < FD->getNumParams(); i++) {
-                    if (FD->getParamDecl(i)->getNameAsString() == candidate.base_array_text &&
-                        FD->getParamDecl(i)->getType()->isPointerType()) {
-                        base_is_param = true;
-                        break;
-                    }
-                }
-                if (base_is_param) {
-                    for (const auto &acc : access_list) {
-                        if (acc.kind == PointerAccessKind::ComparisonExpr) {
-                            is_rs_candidate = true;
-                            break;
-                        }
-                    }
-                }
-            }
-
-            if (is_rs_candidate)
-                rust_slice_candidates.push_back(PtrVar);
-            else
-                other_pointers.push_back(PtrVar);
-        }
-
-        // Pre-validation: determine which pointers will actually be
-        // transformed so that cross-pointer comparisons can be resolved.
-        std::set<const VarDecl *> will_transform;
-        for (auto &pair : analysis.accesses) {
-            const VarDecl *PtrVar = pair.first;
-            auto &candidate = analysis.tracked_pointers[PtrVar];
-            auto &access_list = pair.second;
-            std::string error;
-            if (validatePointerCandidate(PtrVar, candidate, access_list, Ctx, error))
-                will_transform.insert(PtrVar);
-        }
-
-        // Fix up ComparisonExpr accesses that reference another pointer
-        // which will also be transformed. Replace operand_text with the
-        // reconstructed pointer form: other_base + other_name_index.
-        for (auto &pair : analysis.accesses) {
-            const VarDecl *PtrVar = pair.first;
-            auto &candidate = analysis.tracked_pointers[PtrVar];
-            if (will_transform.find(PtrVar) == will_transform.end())
-                continue;
-            for (auto &acc : pair.second) {
-                if (acc.kind != PointerAccessKind::ComparisonExpr)
-                    continue;
-                // Check if operand_text is "(other - base)" pattern
-                // and the other is also being transformed
-                if (!acc.field_name.empty() &&
-                    acc.field_name != candidate.base_array_text)
-                    continue; // shape-5 param reconstruction; leave alone
-                // (pointer-form equality records — field_name == base —
-                // fall through: their operand still names the other
-                // pointer and must be reconstructed below if that
-                // pointer is transformed too)
-                // Look for the other pointer in the comparison's parent
-                const Stmt *P = skipTransparentParents(acc.expr, Ctx);
-                const BinaryOperator *BO = P ? dyn_cast<BinaryOperator>(P) : nullptr;
-                if (!BO) continue;
-                const Expr *LHS = BO->getLHS()->IgnoreParenImpCasts();
-                const Expr *RHS = BO->getRHS()->IgnoreParenImpCasts();
-                const Expr *OtherSide = nullptr;
-                if (const DeclRefExpr *LDRE = dyn_cast<DeclRefExpr>(LHS)) {
-                    if (LDRE->getDecl() == PtrVar) OtherSide = RHS;
-                }
-                if (!OtherSide) {
-                    if (const DeclRefExpr *RDRE = dyn_cast<DeclRefExpr>(RHS)) {
-                        if (RDRE->getDecl() == PtrVar) OtherSide = LHS;
-                    }
-                }
-                if (!OtherSide) continue;
-                // Walk through OtherSide to find a DeclRefExpr to a transformed pointer
-                // Handle both direct refs (e.g., `e`) and expressions (e.g., `buf + len`)
-                const DeclRefExpr *OtherDRE = dyn_cast<DeclRefExpr>(OtherSide);
-                if (!OtherDRE) {
-                    // Try to find the pointer in a BinaryOperator (e.g., arr + n)
-                    if (const BinaryOperator *AddBO = dyn_cast<BinaryOperator>(OtherSide)) {
-                        OtherDRE = dyn_cast<DeclRefExpr>(AddBO->getLHS()->IgnoreParenImpCasts());
-                    }
-                }
-                if (!OtherDRE) continue;
-                const VarDecl *OtherVD = dyn_cast<VarDecl>(OtherDRE->getDecl());
-                if (!OtherVD || will_transform.find(OtherVD) == will_transform.end())
-                    continue;
-                // Both pointers will be transformed. Use pointer reconstruction:
-                // base + index <op> other_base + other_index
-                auto &other_cand = analysis.tracked_pointers[OtherVD];
-                std::string other_base = other_cand.base_array_text;
-                std::string other_idx = indexNameFor(OtherVD);
-                std::string rhs = other_base.empty() ?
-                    other_idx : other_base + " + " + other_idx;
-                acc.field_name = candidate.base_array_text;
-                acc.operand_text = rhs;
-            }
-        }
-
-        // Reject pointers whose init/assign offset references another
-        // pointer that will also be transformed. The init edit would use
-        // stale source text for the offset, conflicting with the inner
-        // pointer's transformation.
-        for (auto &pair : analysis.accesses) {
-            const VarDecl *PtrVar = pair.first;
-            if (will_transform.find(PtrVar) == will_transform.end())
-                continue;
-            for (const auto &acc : pair.second) {
-                if (acc.kind != PointerAccessKind::InitArrayOffset &&
-                    acc.kind != PointerAccessKind::AssignAddrOf &&
-                    acc.kind != PointerAccessKind::AssignArrayOffset)
-                    continue;
-                // Check if any other transformed pointer appears in the
-                // init expression's subtree
-                const Stmt *InitStmt = acc.enclosing_stmt;
-                if (!InitStmt) {
-                    // For declarations, use the VarDecl's init
-                    if (PtrVar->hasInit())
-                        InitStmt = PtrVar->getInit();
-                }
-                if (!InitStmt && acc.expr) {
-                    // For separate assignments (AssignAddrOf, AssignArrayOffset),
-                    // walk up from the DeclRefExpr to find the BinaryOperator
-                    // and check its RHS for references to other transformed ptrs
-                    const Stmt *P = skipTransparentParents(acc.expr, Ctx);
-                    if (const BinaryOperator *BO = dyn_cast_or_null<BinaryOperator>(P))
-                        InitStmt = BO->getRHS();
-                }
-                if (!InitStmt) continue;
-                bool has_conflict = false;
-                // Walk the init to find DeclRefExprs to other transformed pointers
-                std::function<void(const Stmt *)> checkRefs = [&](const Stmt *S) {
-                    if (has_conflict || !S) return;
-                    if (const DeclRefExpr *DRE = dyn_cast<DeclRefExpr>(S)) {
-                        if (const VarDecl *VD = dyn_cast<VarDecl>(DRE->getDecl())) {
-                            if (VD != PtrVar && will_transform.count(VD))
-                                has_conflict = true;
-                        }
-                    }
-                    for (const Stmt *Child : S->children())
-                        checkRefs(Child);
-                };
-                checkRefs(InitStmt);
-                if (has_conflict) {
-                    will_transform.erase(PtrVar);
-                    break;
-                }
-            }
-        }
-
-        // First pass: param-bounded pointers
-        for (const VarDecl *PtrVar : rust_slice_candidates) {
-            auto &access_list = analysis.accesses[PtrVar];
-            auto &candidate = analysis.tracked_pointers[PtrVar];
-            transformPointerVar(FD, PtrVar, candidate, access_list, Ctx);
-        }
-
-        // Second pass: remaining pointers. Skip pointers removed from
-        // will_transform by init conflict detection.
-        for (const VarDecl *PtrVar : other_pointers) {
-            auto &access_list = analysis.accesses[PtrVar];
-            auto &candidate = analysis.tracked_pointers[PtrVar];
-            if (will_transform.find(PtrVar) == will_transform.end())
-                continue;
-            transformPointerVar(FD, PtrVar, candidate, access_list, Ctx);
-        }
+        transformFunction(FD, analysis, Ctx);
     }
 }
 
@@ -463,7 +521,8 @@ void FunctionAccessAnalyzer::transformPointerVar(const FunctionDecl *FD,
     printAccesses(PtrVar, accesses, Ctx);
 
     std::string error;
-    if (!validatePointerCandidate(PtrVar, candidate, accesses, Ctx, error)) {
+    if (validatePointerCandidate(PtrVar, candidate, accesses, Ctx, error) ==
+        TransformMode::Reject) {
         gLog.error = error;
         logFailedPointer(PtrVar, Ctx, error);
         if (VERBOSE)

--- a/xj-prepare-pointertransform/FunctionAccessAnalyzer.cpp
+++ b/xj-prepare-pointertransform/FunctionAccessAnalyzer.cpp
@@ -401,18 +401,17 @@ void FunctionAccessAnalyzer::rejectStaleOffsets(FunctionAnalysis &analysis,
     }
 }
 
-// Step 6.
-//
-// Note the asymmetry between the two groups, which is longstanding behavior
-// and is preserved verbatim: `modes` is consulted for `rest` and not for
-// `param_bounded`. transformPointerVar re-validates the pointer itself, so a
-// param-bounded pointer still cannot be rewritten against a failing verdict —
-// but it *can* be rewritten after rejectStaleOffsets dropped it, since that
-// step's reason is not one validation can see.
+// Step 6. Both groups consult the verdict. transformPointerVar re-validates,
+// which catches a pointer validation itself rejected — but not one that
+// rejectStaleOffsets dropped, because that step's reason (a conflict with
+// another pointer's rewrite) is not a fact validation can see. The map is the
+// only place that knowledge lives.
 void FunctionAccessAnalyzer::emitPointerRewrites(
     const FunctionDecl *FD, FunctionAnalysis &analysis,
     const TransformModeMap &modes, const EditOrder &order, ASTContext &Ctx) {
     for (const VarDecl *PtrVar : order.param_bounded) {
+        if (modes.find(PtrVar) == modes.end())
+            continue;
         auto &access_list = analysis.accesses[PtrVar];
         auto &candidate = analysis.tracked_pointers[PtrVar];
         transformPointerVar(FD, PtrVar, candidate, access_list, Ctx);

--- a/xj-prepare-pointertransform/FunctionAccessAnalyzer.h
+++ b/xj-prepare-pointertransform/FunctionAccessAnalyzer.h
@@ -52,10 +52,9 @@ using TransformModeMap = std::map<const VarDecl *, TransformMode>;
 // rewrites overlap, the param-bounded form wins — applyEdits drops the
 // later of two overlapping edits.
 //
-// The two groups stay separate because they are not treated alike at
-// rewrite time: the verdict map is consulted for `rest` and not for
-// `param_bounded`. That asymmetry is longstanding behavior, preserved
-// here verbatim rather than quietly unified.
+// The two groups differ only in when they are rewritten; both are filtered
+// through the verdict map alike. They stay separate structurally so the
+// ordering rule above has somewhere to live.
 struct EditOrder {
     std::vector<const VarDecl *> param_bounded;
     std::vector<const VarDecl *> rest;

--- a/xj-prepare-pointertransform/FunctionAccessAnalyzer.h
+++ b/xj-prepare-pointertransform/FunctionAccessAnalyzer.h
@@ -23,6 +23,44 @@
 // runs on this tool's output (valid, index-rewritten C) plus the
 // per-pointer metadata records.
 
+// How a pointer will be rewritten, decided by validatePointerCandidate.
+//
+//   Reject   — nothing about this pointer is rewritten.
+//   Collapse — the pointer variable is deleted and every access becomes
+//              `<base source text>[p_index]`. The base is a *syntactic*
+//              fact re-substituted at each access site, so it has to be
+//              textually valid and stable across the whole function.
+//
+// Two values today, so this is exactly the boolean the validator used to
+// return. It is an enum because the verdict is about to gain a third
+// answer, and a bool cannot carry one.
+enum class TransformMode { Reject, Collapse };
+
+// Pointers that will be transformed, and how.
+//
+// This is the single authority on both questions: membership means "will
+// be transformed", and the mapped value is how. Keeping the two together
+// is deliberate — a set of pointers riding alongside a separate map of
+// modes can fall out of step, and then a pointer dropped from one but
+// left in the other is rewritten after having been rejected.
+using TransformModeMap = std::map<const VarDecl *, TransformMode>;
+
+// The order pointers are rewritten in, split by whether their bound
+// comparison resolves against a parameter.
+//
+// Param-bounded pointers go first so that when two pointers' comparison
+// rewrites overlap, the param-bounded form wins — applyEdits drops the
+// later of two overlapping edits.
+//
+// The two groups stay separate because they are not treated alike at
+// rewrite time: the verdict map is consulted for `rest` and not for
+// `param_bounded`. That asymmetry is longstanding behavior, preserved
+// here verbatim rather than quietly unified.
+struct EditOrder {
+    std::vector<const VarDecl *> param_bounded;
+    std::vector<const VarDecl *> rest;
+};
+
 class FunctionAccessAnalyzer : public MatchFinder::MatchCallback {
   public:
     explicit FunctionAccessAnalyzer(Rewriter &R);
@@ -60,11 +98,11 @@ class FunctionAccessAnalyzer : public MatchFinder::MatchCallback {
                        ASTContext &Ctx);
 
     // Defined in ValidationMethods.cpp.
-    bool validatePointerCandidate(const VarDecl *PtrVar,
-                                  PointerCandidate &candidate,
-                                  std::vector<PointerAccess> &accesses,
-                                  ASTContext &Ctx,
-                                  std::string &error);
+    TransformMode validatePointerCandidate(const VarDecl *PtrVar,
+                                           PointerCandidate &candidate,
+                                           std::vector<PointerAccess> &accesses,
+                                           ASTContext &Ctx,
+                                           std::string &error);
 
     // Defined in TransformationMethods.cpp.
     // generateTransformation: rewrite a single local pointer in place.
@@ -86,7 +124,31 @@ class FunctionAccessAnalyzer : public MatchFinder::MatchCallback {
     void applyEdits(std::vector<Edit> &edits, SourceManager &SM);
 
     // ---- Cross-function transformation phase --------------------------
+    // transformAllFunctions walks every analyzed function; transformFunction
+    // runs the rewrite pipeline for one of them. The pipeline steps below
+    // are members because they need validatePointerCandidate or
+    // transformPointerVar; the remaining steps are file-static helpers in
+    // FunctionAccessAnalyzer.cpp.
     void transformAllFunctions(ASTContext &Ctx);
+    void transformFunction(const FunctionDecl *FD, FunctionAnalysis &analysis,
+                           ASTContext &Ctx);
+
+    // Judge every pointer, into the mode it will be rewritten in. Pointers
+    // that cannot be rewritten at all are simply absent from the map, so
+    // membership answers "will this be transformed" and the mapped value
+    // answers "how" — one container rather than a set and a mode that can
+    // fall out of step.
+    TransformModeMap decideTransformModes(FunctionAnalysis &analysis,
+                                          ASTContext &Ctx);
+
+    // Drop pointers whose pasted offset text the rewrite would invalidate.
+    void rejectStaleOffsets(FunctionAnalysis &analysis, TransformModeMap &modes,
+                            ASTContext &Ctx);
+
+    // Rewrite the pointers in `order` that survived into `modes`.
+    void emitPointerRewrites(const FunctionDecl *FD, FunctionAnalysis &analysis,
+                             const TransformModeMap &modes,
+                             const EditOrder &order, ASTContext &Ctx);
 
     // ---- Metadata export for xj-prepare-slicetransform ----------------
     // Look up (or create) the metadata record for FD; nullptr when a

--- a/xj-prepare-pointertransform/ValidationMethods.cpp
+++ b/xj-prepare-pointertransform/ValidationMethods.cpp
@@ -27,7 +27,7 @@ static const DeclRefExpr *findRefToBound(const Stmt *S,
     return nullptr;
 }
 
-bool FunctionAccessAnalyzer::validatePointerCandidate(
+TransformMode FunctionAccessAnalyzer::validatePointerCandidate(
     const VarDecl *PtrVar,
     PointerCandidate &candidate,
     std::vector<PointerAccess> &accesses,
@@ -36,7 +36,7 @@ bool FunctionAccessAnalyzer::validatePointerCandidate(
 
     if (accesses.empty()) {
         error = "No accesses found";
-        return false;
+        return TransformMode::Reject;
     }
 
     // Any single Unknown access disqualifies the pointer — it means the
@@ -44,7 +44,7 @@ bool FunctionAccessAnalyzer::validatePointerCandidate(
     for (const auto &access : accesses) {
         if (access.kind == PointerAccessKind::Unknown) {
             error = "Unknown access pattern";
-            return false;
+            return TransformMode::Reject;
         }
     }
 
@@ -53,7 +53,7 @@ bool FunctionAccessAnalyzer::validatePointerCandidate(
     for (const auto &access : accesses) {
         if (access.kind == PointerAccessKind::AddressOf) {
             error = "Pointer address taken (&p)";
-            return false;
+            return TransformMode::Reject;
         }
     }
 
@@ -62,7 +62,7 @@ bool FunctionAccessAnalyzer::validatePointerCandidate(
     for (const auto &access : accesses) {
         if (access.kind == PointerAccessKind::Comparison) {
             error = "Pointer used in unresolvable comparison";
-            return false;
+            return TransformMode::Reject;
         }
     }
 
@@ -71,7 +71,7 @@ bool FunctionAccessAnalyzer::validatePointerCandidate(
     // *(p - 1) are fine — they were folded into min/max_relative_offset.
     if (!candidate.constant_offsets) {
         error = "Pointer has non-constant dereference offset";
-        return false;
+        return TransformMode::Reject;
     }
 
     // Require at least one mutation (++/--/+=/-=) or one indexed
@@ -115,7 +115,7 @@ bool FunctionAccessAnalyzer::validatePointerCandidate(
 
     if (!has_mutation && !has_array_assignment) {
         error = "No array-like usage (no mutations or indexed assignments)";
-        return false;
+        return TransformMode::Reject;
     }
 
     // Beyond mutation, also require at least one *use* of the value
@@ -150,7 +150,7 @@ bool FunctionAccessAnalyzer::validatePointerCandidate(
     }
     if (!has_meaningful_use && !has_mutation) {
         error = "Pointer never dereferenced or used (only init + comparison)";
-        return false;
+        return TransformMode::Reject;
     }
 
     // Reject type-punning casts. e.g. `float *p = (float *)int_buf;`
@@ -171,7 +171,7 @@ bool FunctionAccessAnalyzer::validatePointerCandidate(
             error = "Pointer pointee type (" + ptrPointee.getAsString() +
                 ") differs from base array element type (" +
                 baseElem.getAsString() + ")";
-            return false;
+            return TransformMode::Reject;
         }
     }
 
@@ -202,7 +202,7 @@ bool FunctionAccessAnalyzer::validatePointerCandidate(
             }
             if (has_write) {
                 error = "Pointer writes through const-qualified base";
-                return false;
+                return TransformMode::Reject;
             }
         }
     }
@@ -215,7 +215,7 @@ bool FunctionAccessAnalyzer::validatePointerCandidate(
         size_t paren_pos = candidate.base_array_text.find('(');
         if (paren_pos != std::string::npos && paren_pos > 0) {
             error = "Base array is a function call return value";
-            return false;
+            return TransformMode::Reject;
         }
     }
 
@@ -354,13 +354,13 @@ bool FunctionAccessAnalyzer::validatePointerCandidate(
                 error = "Base expression '" + base_text +
                         "' depends on '" + finder.mutated_lhs +
                         "', which is mutated within the function";
-                return false;
+                return TransformMode::Reject;
             }
             if (finder.addr_escaped) {
                 error = "Base expression '" + base_text +
                         "' has its address taken via '&" + finder.escaped_text +
                         "', so it may be mutated indirectly within the function";
-                return false;
+                return TransformMode::Reject;
             }
         }
     }
@@ -384,7 +384,7 @@ bool FunctionAccessAnalyzer::validatePointerCandidate(
         }
         if (access.loc.isMacroID()) {
             error = "Pointer used inside macro expansion";
-            return false;
+            return TransformMode::Reject;
         }
     }
 
@@ -414,7 +414,7 @@ bool FunctionAccessAnalyzer::validatePointerCandidate(
     {
         error = "Parameter reseated to a different base array (incoming "
                 "argument is an uncaptured second base)";
-        return false;
+        return TransformMode::Reject;
     }
 
     // If we still don't have a base, the only salvageable case is a
@@ -434,7 +434,7 @@ bool FunctionAccessAnalyzer::validatePointerCandidate(
             candidate.base_array_text = PtrVar->getNameAsString();
         } else {
             error = "Could not determine base array";
-            return false;
+            return TransformMode::Reject;
         }
     }
 
@@ -465,11 +465,11 @@ bool FunctionAccessAnalyzer::validatePointerCandidate(
                         Ref->getDecl()->getNameAsString() +
                         "', declared in the same for-init, so it cannot be "
                         "hoisted out of the loop header";
-                return false;
+                return TransformMode::Reject;
             }
         }
     }
 
     gLog.foundPointer = true;
-    return true;
+    return TransformMode::Collapse;
 }


### PR DESCRIPTION
Clanker sez:

> transformAllFunctions had grown to hold the whole per-function rewrite in one 205-line body. The steps were already there, marked out by comments; this gives them names and signatures and nothing else. Same steps, same order:
> 
>   1. assignIndexNamesInSourceOrder  name every index before anything reads one
>   2. pointersInEditOrder            decide the order rewrites are emitted in
>   3. decideTransformModes           judge each pointer
>   4. resolveCrossPointerComparisons restate comparisons naming another pointer
>   5. rejectStaleOffsets             drop pointers whose pasted offset would rot
>   6. emitPointerRewrites            rewrite the survivors
> 
> The verdict container changes shape with them. `validatePointerCandidate` returned a bool and its answer was accumulated into a `std::set<const VarDecl *> will_transform`; it now returns
> 
>     enum class TransformMode { Reject, Collapse };
> 
> and the accumulator is a `TransformModeMap`, keyed the same way. Two values is exactly the boolean that was there before, so this is not a behavior change. It is an enum because the verdict is about to gain a third answer, and because a set of pointers riding alongside a separate map of modes is a shape that can fall out of step — a pointer dropped from one and left in the other gets rewritten after having been rejected. Keeping membership and mode in one container makes that unrepresentable rather than merely avoided.
> 
> Two asymmetries are preserved verbatim rather than tidied away, because tidying either would change behavior:
> 
>   - emitPointerRewrites consults the verdict map for `rest` and not for `param_bounded`. transformPointerVar re-validates, so a param-bounded pointer still cannot be rewritten against a failing verdict — but it can be rewritten after rejectStaleOffsets dropped it, since that step's reason is not one validation can see. EditOrder keeps the two groups apart so this stays visible.
>   - transformPointerVar still re-validates rather than being handed the mode already decided in step 3.
> 
> Verification: `10j pytest tests -n auto` gives 124 passed / 245 skipped, identical to main, and **not one file under tests/ changes**. That is the whole claim of this PR.