### PR TITLE
Pointer xform multilevel aggregates

### DIFF
--- a/tests/pointer_transform/pointer_transform_cases/anon_aggregate_fields/expected/anon_aggregate_fields.c
+++ b/tests/pointer_transform/pointer_transform_cases/anon_aggregate_fields/expected/anon_aggregate_fields.c
@@ -1,0 +1,72 @@
+#include <stdio.h>
+
+/* Mirrors md4c's MD_MARK: an anonymous struct nested inside an
+ * anonymous union.  Clang represents `m->beg` as three chained
+ * MemberExprs sharing one source range (anon union -> anon struct ->
+ * beg), so a rewriter that walks out only a single anonymous level
+ * loses the field name and emits a dangling "marks[i].".
+ *
+ * `tag` covers the single-anonymous-level path alongside it, and `ch`
+ * is an ordinary named field that needs no walking at all. */
+typedef struct Mark_tag Mark;
+struct Mark_tag {
+    union {
+        struct {
+            unsigned beg;
+            unsigned end;
+        };
+        void* pointer;      /* dummy marks can store a pointer instead */
+    };
+    union {
+        unsigned tag;
+    };
+    char ch;
+};
+
+struct Ctx {
+    Mark* marks;
+    int n_marks;
+};
+
+static unsigned sum_spans(struct Ctx* ctx) {
+    int m_index_xj = 0;
+    unsigned total = 0;
+
+    for (m_index_xj = 0; m_index_xj < ctx->n_marks; m_index_xj++) {
+        total += (ctx->marks)[m_index_xj].end - (ctx->marks)[m_index_xj].beg;   /* two anonymous levels */
+        total += (ctx->marks)[m_index_xj].tag;            /* one anonymous level */
+        total += (unsigned)(ctx->marks)[m_index_xj].ch;   /* named field, no levels */
+    }
+    return total;
+}
+
+/* Writes through the doubly-nested fields, so the ArrowWrite path is
+ * exercised as well as the read path. */
+static void widen(struct Ctx* ctx) {
+    int m_index_xj = 0;
+
+    for (m_index_xj = 0; m_index_xj < ctx->n_marks; m_index_xj++) {
+        (ctx->marks)[m_index_xj].end++;
+        (ctx->marks)[m_index_xj].beg--;
+    }
+}
+
+int main(void) {
+    Mark marks[3];
+    struct Ctx ctx;
+    int i;
+
+    for (i = 0; i < 3; i++) {
+        marks[i].beg = (unsigned)(i + 1);
+        marks[i].end = (unsigned)(i * 3 + 5);
+        marks[i].tag = (unsigned)(i + 1);
+        marks[i].ch = (char)('a' + i);
+    }
+    ctx.marks = marks;
+    ctx.n_marks = 3;
+
+    printf("%u\n", sum_spans(&ctx));
+    widen(&ctx);
+    printf("%u\n", sum_spans(&ctx));
+    return 0;
+}

--- a/tests/pointer_transform/pointer_transform_cases/anon_aggregate_fields/expected_metadata.json
+++ b/tests/pointer_transform/pointer_transform_cases/anon_aggregate_fields/expected_metadata.json
@@ -1,0 +1,26 @@
+{
+  "functions": {
+    "sum_spans@anon_aggregate_fields.c": {
+      "file": "anon_aggregate_fields.c",
+      "pointers": [
+        {
+          "base_text": "ctx->marks",
+          "index_var": "m_index_xj",
+          "name": "m",
+          "param_index": -1
+        }
+      ]
+    },
+    "widen@anon_aggregate_fields.c": {
+      "file": "anon_aggregate_fields.c",
+      "pointers": [
+        {
+          "base_text": "ctx->marks",
+          "index_var": "m_index_xj",
+          "name": "m",
+          "param_index": -1
+        }
+      ]
+    }
+  }
+}

--- a/tests/pointer_transform/pointer_transform_cases/anon_aggregate_fields/expected_ptr/anon_aggregate_fields.c
+++ b/tests/pointer_transform/pointer_transform_cases/anon_aggregate_fields/expected_ptr/anon_aggregate_fields.c
@@ -1,0 +1,72 @@
+#include <stdio.h>
+
+/* Mirrors md4c's MD_MARK: an anonymous struct nested inside an
+ * anonymous union.  Clang represents `m->beg` as three chained
+ * MemberExprs sharing one source range (anon union -> anon struct ->
+ * beg), so a rewriter that walks out only a single anonymous level
+ * loses the field name and emits a dangling "marks[i].".
+ *
+ * `tag` covers the single-anonymous-level path alongside it, and `ch`
+ * is an ordinary named field that needs no walking at all. */
+typedef struct Mark_tag Mark;
+struct Mark_tag {
+    union {
+        struct {
+            unsigned beg;
+            unsigned end;
+        };
+        void* pointer;      /* dummy marks can store a pointer instead */
+    };
+    union {
+        unsigned tag;
+    };
+    char ch;
+};
+
+struct Ctx {
+    Mark* marks;
+    int n_marks;
+};
+
+static unsigned sum_spans(struct Ctx* ctx) {
+    int m_index_xj = 0;
+    unsigned total = 0;
+
+    for (m_index_xj = 0; m_index_xj < ctx->n_marks; m_index_xj++) {
+        total += (ctx->marks)[m_index_xj].end - (ctx->marks)[m_index_xj].beg;   /* two anonymous levels */
+        total += (ctx->marks)[m_index_xj].tag;            /* one anonymous level */
+        total += (unsigned)(ctx->marks)[m_index_xj].ch;   /* named field, no levels */
+    }
+    return total;
+}
+
+/* Writes through the doubly-nested fields, so the ArrowWrite path is
+ * exercised as well as the read path. */
+static void widen(struct Ctx* ctx) {
+    int m_index_xj = 0;
+
+    for (m_index_xj = 0; m_index_xj < ctx->n_marks; m_index_xj++) {
+        (ctx->marks)[m_index_xj].end++;
+        (ctx->marks)[m_index_xj].beg--;
+    }
+}
+
+int main(void) {
+    Mark marks[3];
+    struct Ctx ctx;
+    int i;
+
+    for (i = 0; i < 3; i++) {
+        marks[i].beg = (unsigned)(i + 1);
+        marks[i].end = (unsigned)(i * 3 + 5);
+        marks[i].tag = (unsigned)(i + 1);
+        marks[i].ch = (char)('a' + i);
+    }
+    ctx.marks = marks;
+    ctx.n_marks = 3;
+
+    printf("%u\n", sum_spans(&ctx));
+    widen(&ctx);
+    printf("%u\n", sum_spans(&ctx));
+    return 0;
+}

--- a/tests/pointer_transform/pointer_transform_cases/anon_aggregate_fields/input/anon_aggregate_fields.c
+++ b/tests/pointer_transform/pointer_transform_cases/anon_aggregate_fields/input/anon_aggregate_fields.c
@@ -1,0 +1,72 @@
+#include <stdio.h>
+
+/* Mirrors md4c's MD_MARK: an anonymous struct nested inside an
+ * anonymous union.  Clang represents `m->beg` as three chained
+ * MemberExprs sharing one source range (anon union -> anon struct ->
+ * beg), so a rewriter that walks out only a single anonymous level
+ * loses the field name and emits a dangling "marks[i].".
+ *
+ * `tag` covers the single-anonymous-level path alongside it, and `ch`
+ * is an ordinary named field that needs no walking at all. */
+typedef struct Mark_tag Mark;
+struct Mark_tag {
+    union {
+        struct {
+            unsigned beg;
+            unsigned end;
+        };
+        void* pointer;      /* dummy marks can store a pointer instead */
+    };
+    union {
+        unsigned tag;
+    };
+    char ch;
+};
+
+struct Ctx {
+    Mark* marks;
+    int n_marks;
+};
+
+static unsigned sum_spans(struct Ctx* ctx) {
+    Mark* m;
+    unsigned total = 0;
+
+    for (m = ctx->marks; m < ctx->marks + ctx->n_marks; m++) {
+        total += m->end - m->beg;   /* two anonymous levels */
+        total += m->tag;            /* one anonymous level */
+        total += (unsigned)m->ch;   /* named field, no levels */
+    }
+    return total;
+}
+
+/* Writes through the doubly-nested fields, so the ArrowWrite path is
+ * exercised as well as the read path. */
+static void widen(struct Ctx* ctx) {
+    Mark* m;
+
+    for (m = ctx->marks; m < ctx->marks + ctx->n_marks; m++) {
+        m->end++;
+        m->beg--;
+    }
+}
+
+int main(void) {
+    Mark marks[3];
+    struct Ctx ctx;
+    int i;
+
+    for (i = 0; i < 3; i++) {
+        marks[i].beg = (unsigned)(i + 1);
+        marks[i].end = (unsigned)(i * 3 + 5);
+        marks[i].tag = (unsigned)(i + 1);
+        marks[i].ch = (char)('a' + i);
+    }
+    ctx.marks = marks;
+    ctx.n_marks = 3;
+
+    printf("%u\n", sum_spans(&ctx));
+    widen(&ctx);
+    printf("%u\n", sum_spans(&ctx));
+    return 0;
+}

--- a/xj-prepare-pointertransform/PointerAccessCollector.cpp
+++ b/xj-prepare-pointertransform/PointerAccessCollector.cpp
@@ -10,7 +10,8 @@ PointerAccessCollector::PointerAccessCollector(ASTContext &Ctx)
 // True if `E` is one of the recognized null-pointer spellings: a 0
 // literal, the GNU __null builtin, or a cast wrapping one of those
 // (e.g. ((void*)0)).
-bool PointerAccessCollector::isNullExpr(const Expr *E) {
+bool PointerAccessCollector::isNullExpr(const Expr *E)
+{
     E = E->IgnoreParenImpCasts();
     if (const IntegerLiteral *IL = dyn_cast<IntegerLiteral>(E))
         return IL->getValue() == 0;
@@ -40,37 +41,49 @@ bool PointerAccessCollector::isNullExpr(const Expr *E) {
 //
 // Returns true if the expression is unsafe; the caller should emit
 // PointerAccessKind::Unknown instead of capturing the base.
-static bool baseIsUnsafe(const Expr *E, bool is_global) {
-    if (!E) return false;
+static bool baseIsUnsafe(const Expr *E, bool is_global)
+{
+    if (!E)
+        return false;
 
-    struct Walker : public RecursiveASTVisitor<Walker> {
+    struct Walker : public RecursiveASTVisitor<Walker>
+    {
         bool is_global;
         bool unsafe = false;
 
         explicit Walker(bool g) : is_global(g) {}
 
-        bool VisitUnaryOperator(UnaryOperator *UO) {
-            if (UO->isIncrementDecrementOp()) {
+        bool VisitUnaryOperator(UnaryOperator *UO)
+        {
+            if (UO->isIncrementDecrementOp())
+            {
                 unsafe = true;
                 return false;
             }
             return true;
         }
-        bool VisitBinaryOperator(BinaryOperator *BO) {
-            if (BO->isAssignmentOp() || BO->getOpcode() == BO_Comma) {
+        bool VisitBinaryOperator(BinaryOperator *BO)
+        {
+            if (BO->isAssignmentOp() || BO->getOpcode() == BO_Comma)
+            {
                 unsafe = true;
                 return false;
             }
             return true;
         }
-        bool VisitCallExpr(CallExpr *) {
+        bool VisitCallExpr(CallExpr *)
+        {
             unsafe = true;
             return false;
         }
-        bool VisitDeclRefExpr(DeclRefExpr *DRE) {
-            if (!is_global) return true;
-            if (const auto *VD = dyn_cast<VarDecl>(DRE->getDecl())) {
-                if (!VD->hasGlobalStorage()) {
+        bool VisitDeclRefExpr(DeclRefExpr *DRE)
+        {
+            if (!is_global)
+                return true;
+            if (const auto *VD = dyn_cast<VarDecl>(DRE->getDecl()))
+            {
+                if (!VD->hasGlobalStorage())
+                {
                     unsafe = true;
                     return false;
                 }
@@ -88,15 +101,17 @@ static bool baseIsUnsafe(const Expr *E, bool is_global) {
 // index expression out separately. Used when classifying initializers
 // like `int *p = &buf[3];`.
 bool PointerAccessCollector::isAddrOfSubscript(const Expr *E,
-                                                std::string &base_text,
-                                                std::string &index_text) {
+                                               std::string &base_text,
+                                               std::string &index_text)
+{
     E = E->IgnoreParenImpCasts();
     const UnaryOperator *UO = dyn_cast<UnaryOperator>(E);
     if (!UO || UO->getOpcode() != UO_AddrOf)
         return false;
 
     const Expr *Sub = UO->getSubExpr()->IgnoreParenImpCasts();
-    if (const ArraySubscriptExpr *ASE = dyn_cast<ArraySubscriptExpr>(Sub)) {
+    if (const ArraySubscriptExpr *ASE = dyn_cast<ArraySubscriptExpr>(Sub))
+    {
         base_text = getSourceText(ASE->getBase()->IgnoreParenImpCasts(), SM, LO);
         index_text = getSourceText(ASE->getIdx(), SM, LO);
         return true;
@@ -113,9 +128,10 @@ bool PointerAccessCollector::isAddrOfSubscript(const Expr *E,
 // pointer/array reference. Anything else falls through to Unknown,
 // which makes the pointer unsafe and will be rejected by validation.
 void PointerAccessCollector::analyzePointerInit(const Expr *Init,
-                                                 const VarDecl *PtrVar,
-                                                 PointerCandidate &candidate,
-                                                 std::vector<PointerAccess> &access_list) {
+                                                const VarDecl *PtrVar,
+                                                PointerCandidate &candidate,
+                                                std::vector<PointerAccess> &access_list)
+{
     if (!Init)
         return;
 
@@ -129,7 +145,8 @@ void PointerAccessCollector::analyzePointerInit(const Expr *Init,
         Init = CSCE->getSubExpr()->IgnoreParenImpCasts();
 
     // Case 1: NULL — no base array yet, will be encoded as -1.
-    if (isNullExpr(Init)) {
+    if (isNullExpr(Init))
+    {
         PointerAccess pa;
         pa.kind = PointerAccessKind::InitNull;
         pa.loc = Init->getBeginLoc();
@@ -141,7 +158,8 @@ void PointerAccessCollector::analyzePointerInit(const Expr *Init,
 
     bool is_global = PtrVar && PtrVar->hasGlobalStorage();
 
-    auto emitUnknown = [&](const Expr *E) {
+    auto emitUnknown = [&](const Expr *E)
+    {
         PointerAccess pa;
         pa.kind = PointerAccessKind::Unknown;
         pa.loc = E->getBeginLoc();
@@ -152,11 +170,13 @@ void PointerAccessCollector::analyzePointerInit(const Expr *Init,
 
     // Case 2: &arr[i] — base is arr, initial index is i.
     std::string base_text, index_text;
-    if (isAddrOfSubscript(Init, base_text, index_text)) {
+    if (isAddrOfSubscript(Init, base_text, index_text))
+    {
         const auto *UO = cast<UnaryOperator>(Init);
         const auto *ASE = cast<ArraySubscriptExpr>(UO->getSubExpr()->IgnoreParenImpCasts());
         if (baseIsUnsafe(ASE->getBase()->IgnoreParenImpCasts(), is_global) ||
-            baseIsUnsafe(ASE->getIdx(), is_global)) {
+            baseIsUnsafe(ASE->getIdx(), is_global))
+        {
             emitUnknown(Init);
             return;
         }
@@ -174,13 +194,17 @@ void PointerAccessCollector::analyzePointerInit(const Expr *Init,
     }
 
     // Case 3: arr + offset — pointer/array on the LHS of a +.
-    if (const BinaryOperator *BO = dyn_cast<BinaryOperator>(Init)) {
-        if (BO->getOpcode() == BO_Add) {
+    if (const BinaryOperator *BO = dyn_cast<BinaryOperator>(Init))
+    {
+        if (BO->getOpcode() == BO_Add)
+        {
             const Expr *LHS = BO->getLHS()->IgnoreParenImpCasts();
             const Expr *RHS = BO->getRHS()->IgnoreParenImpCasts();
 
-            if (LHS->getType()->isPointerType() || LHS->getType()->isArrayType()) {
-                if (baseIsUnsafe(LHS, is_global) || baseIsUnsafe(RHS, is_global)) {
+            if (LHS->getType()->isPointerType() || LHS->getType()->isArrayType())
+            {
+                if (baseIsUnsafe(LHS, is_global) || baseIsUnsafe(RHS, is_global))
+                {
                     emitUnknown(Init);
                     return;
                 }
@@ -201,8 +225,10 @@ void PointerAccessCollector::analyzePointerInit(const Expr *Init,
 
     // Case 4: bare pointer/array reference, e.g. `int *p = arr;` or
     // `char *p = bs->buf;`. The whole RHS becomes the base text.
-    if (Init->getType()->isPointerType() || Init->getType()->isArrayType()) {
-        if (baseIsUnsafe(Init, is_global)) {
+    if (Init->getType()->isPointerType() || Init->getType()->isArrayType())
+    {
+        if (baseIsUnsafe(Init, is_global))
+        {
             emitUnknown(Init);
             return;
         }
@@ -231,7 +257,8 @@ void PointerAccessCollector::analyzePointerInit(const Expr *Init,
 // it in `tracked_pointers`, and run the initializer (if any) through
 // analyzePointerInit. Uninitialized pointers are still tracked because
 // their base array may be set later by an assignment like `p = arr`.
-bool PointerAccessCollector::VisitVarDecl(VarDecl *VD) {
+bool PointerAccessCollector::VisitVarDecl(VarDecl *VD)
+{
     if (!VD->getType()->isPointerType())
         return true;
     if (SM.isInSystemHeader(VD->getLocation()))
@@ -247,7 +274,8 @@ bool PointerAccessCollector::VisitVarDecl(VarDecl *VD) {
 
     std::vector<PointerAccess> access_list;
 
-    if (VD->hasInit()) {
+    if (VD->hasInit())
+    {
         analyzePointerInit(VD->getInit(), VD, candidate, access_list);
     }
 
@@ -256,8 +284,8 @@ bool PointerAccessCollector::VisitVarDecl(VarDecl *VD) {
 
     if (VERBOSE)
         llvm::outs() << "[Collect] Tracking pointer: " << VD->getNameAsString()
-                      << (is_param ? " (parameter)" : " (local)")
-                      << " base=" << candidate.base_array_text << "\n";
+                     << (is_param ? " (parameter)" : " (local)")
+                     << " base=" << candidate.base_array_text << "\n";
 
     return true;
 }
@@ -265,7 +293,8 @@ bool PointerAccessCollector::VisitVarDecl(VarDecl *VD) {
 // Every reference to a tracked pointer flows through here. We skip the
 // reference inside the pointer's own initializer (already handled in
 // VisitVarDecl) and forward everything else to classifyAccess.
-bool PointerAccessCollector::VisitDeclRefExpr(DeclRefExpr *DRE) {
+bool PointerAccessCollector::VisitDeclRefExpr(DeclRefExpr *DRE)
+{
     const VarDecl *VD = dyn_cast<VarDecl>(DRE->getDecl());
     if (!VD)
         return true;
@@ -274,10 +303,12 @@ bool PointerAccessCollector::VisitDeclRefExpr(DeclRefExpr *DRE) {
     if (it == tracked_pointers.end())
         return true;
 
-    if (VD->hasInit()) {
+    if (VD->hasInit())
+    {
         SourceRange initRange = VD->getInit()->getSourceRange();
         if (SM.isBeforeInTranslationUnit(DRE->getLocation(), initRange.getEnd()) &&
-            !SM.isBeforeInTranslationUnit(DRE->getLocation(), initRange.getBegin())) {
+            !SM.isBeforeInTranslationUnit(DRE->getLocation(), initRange.getBegin()))
+        {
             return true;
         }
     }
@@ -291,17 +322,20 @@ bool PointerAccessCollector::VisitDeclRefExpr(DeclRefExpr *DRE) {
 // wrapper around `S` itself — so callers comparing AST nodes can match
 // either the bare DRE or its wrapped form.
 static const Stmt *skipTransparentParentsOf(const Stmt *S, ASTContext &Ctx,
-                                             const Stmt *&outermost) {
+                                            const Stmt *&outermost)
+{
     outermost = S;
     const Stmt *Current = S;
-    while (true) {
+    while (true)
+    {
         auto Parents = Ctx.getParents(*Current);
         if (Parents.empty())
             return nullptr;
         const Stmt *P = Parents[0].get<Stmt>();
         if (!P)
             return nullptr;
-        if (isa<ImplicitCastExpr>(P) || isa<ParenExpr>(P)) {
+        if (isa<ImplicitCastExpr>(P) || isa<ParenExpr>(P))
+        {
             outermost = P;
             Current = P;
             continue;
@@ -317,12 +351,14 @@ static const Stmt *skipTransparentParentsOf(const Stmt *S, ASTContext &Ctx,
 // final fallback emits Unknown, which causes validation to reject the
 // pointer.
 void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
-                                             const VarDecl *PtrVar,
-                                             std::vector<PointerAccess> &access_list,
-                                             PointerCandidate &candidate) {
+                                            const VarDecl *PtrVar,
+                                            std::vector<PointerAccess> &access_list,
+                                            PointerCandidate &candidate)
+{
     const Stmt *OutermostDRE = DRE; // top of the transparent wrapper chain over DRE
     const Stmt *Parent = skipTransparentParentsOf(DRE, Ctx, OutermostDRE);
-    if (!Parent) {
+    if (!Parent)
+    {
         access_list.push_back({PointerAccessKind::Unknown, DRE->getLocation(),
                                DRE, nullptr, "", "", "", ""});
         return;
@@ -342,13 +378,15 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
     // is a ConditionalOperator), which hid the fact that p escapes via
     // return. The pass would then convert p to an index, c2rust would emit a
     // bool→int→pointer cast chain, and the translated Rust would SIGSEGV.
-    while (const auto *CO = dyn_cast<ConditionalOperator>(Parent)) {
+    while (const auto *CO = dyn_cast<ConditionalOperator>(Parent))
+    {
         if (OutermostDRE != CO->getTrueExpr() &&
             OutermostDRE != CO->getFalseExpr())
             break; // OutermostDRE is the cond — leave Parent as the `?:`
         OutermostDRE = CO;
         Parent = skipTransparentParentsOf(CO, Ctx, OutermostDRE);
-        if (!Parent) {
+        if (!Parent)
+        {
             access_list.push_back({PointerAccessKind::Unknown, DRE->getLocation(),
                                    DRE, nullptr, "", "", "", ""});
             return;
@@ -356,15 +394,20 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
     }
 
     // ---- UnaryOperator: *p, p++, p--, &p, !p ---------------------------
-    if (const UnaryOperator *UO = dyn_cast<UnaryOperator>(Parent)) {
-        switch (UO->getOpcode()) {
-        case UO_Deref: {
+    if (const UnaryOperator *UO = dyn_cast<UnaryOperator>(Parent))
+    {
+        switch (UO->getOpcode())
+        {
+        case UO_Deref:
+        {
             // *p — distinguish read vs write by checking whether the
             // deref is the LHS of an assignment.
             const Stmt *GP = skipTransparentParents(UO, Ctx);
             bool is_write = false;
-            if (GP) {
-                if (const BinaryOperator *BO = dyn_cast<BinaryOperator>(GP)) {
+            if (GP)
+            {
+                if (const BinaryOperator *BO = dyn_cast<BinaryOperator>(GP))
+                {
                     if (BO->isAssignmentOp() && BO->getLHS()->IgnoreParenImpCasts() == UO)
                         is_write = true;
                 }
@@ -375,14 +418,18 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
                                    "", "", "", ""});
             return;
         }
-        case UO_PostInc: {
+        case UO_PostInc:
+        {
             // Either standalone `p++` or the `p++` inside `*p++`. The
             // dereferenced form maps to DerefPostInc regardless of
             // read/write context: arr[p_index++] is valid on either side.
             const Stmt *GP = skipTransparentParents(UO, Ctx);
-            if (GP) {
-                if (const UnaryOperator *GUO = dyn_cast<UnaryOperator>(GP)) {
-                    if (GUO->getOpcode() == UO_Deref) {
+            if (GP)
+            {
+                if (const UnaryOperator *GUO = dyn_cast<UnaryOperator>(GP))
+                {
+                    if (GUO->getOpcode() == UO_Deref)
+                    {
                         access_list.push_back({PointerAccessKind::DerefPostInc,
                                                GUO->getBeginLoc(), DRE, nullptr,
                                                "", "", "", ""});
@@ -395,12 +442,16 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
                                    "", "", "", ""});
             return;
         }
-        case UO_PreInc: {
+        case UO_PreInc:
+        {
             // ++p, possibly inside *++p.
             const Stmt *GP = skipTransparentParents(UO, Ctx);
-            if (GP) {
-                if (const UnaryOperator *GUO = dyn_cast<UnaryOperator>(GP)) {
-                    if (GUO->getOpcode() == UO_Deref) {
+            if (GP)
+            {
+                if (const UnaryOperator *GUO = dyn_cast<UnaryOperator>(GP))
+                {
+                    if (GUO->getOpcode() == UO_Deref)
+                    {
                         access_list.push_back({PointerAccessKind::DerefPreInc,
                                                GUO->getBeginLoc(), DRE, nullptr,
                                                "", "", "", ""});
@@ -413,11 +464,15 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
                                    "", "", "", ""});
             return;
         }
-        case UO_PostDec: {
+        case UO_PostDec:
+        {
             const Stmt *GP = skipTransparentParents(UO, Ctx);
-            if (GP) {
-                if (const UnaryOperator *GUO = dyn_cast<UnaryOperator>(GP)) {
-                    if (GUO->getOpcode() == UO_Deref) {
+            if (GP)
+            {
+                if (const UnaryOperator *GUO = dyn_cast<UnaryOperator>(GP))
+                {
+                    if (GUO->getOpcode() == UO_Deref)
+                    {
                         access_list.push_back({PointerAccessKind::DerefPostDec,
                                                GUO->getBeginLoc(), DRE, nullptr,
                                                "", "", "", ""});
@@ -430,11 +485,15 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
                                    "", "", "", ""});
             return;
         }
-        case UO_PreDec: {
+        case UO_PreDec:
+        {
             const Stmt *GP = skipTransparentParents(UO, Ctx);
-            if (GP) {
-                if (const UnaryOperator *GUO = dyn_cast<UnaryOperator>(GP)) {
-                    if (GUO->getOpcode() == UO_Deref) {
+            if (GP)
+            {
+                if (const UnaryOperator *GUO = dyn_cast<UnaryOperator>(GP))
+                {
+                    if (GUO->getOpcode() == UO_Deref)
+                    {
                         access_list.push_back({PointerAccessKind::DerefPreDec,
                                                GUO->getBeginLoc(), DRE, nullptr,
                                                "", "", "", ""});
@@ -466,8 +525,10 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
     }
 
     // ---- MemberExpr: p->field (arrow access) --------------------------
-    if (const MemberExpr *ME = dyn_cast<MemberExpr>(Parent)) {
-        if (ME->isArrow()) {
+    if (const MemberExpr *ME = dyn_cast<MemberExpr>(Parent))
+    {
+        if (ME->isArrow())
+        {
             // When `field` lives inside an anonymous struct/union (e.g.
             // the `offset`/`data` union members of `grid_cell_entry`),
             // Clang represents `gce->offset` as two chained MemberExprs
@@ -481,8 +542,10 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
             const MemberExpr *RealME = ME;
             const Stmt *Outer = skipTransparentParents(ME, Ctx);
             if (const auto *AnonFD = dyn_cast<FieldDecl>(ME->getMemberDecl());
-                AnonFD && AnonFD->isAnonymousStructOrUnion()) {
-                if (const auto *OuterME = Outer ? dyn_cast<MemberExpr>(Outer) : nullptr) {
+                AnonFD && AnonFD->isAnonymousStructOrUnion())
+            {
+                if (const auto *OuterME = Outer ? dyn_cast<MemberExpr>(Outer) : nullptr)
+                {
                     RealME = OuterME;
                     Outer = skipTransparentParents(OuterME, Ctx);
                 }
@@ -491,12 +554,15 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
             // Read vs write: write if either an assignment LHS or an
             // increment/decrement target.
             bool is_write = false;
-            if (Outer) {
-                if (const BinaryOperator *BO = dyn_cast<BinaryOperator>(Outer)) {
+            if (Outer)
+            {
+                if (const BinaryOperator *BO = dyn_cast<BinaryOperator>(Outer))
+                {
                     if (BO->isAssignmentOp() && BO->getLHS()->IgnoreParenImpCasts() == RealME)
                         is_write = true;
                 }
-                if (const UnaryOperator *UO2 = dyn_cast<UnaryOperator>(Outer)) {
+                if (const UnaryOperator *UO2 = dyn_cast<UnaryOperator>(Outer))
+                {
                     if (UO2->isIncrementDecrementOp())
                         is_write = true;
                 }
@@ -510,16 +576,20 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
     }
 
     // ---- ArraySubscriptExpr: p[i] -------------------------------------
-    if (const ArraySubscriptExpr *ASE = dyn_cast<ArraySubscriptExpr>(Parent)) {
+    if (const ArraySubscriptExpr *ASE = dyn_cast<ArraySubscriptExpr>(Parent))
+    {
         // Make sure p is the base of the subscript, not the index, so
         // we don't fire on patterns like `arr[p]`.
         if (ASE->getBase()->IgnoreParenImpCasts() == DRE ||
-            ASE->getLHS()->IgnoreParenImpCasts() == DRE) {
+            ASE->getLHS()->IgnoreParenImpCasts() == DRE)
+        {
             std::string sub_text = getSourceText(ASE->getIdx(), SM, LO);
             const Stmt *GP = skipTransparentParents(ASE, Ctx);
             bool is_write = false;
-            if (GP) {
-                if (const BinaryOperator *BO = dyn_cast<BinaryOperator>(GP)) {
+            if (GP)
+            {
+                if (const BinaryOperator *BO = dyn_cast<BinaryOperator>(GP))
+                {
                     if (BO->isAssignmentOp() && BO->getLHS()->IgnoreParenImpCasts() == ASE)
                         is_write = true;
                 }
@@ -534,37 +604,58 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
 
     // ---- BinaryOperator: comparisons, assignments, compound assigns,
     //                       pointer arithmetic --------------------------
-    if (const BinaryOperator *BO = dyn_cast<BinaryOperator>(Parent)) {
+    if (const BinaryOperator *BO = dyn_cast<BinaryOperator>(Parent))
+    {
         // Comparison: p == NULL, p < end, p < arr + n, p >= arr, ...
         // We try several shapes in order of specificity, falling back
         // to the unresolvable "Comparison" kind if none of them apply.
-        if (BO->isComparisonOp()) {
+        if (BO->isComparisonOp())
+        {
             // Figure out which operand is our pointer and normalize the
             // operator so the pointer is conceptually on the LHS.
             const Expr *OtherSide;
             bool ptr_is_lhs;
             if (BO->getLHS()->IgnoreParenImpCasts() == DRE ||
-                BO->getLHS()->IgnoreParenImpCasts() == OutermostDRE) {
+                BO->getLHS()->IgnoreParenImpCasts() == OutermostDRE)
+            {
                 OtherSide = BO->getRHS()->IgnoreParenImpCasts();
                 ptr_is_lhs = true;
-            } else {
+            }
+            else
+            {
                 OtherSide = BO->getLHS()->IgnoreParenImpCasts();
                 ptr_is_lhs = false;
             }
 
             std::string op_text;
-            switch (BO->getOpcode()) {
-            case BO_LT:  op_text = ptr_is_lhs ? "<"  : ">";  break;
-            case BO_GT:  op_text = ptr_is_lhs ? ">"  : "<";  break;
-            case BO_LE:  op_text = ptr_is_lhs ? "<=" : ">="; break;
-            case BO_GE:  op_text = ptr_is_lhs ? ">=" : "<="; break;
-            case BO_EQ:  op_text = "=="; break;
-            case BO_NE:  op_text = "!="; break;
-            default:     op_text = "??"; break;
+            switch (BO->getOpcode())
+            {
+            case BO_LT:
+                op_text = ptr_is_lhs ? "<" : ">";
+                break;
+            case BO_GT:
+                op_text = ptr_is_lhs ? ">" : "<";
+                break;
+            case BO_LE:
+                op_text = ptr_is_lhs ? "<=" : ">=";
+                break;
+            case BO_GE:
+                op_text = ptr_is_lhs ? ">=" : "<=";
+                break;
+            case BO_EQ:
+                op_text = "==";
+                break;
+            case BO_NE:
+                op_text = "!=";
+                break;
+            default:
+                op_text = "??";
+                break;
             }
 
             // Shape 1: p ?= NULL
-            if (isNullExpr(OtherSide)) {
+            if (isNullExpr(OtherSide))
+            {
                 access_list.push_back({PointerAccessKind::ComparisonNull,
                                        BO->getBeginLoc(), DRE, nullptr,
                                        op_text, "", "", "-1"});
@@ -578,10 +669,13 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
             // may still match its own name: validation later makes the
             // parameter itself the base (index counts from its incoming
             // value), so `p ?= p + n` is `index ?= n`.
-            if (const BinaryOperator *AddBO = dyn_cast<BinaryOperator>(OtherSide)) {
-                if (AddBO->getOpcode() == BO_Add) {
+            if (const BinaryOperator *AddBO = dyn_cast<BinaryOperator>(OtherSide))
+            {
+                if (AddBO->getOpcode() == BO_Add)
+                {
                     const Expr *AddLHS = AddBO->getLHS()->IgnoreParenImpCasts();
-                    if (AddLHS->getType()->isPointerType() || AddLHS->getType()->isArrayType()) {
+                    if (AddLHS->getType()->isPointerType() || AddLHS->getType()->isArrayType())
+                    {
                         std::string add_lhs_text = getSourceText(AddLHS, SM, LO);
                         bool lhs_is_base =
                             !candidate.base_array_text.empty()
@@ -589,7 +683,8 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
                                 : candidate.is_parameter &&
                                       add_lhs_text ==
                                           candidate.ptr_var->getNameAsString();
-                        if (lhs_is_base) {
+                        if (lhs_is_base)
+                        {
                             std::string offset = getSourceText(AddBO->getRHS(), SM, LO);
                             access_list.push_back({PointerAccessKind::ComparisonExpr,
                                                    BO->getBeginLoc(), DRE, nullptr,
@@ -605,16 +700,19 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
             // Shape 3 / 4: comparing to another pointer expression.
             //   3) the same base array         →  index ?= 0
             //   4) some other pointer `end`    →  index ?= (end - base)
-            if (OtherSide->getType()->isPointerType() || OtherSide->getType()->isArrayType()) {
+            if (OtherSide->getType()->isPointerType() || OtherSide->getType()->isArrayType())
+            {
                 std::string other_text = getSourceText(OtherSide, SM, LO);
-                if (other_text == candidate.base_array_text) {
+                if (other_text == candidate.base_array_text)
+                {
                     access_list.push_back({PointerAccessKind::ComparisonExpr,
                                            BO->getBeginLoc(), DRE, nullptr,
                                            op_text, "", "", "0"});
                     return;
                 }
 
-                if (!candidate.base_array_text.empty()) {
+                if (!candidate.base_array_text.empty())
+                {
                     // Equality comparisons stay in pointer form:
                     //   p != q  →  base + p_index != (q)
                     // The index form `p_index != (q - base)` is ill-typed
@@ -623,7 +721,8 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
                     // does not), and is UB when q doesn't point into
                     // base's array — equality alone is defined for any
                     // two pointers.
-                    if (BO->getOpcode() == BO_EQ || BO->getOpcode() == BO_NE) {
+                    if (BO->getOpcode() == BO_EQ || BO->getOpcode() == BO_NE)
+                    {
                         access_list.push_back({PointerAccessKind::ComparisonExpr,
                                                BO->getBeginLoc(), DRE, nullptr,
                                                op_text, candidate.base_array_text,
@@ -644,7 +743,8 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
             // generic). Rebuild the pointer at the call as
             // `(base + index)` once detection picks a base later.
             if (candidate.is_parameter &&
-                OtherSide->getType()->isPointerType()) {
+                OtherSide->getType()->isPointerType())
+            {
                 std::string param_name = candidate.ptr_var->getNameAsString();
                 std::string other_text = getSourceText(OtherSide, SM, LO);
                 access_list.push_back({PointerAccessKind::ComparisonExpr,
@@ -664,15 +764,20 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
         // Mirrors analyzePointerInit but for assignments after the
         // declaration, and additionally enforces base-array consistency:
         // a second base that doesn't match the first → Unknown (reject).
-        if (BO->getOpcode() == BO_Assign) {
+        if (BO->getOpcode() == BO_Assign)
+        {
             if (BO->getLHS()->IgnoreParenImpCasts() == DRE ||
-                BO->getLHS()->IgnoreParenImpCasts() == OutermostDRE) {
+                BO->getLHS()->IgnoreParenImpCasts() == OutermostDRE)
+            {
                 // Reject `(p = &arr[i])->field`: after rewriting the
                 // assignment becomes an int, and `->` no longer applies.
                 const Stmt *AssignParent = skipTransparentParents(BO, Ctx);
-                if (AssignParent) {
-                    if (const MemberExpr *ME = dyn_cast<MemberExpr>(AssignParent)) {
-                        if (ME->isArrow()) {
+                if (AssignParent)
+                {
+                    if (const MemberExpr *ME = dyn_cast<MemberExpr>(AssignParent))
+                    {
+                        if (ME->isArrow())
+                        {
                             access_list.push_back({PointerAccessKind::Unknown,
                                                    BO->getBeginLoc(), DRE, nullptr,
                                                    "", "", "", ""});
@@ -685,7 +790,8 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
                     RHS = CSCE->getSubExpr()->IgnoreParenImpCasts();
 
                 // p = NULL
-                if (isNullExpr(RHS)) {
+                if (isNullExpr(RHS))
+                {
                     access_list.push_back({PointerAccessKind::AssignNull,
                                            BO->getBeginLoc(), DRE, nullptr,
                                            "", "", "", ""});
@@ -696,20 +802,25 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
 
                 // p = &arr[i]
                 std::string base_text, index_text;
-                if (isAddrOfSubscript(RHS, base_text, index_text)) {
+                if (isAddrOfSubscript(RHS, base_text, index_text))
+                {
                     const auto *UO = cast<UnaryOperator>(RHS);
                     const auto *ASE = cast<ArraySubscriptExpr>(UO->getSubExpr()->IgnoreParenImpCasts());
                     if (baseIsUnsafe(ASE->getBase()->IgnoreParenImpCasts(), is_global) ||
-                        baseIsUnsafe(ASE->getIdx(), is_global)) {
+                        baseIsUnsafe(ASE->getIdx(), is_global))
+                    {
                         access_list.push_back({PointerAccessKind::Unknown,
                                                BO->getBeginLoc(), DRE, nullptr,
                                                "", "", "", ""});
                         return;
                     }
-                    if (candidate.base_array_text.empty()) {
+                    if (candidate.base_array_text.empty())
+                    {
                         candidate.base_array_text = base_text;
                         candidate.base_array = RHS;
-                    } else if (base_text != candidate.base_array_text) {
+                    }
+                    else if (base_text != candidate.base_array_text)
+                    {
                         access_list.push_back({PointerAccessKind::Unknown,
                                                BO->getBeginLoc(), DRE, nullptr,
                                                "", "", "", ""});
@@ -722,12 +833,15 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
                 }
 
                 // p = arr + offset
-                if (const BinaryOperator *AddBO = dyn_cast<BinaryOperator>(RHS)) {
+                if (const BinaryOperator *AddBO = dyn_cast<BinaryOperator>(RHS))
+                {
                     if (AddBO->getOpcode() == BO_Add &&
-                        AddBO->getLHS()->IgnoreParenImpCasts()->getType()->isPointerType()) {
+                        AddBO->getLHS()->IgnoreParenImpCasts()->getType()->isPointerType())
+                    {
                         const Expr *AddLHS = AddBO->getLHS()->IgnoreParenImpCasts();
                         if (baseIsUnsafe(AddLHS, is_global) ||
-                            baseIsUnsafe(AddBO->getRHS(), is_global)) {
+                            baseIsUnsafe(AddBO->getRHS(), is_global))
+                        {
                             access_list.push_back({PointerAccessKind::Unknown,
                                                    BO->getBeginLoc(), DRE, nullptr,
                                                    "", "", "", ""});
@@ -735,10 +849,13 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
                         }
                         std::string rhs_base = getSourceText(AddLHS, SM, LO);
                         std::string rhs_offset = getSourceText(AddBO->getRHS(), SM, LO);
-                        if (candidate.base_array_text.empty()) {
+                        if (candidate.base_array_text.empty())
+                        {
                             candidate.base_array_text = rhs_base;
                             candidate.base_array = AddLHS;
-                        } else if (rhs_base != candidate.base_array_text) {
+                        }
+                        else if (rhs_base != candidate.base_array_text)
+                        {
                             access_list.push_back({PointerAccessKind::Unknown,
                                                    BO->getBeginLoc(), DRE, nullptr,
                                                    "", "", "", ""});
@@ -758,22 +875,28 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
                 // any arg matching the candidate's base (passed as `base`)
                 // — otherwise the rewritten call ends up with a duplicated
                 // base argument that fails to compile.
-                if (const CallExpr *RhsCall = dyn_cast<CallExpr>(RHS)) {
-                    if (const FunctionDecl *Callee = RhsCall->getDirectCallee()) {
+                if (const CallExpr *RhsCall = dyn_cast<CallExpr>(RHS))
+                {
+                    if (const FunctionDecl *Callee = RhsCall->getDirectCallee())
+                    {
                         std::string func_name = Callee->getNameAsString();
                         if (g_allowed_funcs.count(func_name) &&
-                            RhsCall->getType()->isPointerType()) {
+                            RhsCall->getType()->isPointerType())
+                        {
                             std::string other_args;
-                            for (unsigned i = 0; i < RhsCall->getNumArgs(); i++) {
+                            for (unsigned i = 0; i < RhsCall->getNumArgs(); i++)
+                            {
                                 const Expr *Arg = RhsCall->getArg(i)->IgnoreParenImpCasts();
-                                if (const DeclRefExpr *ArgDRE = dyn_cast<DeclRefExpr>(Arg)) {
+                                if (const DeclRefExpr *ArgDRE = dyn_cast<DeclRefExpr>(Arg))
+                                {
                                     if (ArgDRE->getDecl() == PtrVar)
-                                        continue;  // the pointer is the wrapper's `start` param
+                                        continue; // the pointer is the wrapper's `start` param
                                     // The base may be passed as the first strchr arg
                                     // (e.g. Lua's `l = strchr(path, sep)` where `path`
                                     // is l's base). It's already covered by the wrapper's
                                     // `base` param — skip it here too.
-                                    if (const VarDecl *ArgVD = dyn_cast<VarDecl>(ArgDRE->getDecl())) {
+                                    if (const VarDecl *ArgVD = dyn_cast<VarDecl>(ArgDRE->getDecl()))
+                                    {
                                         if (ArgVD->getNameAsString() == candidate.base_array_text)
                                             continue;
                                     }
@@ -784,7 +907,8 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
                                 if (!candidate.base_array_text.empty() &&
                                     arg_text == candidate.base_array_text)
                                     continue;
-                                if (!other_args.empty()) other_args += ", ";
+                                if (!other_args.empty())
+                                    other_args += ", ";
                                 other_args += arg_text;
                             }
                             access_list.push_back({PointerAccessKind::AssignFromAllowedFunc,
@@ -797,8 +921,10 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
 
                 // p = arr (or another pointer/array expression that
                 // matches the existing base).
-                if (RHS->getType()->isPointerType() || RHS->getType()->isArrayType()) {
-                    if (baseIsUnsafe(RHS, is_global)) {
+                if (RHS->getType()->isPointerType() || RHS->getType()->isArrayType())
+                {
+                    if (baseIsUnsafe(RHS, is_global))
+                    {
                         // RHS has a side effect (e.g. `p = argv[n++]`) or,
                         // for a global pointer, references a local — pasting
                         // it at every access site would duplicate the side
@@ -809,10 +935,13 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
                         return;
                     }
                     std::string rhs_text = getSourceText(RHS, SM, LO);
-                    if (candidate.base_array_text.empty()) {
+                    if (candidate.base_array_text.empty())
+                    {
                         candidate.base_array_text = rhs_text;
                         candidate.base_array = RHS;
-                    } else if (rhs_text != candidate.base_array_text) {
+                    }
+                    else if (rhs_text != candidate.base_array_text)
+                    {
                         // Different source — the pointer is being reseated
                         // (e.g. a linked-list walk like `p = p->next`).
                         // We can't represent that as a single index.
@@ -838,7 +967,8 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
         // p += n / p -= n
         if (BO->getOpcode() == BO_AddAssign &&
             (BO->getLHS()->IgnoreParenImpCasts() == DRE ||
-             BO->getLHS()->IgnoreParenImpCasts() == OutermostDRE)) {
+             BO->getLHS()->IgnoreParenImpCasts() == OutermostDRE))
+        {
             std::string operand = getSourceText(BO->getRHS(), SM, LO);
             access_list.push_back({PointerAccessKind::PlusAssign,
                                    BO->getBeginLoc(), DRE, nullptr,
@@ -847,7 +977,8 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
         }
         if (BO->getOpcode() == BO_SubAssign &&
             (BO->getLHS()->IgnoreParenImpCasts() == DRE ||
-             BO->getLHS()->IgnoreParenImpCasts() == OutermostDRE)) {
+             BO->getLHS()->IgnoreParenImpCasts() == OutermostDRE))
+        {
             std::string operand = getSourceText(BO->getRHS(), SM, LO);
             access_list.push_back({PointerAccessKind::MinusAssign,
                                    BO->getBeginLoc(), DRE, nullptr,
@@ -860,15 +991,20 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
         // through nested +/- until we hit a non-arithmetic parent.
         if ((BO->getOpcode() == BO_Add || BO->getOpcode() == BO_Sub) &&
             (BO->getLHS()->IgnoreParenImpCasts() == DRE ||
-             BO->getLHS()->IgnoreParenImpCasts() == OutermostDRE)) {
+             BO->getLHS()->IgnoreParenImpCasts() == OutermostDRE))
+        {
             const Stmt *Current = BO;
-            while (true) {
+            while (true)
+            {
                 const Stmt *Up = skipTransparentParents(Current, Ctx);
-                if (!Up) break;
+                if (!Up)
+                    break;
 
                 // *(p ± expr) — dereference of a pointer-arithmetic chain.
-                if (const UnaryOperator *DerefUO = dyn_cast<UnaryOperator>(Up)) {
-                    if (DerefUO->getOpcode() == UO_Deref) {
+                if (const UnaryOperator *DerefUO = dyn_cast<UnaryOperator>(Up))
+                {
+                    if (DerefUO->getOpcode() == UO_Deref)
+                    {
                         // Pull out the offset text by stripping the
                         // pointer name from the start of the arithmetic
                         // expression. Using the outermost BO (`Current`)
@@ -893,16 +1029,20 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
 
                         const BinaryOperator *CurBO = BO;
                         const Stmt *CurNode = BO;
-                        while (CurBO) {
+                        while (CurBO)
+                        {
                             const Expr *RHS = CurBO->getRHS()->IgnoreParenImpCasts();
                             Expr::EvalResult evalResult;
-                            if (RHS->EvaluateAsInt(evalResult, Ctx)) {
+                            if (RHS->EvaluateAsInt(evalResult, Ctx))
+                            {
                                 int ival = (int)evalResult.Val.getInt().getExtValue();
                                 if (CurBO->getOpcode() == BO_Add)
                                     const_offset += ival;
                                 else if (CurBO->getOpcode() == BO_Sub)
                                     const_offset -= ival;
-                            } else {
+                            }
+                            else
+                            {
                                 is_const_offset = false;
                             }
                             const Stmt *NextUp = skipTransparentParents(CurNode, Ctx);
@@ -914,21 +1054,26 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
                                 CurBO = nullptr;
                         }
 
-                        if (is_const_offset) {
+                        if (is_const_offset)
+                        {
                             if (const_offset < candidate.min_relative_offset)
                                 candidate.min_relative_offset = const_offset;
                             if (const_offset > candidate.max_relative_offset)
                                 candidate.max_relative_offset = const_offset;
-                        } else {
+                        }
+                        else
+                        {
                             candidate.constant_offsets = false;
                         }
 
                         // Read or write of *(p ± expr)?
                         const Stmt *DerefParent = skipTransparentParents(DerefUO, Ctx);
                         bool is_write = false;
-                        if (DerefParent) {
+                        if (DerefParent)
+                        {
                             if (const BinaryOperator *AssignBO =
-                                    dyn_cast<BinaryOperator>(DerefParent)) {
+                                    dyn_cast<BinaryOperator>(DerefParent))
+                            {
                                 if (AssignBO->isAssignmentOp() &&
                                     AssignBO->getLHS()->IgnoreParenImpCasts() == DerefUO)
                                     is_write = true;
@@ -946,8 +1091,10 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
                 }
 
                 // Keep walking through chained additions/subtractions.
-                if (const BinaryOperator *UpBO = dyn_cast<BinaryOperator>(Up)) {
-                    if (UpBO->getOpcode() == BO_Add || UpBO->getOpcode() == BO_Sub) {
+                if (const BinaryOperator *UpBO = dyn_cast<BinaryOperator>(Up))
+                {
+                    if (UpBO->getOpcode() == BO_Add || UpBO->getOpcode() == BO_Sub)
+                    {
                         Current = UpBO;
                         continue;
                     }
@@ -956,10 +1103,13 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
                 // Pointer arithmetic that ends up as a function argument,
                 // e.g. `func(p + 1)`. Same handling as the bare pointer
                 // case below — recorded as PassedTo[Allowed]Func.
-                if (const CallExpr *CE = dyn_cast<CallExpr>(Up)) {
-                    if (const FunctionDecl *Callee = CE->getDirectCallee()) {
+                if (const CallExpr *CE = dyn_cast<CallExpr>(Up))
+                {
+                    if (const FunctionDecl *Callee = CE->getDirectCallee())
+                    {
                         std::string func_name = Callee->getNameAsString();
-                        if (g_allowed_funcs.count(func_name)) {
+                        if (g_allowed_funcs.count(func_name))
+                        {
                             access_list.push_back({PointerAccessKind::PassedToAllowedFunc,
                                                    DRE->getLocation(), DRE, CE,
                                                    func_name, "", "", ""});
@@ -977,8 +1127,10 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
     }
 
     // ---- Logical context: p && q, p || q -------------------------------
-    if (const BinaryOperator *BO = dyn_cast<BinaryOperator>(Parent)) {
-        if (BO->getOpcode() == BO_LAnd || BO->getOpcode() == BO_LOr) {
+    if (const BinaryOperator *BO = dyn_cast<BinaryOperator>(Parent))
+    {
+        if (BO->getOpcode() == BO_LAnd || BO->getOpcode() == BO_LOr)
+        {
             access_list.push_back({PointerAccessKind::BoolTrue,
                                    DRE->getLocation(), DRE, nullptr,
                                    "", "", "", ""});
@@ -989,7 +1141,8 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
     // ---- Boolean context: if/while/for/do/?: condition -----------------
     if (isa<IfStmt>(Parent) || isa<WhileStmt>(Parent) ||
         isa<ForStmt>(Parent) || isa<DoStmt>(Parent) ||
-        isa<ConditionalOperator>(Parent)) {
+        isa<ConditionalOperator>(Parent))
+    {
         access_list.push_back({PointerAccessKind::BoolTrue,
                                DRE->getLocation(), DRE, nullptr,
                                "", "", "", ""});
@@ -997,10 +1150,13 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
     }
 
     // ---- Direct call argument: func(p) ---------------------------------
-    if (const CallExpr *CE = dyn_cast<CallExpr>(Parent)) {
-        if (const FunctionDecl *Callee = CE->getDirectCallee()) {
+    if (const CallExpr *CE = dyn_cast<CallExpr>(Parent))
+    {
+        if (const FunctionDecl *Callee = CE->getDirectCallee())
+        {
             std::string func_name = Callee->getNameAsString();
-            if (g_allowed_funcs.count(func_name)) {
+            if (g_allowed_funcs.count(func_name))
+            {
                 access_list.push_back({PointerAccessKind::PassedToAllowedFunc,
                                        DRE->getLocation(), DRE, CE,
                                        func_name, "", "", ""});
@@ -1014,7 +1170,8 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
     }
 
     // ---- return p ------------------------------------------------------
-    if (isa<ReturnStmt>(Parent)) {
+    if (isa<ReturnStmt>(Parent))
+    {
         access_list.push_back({PointerAccessKind::ReturnPtr,
                                DRE->getLocation(), DRE, Parent,
                                "", "", "", ""});
@@ -1024,7 +1181,7 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
     // ---- Anything we don't recognize -> reject -------------------------
     if (VERBOSE)
         llvm::outs() << "[Collect] Unknown access to " << PtrVar->getNameAsString()
-                      << " at " << DRE->getLocation().printToString(SM) << "\n";
+                     << " at " << DRE->getLocation().printToString(SM) << "\n";
     access_list.push_back({PointerAccessKind::Unknown, DRE->getLocation(),
                            DRE, nullptr, "", "", "", ""});
 }

--- a/xj-prepare-pointertransform/PointerAccessCollector.cpp
+++ b/xj-prepare-pointertransform/PointerAccessCollector.cpp
@@ -529,26 +529,27 @@ void PointerAccessCollector::classifyAccess(DeclRefExpr *DRE,
     {
         if (ME->isArrow())
         {
-            // When `field` lives inside an anonymous struct/union (e.g.
-            // the `offset`/`data` union members of `grid_cell_entry`),
-            // Clang represents `gce->offset` as two chained MemberExprs
+            // When `field` lives inside an anonymous struct/union,
+            // Clang represents `ptr->field` as chained MemberExprs
             // sharing one source range: an inner node — always `ME`
             // here, since its base is the tracked pointer — whose
             // "member" is the anonymous aggregate itself (an unnamed
             // FieldDecl, so getNameAsString() is ""), and an outer node
-            // for the real field ("offset"). Without resolving to the
+            // for the real field ("field"). Without resolving to the
             // outer node, field_name comes back empty and the rewriter
-            // later turns "gce->offset" into a dangling "gce_index].".
+            // later turns ptr->field" into a dangling "p_index].".
             const MemberExpr *RealME = ME;
             const Stmt *Outer = skipTransparentParents(ME, Ctx);
-            if (const auto *AnonFD = dyn_cast<FieldDecl>(ME->getMemberDecl());
-                AnonFD && AnonFD->isAnonymousStructOrUnion())
+            while (true)
             {
-                if (const auto *OuterME = Outer ? dyn_cast<MemberExpr>(Outer) : nullptr)
-                {
-                    RealME = OuterME;
-                    Outer = skipTransparentParents(OuterME, Ctx);
-                }
+                const auto *AnonFD = dyn_cast<FieldDecl>(RealME->getMemberDecl());
+                if (!AnonFD || !AnonFD->isAnonymousStructOrUnion())
+                    break;
+                const auto *OuterME = Outer ? dyn_cast<MemberExpr>(Outer) : nullptr;
+                if (!OuterME)
+                    break;
+                RealME = OuterME;
+                Outer = skipTransparentParents(OuterME, Ctx);
             }
             std::string field_name = RealME->getMemberDecl()->getNameAsString();
             // Read vs write: write if either an assignment LHS or an

--- a/xj-prepare-pointertransform/TransformationMethods.cpp
+++ b/xj-prepare-pointertransform/TransformationMethods.cpp
@@ -24,13 +24,18 @@
 //   "(short *) buf" -> "((short *) buf)"  ([] binds tighter than a cast)
 //
 // If neither hazard applies, the original text is returned unchanged.
-static std::string safeBase(const std::string &base) {
-    if (base.empty()) return base;
+static std::string safeBase(const std::string &base)
+{
+    if (base.empty())
+        return base;
 
     int depth = 0;
-    for (char c : base) {
-        if (c == '(' || c == '[') depth++;
-        else if (c == ')' || c == ']') depth--;
+    for (char c : base)
+    {
+        if (c == '(' || c == '[')
+            depth++;
+        else if (c == ')' || c == ']')
+            depth--;
         else if (depth == 0 && (c == '+' || c == '-'))
             return "(" + base + ")";
     }
@@ -38,14 +43,20 @@ static std::string safeBase(const std::string &base) {
     // Cast detection: if the first paren group ends before the end of
     // the string, what follows is the cast target — and [] would bind
     // to it instead of the whole cast.
-    if (base[0] == '(') {
+    if (base[0] == '(')
+    {
         int d = 0;
-        for (size_t i = 0; i < base.size(); i++) {
-            if (base[i] == '(') d++;
-            else if (base[i] == ')') {
+        for (size_t i = 0; i < base.size(); i++)
+        {
+            if (base[i] == '(')
+                d++;
+            else if (base[i] == ')')
+            {
                 d--;
-                if (d == 0 && i + 1 < base.size()) {
-                    for (size_t j = i + 1; j < base.size(); j++) {
+                if (d == 0 && i + 1 < base.size())
+                {
+                    for (size_t j = i + 1; j < base.size(); j++)
+                    {
                         if (!isspace((unsigned char)base[j]))
                             return "(" + base + ")";
                     }
@@ -80,12 +91,14 @@ static std::string safeBase(const std::string &base) {
 // and a bare insertion there would also detach the loop from the construct
 // that owns it. Such an anchor gets wrapped in a fresh block instead.
 
-struct DeclAnchor {
-    const Stmt *stmt = nullptr;  // insert before this; null = no legal position
-    bool needs_braces = false;   // ... after wrapping it in a block
+struct DeclAnchor
+{
+    const Stmt *stmt = nullptr; // insert before this; null = no legal position
+    bool needs_braces = false;  // ... after wrapping it in a block
 };
 
-static DeclAnchor declAnchorFor(const DeclStmt *DS, ASTContext &Ctx) {
+static DeclAnchor declAnchorFor(const DeclStmt *DS, ASTContext &Ctx)
+{
     DeclAnchor A;
     const ForStmt *FS = forStmtInitializedBy(DS, Ctx);
     A.stmt = FS ? static_cast<const Stmt *>(FS) : static_cast<const Stmt *>(DS);
@@ -98,7 +111,8 @@ static DeclAnchor declAnchorFor(const DeclStmt *DS, ASTContext &Ctx) {
     // DeclStmt itself, a block would scope away the very variable being
     // declared — but that shape does not arise: a bare DeclStmt outside a
     // compound statement is not valid C to begin with.
-    if (!FS) {
+    if (!FS)
+    {
         A.stmt = nullptr;
         return A;
     }
@@ -117,7 +131,8 @@ static DeclAnchor declAnchorFor(const DeclStmt *DS, ASTContext &Ctx) {
 // *last*, so the second pointer's braces enclose the first's.
 static bool emitDeclBefore(const DeclAnchor &A, const std::string &decl,
                            const SourceManager &SM, const LangOptions &LO,
-                           std::vector<Edit> &edits) {
+                           std::vector<Edit> &edits)
+{
     if (!A.stmt)
         return false;
 
@@ -143,7 +158,8 @@ static bool emitDeclBefore(const DeclAnchor &A, const std::string &decl,
     bool ends_at_terminator =
         !Lexer::getRawToken(End, last, SM, LO, /*IgnoreWhiteSpace=*/true) &&
         (last.is(tok::r_brace) || last.is(tok::semi));
-    if (!ends_at_terminator) {
+    if (!ends_at_terminator)
+    {
         auto next = Lexer::findNextToken(End, SM, LO);
         if (!next || !next->is(tok::semi))
             return false;
@@ -169,7 +185,8 @@ bool FunctionAccessAnalyzer::generateTransformation(
     const VarDecl *PtrVar,
     PointerCandidate &candidate,
     std::vector<PointerAccess> &accesses,
-    ASTContext &Ctx) {
+    ASTContext &Ctx)
+{
 
     SourceManager &SM = Ctx.getSourceManager();
     const LangOptions &LO = Ctx.getLangOpts();
@@ -193,9 +210,11 @@ bool FunctionAccessAnalyzer::generateTransformation(
     // to the appropriate integer form: 0 for InitArray, n for
     // InitArrayOffset, -1 for InitNull). Parameter pointers are
     // handled separately in the signature-rewrite paths.
-    if (!candidate.is_parameter) {
+    if (!candidate.is_parameter)
+    {
         const DeclStmt *DS = findDeclStmtForVar(PtrVar, Body);
-        if (!DS) {
+        if (!DS)
+        {
             if (VERBOSE)
                 llvm::outs() << "[Error] Could not find DeclStmt for " << ptr_name << "\n";
             return false;
@@ -204,8 +223,10 @@ bool FunctionAccessAnalyzer::generateTransformation(
         // Build the replacement declaration
         std::string init_value;
         bool found_init = false;
-        for (const auto &access : accesses) {
-            switch (access.kind) {
+        for (const auto &access : accesses)
+        {
+            switch (access.kind)
+            {
             case PointerAccessKind::InitNull:
                 init_value = "-1";
                 found_init = true;
@@ -221,7 +242,8 @@ bool FunctionAccessAnalyzer::generateTransformation(
             default:
                 break;
             }
-            if (found_init) break;
+            if (found_init)
+                break;
         }
 
         if (!found_init)
@@ -232,7 +254,8 @@ bool FunctionAccessAnalyzer::generateTransformation(
 
         std::string replacement = "int " + index_name + " = " + init_value + ";";
 
-        if (multi_decl && for_init) {
+        if (multi_decl && for_init)
+        {
             // The index cannot go after this DeclStmt — in a for-init that
             // slot is the loop condition — and the statement cannot be
             // replaced in place either, because the other declarators have
@@ -242,13 +265,16 @@ bool FunctionAccessAnalyzer::generateTransformation(
             // only sound when it names nothing the statement binds;
             // validation rejects the pointer otherwise, so by the time we
             // get here the hoist is known to be safe.
-            if (!emitDeclBefore(declAnchorFor(DS, Ctx), replacement, SM, LO, edits)) {
+            if (!emitDeclBefore(declAnchorFor(DS, Ctx), replacement, SM, LO, edits))
+            {
                 if (VERBOSE)
                     llvm::outs() << "[Error] No position for the index of "
                                  << ptr_name << "\n";
                 return false;
             }
-        } else if (multi_decl) {
+        }
+        else if (multi_decl)
+        {
             // Multi-declarator: keep the DeclStmt intact (PtrVar becomes unused)
             // and insert the index declaration on a new line after it
             SourceLocation DeclEnd = DS->getEndLoc();
@@ -260,7 +286,9 @@ bool FunctionAccessAnalyzer::generateTransformation(
             e.start = DeclEnd;
             e.text = "\n" + indent + replacement;
             edits.push_back(e);
-        } else {
+        }
+        else
+        {
             SourceLocation DeclStart = DS->getBeginLoc();
             SourceLocation DeclEnd = Lexer::getLocForEndOfToken(
                 DS->getEndLoc(), 0, SM, LO);
@@ -273,12 +301,14 @@ bool FunctionAccessAnalyzer::generateTransformation(
             e.text = replacement;
             edits.push_back(e);
         }
-
-    } else {
+    }
+    else
+    {
         // Parameter: insert index variable at top of function body
         // Keep the parameter itself, add int p_index = 0; after opening brace
         const CompoundStmt *CS = dyn_cast<CompoundStmt>(Body);
-        if (!CS) {
+        if (!CS)
+        {
             if (VERBOSE)
                 llvm::outs() << "[Error] Function body is not a CompoundStmt\n";
             return false;
@@ -318,27 +348,33 @@ bool FunctionAccessAnalyzer::generateTransformation(
     // and pushes an Edit covering the right source range. Init kinds
     // were already handled by the declaration rewrite above and are
     // skipped here.
-    for (const auto &access : accesses) {
+    for (const auto &access : accesses)
+    {
         if (access.kind == PointerAccessKind::InitNull ||
             access.kind == PointerAccessKind::InitArray ||
             access.kind == PointerAccessKind::InitArrayOffset)
             continue;
 
-        auto findParent = [&](const Expr *E) -> const Stmt * {
+        auto findParent = [&](const Expr *E) -> const Stmt *
+        {
             return skipTransparentParents(E, Ctx);
         };
-        auto findGrandParent = [&](const Stmt *P) -> const Stmt * {
+        auto findGrandParent = [&](const Stmt *P) -> const Stmt *
+        {
             return skipTransparentParents(P, Ctx);
         };
 
-        switch (access.kind) {
+        switch (access.kind)
+        {
 
         // ---- Dereference: *p -> arr[p_index] ----
         case PointerAccessKind::Deref:
-        case PointerAccessKind::DerefWrite: {
+        case PointerAccessKind::DerefWrite:
+        {
             const Stmt *P = findParent(access.expr);
             const UnaryOperator *UO = P ? dyn_cast<UnaryOperator>(P) : nullptr;
-            if (!UO) break;
+            if (!UO)
+                break;
 
             SourceLocation StarLoc = UO->getBeginLoc();
             SourceLocation EndLoc = Lexer::getLocForEndOfToken(
@@ -355,13 +391,16 @@ bool FunctionAccessAnalyzer::generateTransformation(
         }
 
         // ---- Deref with post-increment: *p++ -> arr[p_index++] ----
-        case PointerAccessKind::DerefPostInc: {
+        case PointerAccessKind::DerefPostInc:
+        {
             const Stmt *P = findParent(access.expr);
             const UnaryOperator *IncOp = P ? dyn_cast<UnaryOperator>(P) : nullptr;
-            if (!IncOp) break;
+            if (!IncOp)
+                break;
             const Stmt *GP = findGrandParent(IncOp);
             const UnaryOperator *DerefOp = GP ? dyn_cast<UnaryOperator>(GP) : nullptr;
-            if (!DerefOp) break;
+            if (!DerefOp)
+                break;
 
             SourceLocation StartLoc = DerefOp->getBeginLoc();
             SourceLocation EndLoc = Lexer::getLocForEndOfToken(
@@ -378,13 +417,16 @@ bool FunctionAccessAnalyzer::generateTransformation(
         }
 
         // ---- Deref with pre-increment: *++p -> arr[++p_index] ----
-        case PointerAccessKind::DerefPreInc: {
+        case PointerAccessKind::DerefPreInc:
+        {
             const Stmt *P = findParent(access.expr);
             const UnaryOperator *IncOp = P ? dyn_cast<UnaryOperator>(P) : nullptr;
-            if (!IncOp) break;
+            if (!IncOp)
+                break;
             const Stmt *GP = findGrandParent(IncOp);
             const UnaryOperator *DerefOp = GP ? dyn_cast<UnaryOperator>(GP) : nullptr;
-            if (!DerefOp) break;
+            if (!DerefOp)
+                break;
 
             SourceLocation StartLoc = DerefOp->getBeginLoc();
             SourceLocation EndLoc = Lexer::getLocForEndOfToken(
@@ -401,13 +443,16 @@ bool FunctionAccessAnalyzer::generateTransformation(
         }
 
         // ---- Deref with post-decrement: *p-- -> arr[p_index--] ----
-        case PointerAccessKind::DerefPostDec: {
+        case PointerAccessKind::DerefPostDec:
+        {
             const Stmt *P = findParent(access.expr);
             const UnaryOperator *DecOp = P ? dyn_cast<UnaryOperator>(P) : nullptr;
-            if (!DecOp) break;
+            if (!DecOp)
+                break;
             const Stmt *GP = findGrandParent(DecOp);
             const UnaryOperator *DerefOp = GP ? dyn_cast<UnaryOperator>(GP) : nullptr;
-            if (!DerefOp) break;
+            if (!DerefOp)
+                break;
 
             SourceLocation StartLoc = DerefOp->getBeginLoc();
             SourceLocation EndLoc = Lexer::getLocForEndOfToken(
@@ -424,13 +469,16 @@ bool FunctionAccessAnalyzer::generateTransformation(
         }
 
         // ---- Deref with pre-decrement: *--p -> arr[--p_index] ----
-        case PointerAccessKind::DerefPreDec: {
+        case PointerAccessKind::DerefPreDec:
+        {
             const Stmt *P = findParent(access.expr);
             const UnaryOperator *DecOp = P ? dyn_cast<UnaryOperator>(P) : nullptr;
-            if (!DecOp) break;
+            if (!DecOp)
+                break;
             const Stmt *GP = findGrandParent(DecOp);
             const UnaryOperator *DerefOp = GP ? dyn_cast<UnaryOperator>(GP) : nullptr;
-            if (!DerefOp) break;
+            if (!DerefOp)
+                break;
 
             SourceLocation StartLoc = DerefOp->getBeginLoc();
             SourceLocation EndLoc = Lexer::getLocForEndOfToken(
@@ -448,11 +496,14 @@ bool FunctionAccessAnalyzer::generateTransformation(
 
         // ---- Deref with offset: *(p + expr) -> arr[p_index + expr] ----
         case PointerAccessKind::DerefOffset:
-        case PointerAccessKind::DerefOffsetWrite: {
+        case PointerAccessKind::DerefOffsetWrite:
+        {
             // enclosing_stmt holds the UO_Deref node
             const UnaryOperator *DerefUO = access.enclosing_stmt
-                ? dyn_cast<UnaryOperator>(access.enclosing_stmt) : nullptr;
-            if (!DerefUO) break;
+                                               ? dyn_cast<UnaryOperator>(access.enclosing_stmt)
+                                               : nullptr;
+            if (!DerefUO)
+                break;
 
             SourceLocation StartLoc = DerefUO->getBeginLoc();
             SourceLocation EndLoc = Lexer::getLocForEndOfToken(
@@ -471,10 +522,12 @@ bool FunctionAccessAnalyzer::generateTransformation(
 
         // ---- Arrow access: p->field -> arr[p_index].field ----
         case PointerAccessKind::ArrowAccess:
-        case PointerAccessKind::ArrowWrite: {
+        case PointerAccessKind::ArrowWrite:
+        {
             const Stmt *P = findParent(access.expr);
             const MemberExpr *ME = P ? dyn_cast<MemberExpr>(P) : nullptr;
-            if (!ME) break;
+            if (!ME)
+                break;
 
             SourceLocation StartLoc = ME->getBeginLoc();
             SourceLocation EndLoc = Lexer::getLocForEndOfToken(
@@ -492,19 +545,24 @@ bool FunctionAccessAnalyzer::generateTransformation(
 
         // ---- Subscript: p[i] -> arr[p_index + i] ----
         case PointerAccessKind::Subscript:
-        case PointerAccessKind::SubscriptWrite: {
+        case PointerAccessKind::SubscriptWrite:
+        {
             const Stmt *P = findParent(access.expr);
             const ArraySubscriptExpr *ASE = P ? dyn_cast<ArraySubscriptExpr>(P) : nullptr;
-            if (!ASE) break;
+            if (!ASE)
+                break;
 
             SourceLocation StartLoc = ASE->getBeginLoc();
             SourceLocation EndLoc = Lexer::getLocForEndOfToken(
                 ASE->getEndLoc(), 0, SM, LO);
 
             std::string index_expr;
-            if (access.subscript_text == "0") {
+            if (access.subscript_text == "0")
+            {
                 index_expr = index_name;
-            } else {
+            }
+            else
+            {
                 index_expr = index_name + " + " + access.subscript_text;
             }
 
@@ -538,20 +596,27 @@ bool FunctionAccessAnalyzer::generateTransformation(
         // an integer where a `char *` was expected. c2rust then cast
         // the int to a pointer, producing literal addresses like 0x4
         // and SIGSEGV'ing on dereference.
-        case PointerAccessKind::Increment: {
+        case PointerAccessKind::Increment:
+        {
             const Stmt *P = findParent(access.expr);
             const UnaryOperator *UO = P ? dyn_cast<UnaryOperator>(P) : nullptr;
-            if (!UO) break;
+            if (!UO)
+                break;
 
             bool wrap = false;
             const Stmt *GP = findGrandParent(UO);
-            if (GP) {
-                if (isa<CallExpr>(GP) || isa<ReturnStmt>(GP)) {
+            if (GP)
+            {
+                if (isa<CallExpr>(GP) || isa<ReturnStmt>(GP))
+                {
                     wrap = true;
-                } else if (const auto *BO = dyn_cast<BinaryOperator>(GP)) {
+                }
+                else if (const auto *BO = dyn_cast<BinaryOperator>(GP))
+                {
                     if (BO->isAssignmentOp() &&
                         BO->getRHS()->IgnoreParenImpCasts() == UO &&
-                        BO->getLHS()->getType()->isPointerType()) {
+                        BO->getLHS()->getType()->isPointerType())
+                    {
                         wrap = true;
                     }
                 }
@@ -564,12 +629,12 @@ bool FunctionAccessAnalyzer::generateTransformation(
             std::string replacement;
             if (UO->getOpcode() == UO_PostInc)
                 replacement = wrap
-                    ? ("(" + base_array + " + " + index_name + "++)")
-                    : (index_name + "++");
+                                  ? ("(" + base_array + " + " + index_name + "++)")
+                                  : (index_name + "++");
             else // UO_PreInc
                 replacement = wrap
-                    ? ("(" + base_array + " + ++" + index_name + ")")
-                    : ("++" + index_name);
+                                  ? ("(" + base_array + " + ++" + index_name + ")")
+                                  : ("++" + index_name);
 
             Edit e;
             e.type = Edit::Replace;
@@ -583,20 +648,27 @@ bool FunctionAccessAnalyzer::generateTransformation(
 
         // ---- Standalone decrement: p-- -> p_index-- ----
         // Same context-aware wrapping as Increment above; see comment there.
-        case PointerAccessKind::Decrement: {
+        case PointerAccessKind::Decrement:
+        {
             const Stmt *P = findParent(access.expr);
             const UnaryOperator *UO = P ? dyn_cast<UnaryOperator>(P) : nullptr;
-            if (!UO) break;
+            if (!UO)
+                break;
 
             bool wrap = false;
             const Stmt *GP = findGrandParent(UO);
-            if (GP) {
-                if (isa<CallExpr>(GP) || isa<ReturnStmt>(GP)) {
+            if (GP)
+            {
+                if (isa<CallExpr>(GP) || isa<ReturnStmt>(GP))
+                {
                     wrap = true;
-                } else if (const auto *BO = dyn_cast<BinaryOperator>(GP)) {
+                }
+                else if (const auto *BO = dyn_cast<BinaryOperator>(GP))
+                {
                     if (BO->isAssignmentOp() &&
                         BO->getRHS()->IgnoreParenImpCasts() == UO &&
-                        BO->getLHS()->getType()->isPointerType()) {
+                        BO->getLHS()->getType()->isPointerType())
+                    {
                         wrap = true;
                     }
                 }
@@ -609,12 +681,12 @@ bool FunctionAccessAnalyzer::generateTransformation(
             std::string replacement;
             if (UO->getOpcode() == UO_PostDec)
                 replacement = wrap
-                    ? ("(" + base_array + " + " + index_name + "--)")
-                    : (index_name + "--");
+                                  ? ("(" + base_array + " + " + index_name + "--)")
+                                  : (index_name + "--");
             else // UO_PreDec
                 replacement = wrap
-                    ? ("(" + base_array + " + --" + index_name + ")")
-                    : ("--" + index_name);
+                                  ? ("(" + base_array + " + --" + index_name + ")")
+                                  : ("--" + index_name);
 
             Edit e;
             e.type = Edit::Replace;
@@ -627,7 +699,8 @@ bool FunctionAccessAnalyzer::generateTransformation(
         }
 
         // ---- Plus assign: p += n -> p_index += n ----
-        case PointerAccessKind::PlusAssign: {
+        case PointerAccessKind::PlusAssign:
+        {
             // Replace just the LHS identifier (p -> p_index), leaving
             // the += and RHS intact so inner edits (e.g., function args)
             // don't overlap with this edit.
@@ -646,7 +719,8 @@ bool FunctionAccessAnalyzer::generateTransformation(
         }
 
         // ---- Minus assign: p -= n -> p_index -= n ----
-        case PointerAccessKind::MinusAssign: {
+        case PointerAccessKind::MinusAssign:
+        {
             // Replace just the LHS identifier, same as PlusAssign.
             SourceLocation StartLoc = access.expr->getBeginLoc();
             SourceLocation EndLoc = Lexer::getLocForEndOfToken(
@@ -663,12 +737,15 @@ bool FunctionAccessAnalyzer::generateTransformation(
         }
 
         // ---- Assign null: p = NULL -> p_index = -1 ----
-        case PointerAccessKind::AssignNull: {
+        case PointerAccessKind::AssignNull:
+        {
             // Retained pointer: `p = NULL` keeps acting on the live pointer.
-            if (ptr_retained) break;
+            if (ptr_retained)
+                break;
             const Stmt *P = findParent(access.expr);
             const BinaryOperator *BO = P ? dyn_cast<BinaryOperator>(P) : nullptr;
-            if (!BO) break;
+            if (!BO)
+                break;
 
             SourceLocation StartLoc = BO->getBeginLoc();
             SourceLocation EndLoc = Lexer::getLocForEndOfToken(
@@ -685,10 +762,12 @@ bool FunctionAccessAnalyzer::generateTransformation(
         }
 
         // ---- Assign &arr[i]: p = &arr[i] -> p_index = i ----
-        case PointerAccessKind::AssignAddrOf: {
+        case PointerAccessKind::AssignAddrOf:
+        {
             const Stmt *P = findParent(access.expr);
             const BinaryOperator *BO = P ? dyn_cast<BinaryOperator>(P) : nullptr;
-            if (!BO) break;
+            if (!BO)
+                break;
 
             SourceLocation StartLoc = BO->getBeginLoc();
             SourceLocation EndLoc = Lexer::getLocForEndOfToken(
@@ -705,10 +784,12 @@ bool FunctionAccessAnalyzer::generateTransformation(
         }
 
         // ---- Assign arr: p = arr -> p_index = 0 ----
-        case PointerAccessKind::AssignArray: {
+        case PointerAccessKind::AssignArray:
+        {
             const Stmt *P = findParent(access.expr);
             const BinaryOperator *BO = P ? dyn_cast<BinaryOperator>(P) : nullptr;
-            if (!BO) break;
+            if (!BO)
+                break;
 
             SourceLocation StartLoc = BO->getBeginLoc();
             SourceLocation EndLoc = Lexer::getLocForEndOfToken(
@@ -725,10 +806,12 @@ bool FunctionAccessAnalyzer::generateTransformation(
         }
 
         // ---- Assign arr + offset: p = arr + off -> p_index = off ----
-        case PointerAccessKind::AssignArrayOffset: {
+        case PointerAccessKind::AssignArrayOffset:
+        {
             const Stmt *P = findParent(access.expr);
             const BinaryOperator *BO = P ? dyn_cast<BinaryOperator>(P) : nullptr;
-            if (!BO) break;
+            if (!BO)
+                break;
 
             SourceLocation StartLoc = BO->getBeginLoc();
             SourceLocation EndLoc = Lexer::getLocForEndOfToken(
@@ -747,7 +830,8 @@ bool FunctionAccessAnalyzer::generateTransformation(
         // ---- Comparison null: p == NULL -> p_index == -1 ----
         // ---- Comparison expr: p < arr+n -> p_index < n ----
         case PointerAccessKind::ComparisonNull:
-        case PointerAccessKind::ComparisonExpr: {
+        case PointerAccessKind::ComparisonExpr:
+        {
             // Retained pointer: `p == NULL` / `p != NULL` keeps testing the
             // live pointer. (ComparisonExpr is still an index comparison and
             // is rewritten as usual.)
@@ -755,7 +839,8 @@ bool FunctionAccessAnalyzer::generateTransformation(
                 break;
             const Stmt *P = findParent(access.expr);
             const BinaryOperator *BO = P ? dyn_cast<BinaryOperator>(P) : nullptr;
-            if (!BO) break;
+            if (!BO)
+                break;
 
             SourceLocation StartLoc = BO->getBeginLoc();
             SourceLocation EndLoc = Lexer::getLocForEndOfToken(
@@ -777,9 +862,11 @@ bool FunctionAccessAnalyzer::generateTransformation(
         }
 
         // ---- Bool true: if (p), p && ... -> p_index != -1 ----
-        case PointerAccessKind::BoolTrue: {
+        case PointerAccessKind::BoolTrue:
+        {
             // Retained pointer: `if (p)` keeps testing the live pointer.
-            if (ptr_retained) break;
+            if (ptr_retained)
+                break;
             // Replace just the pointer DRE (source range = the pointer name token)
             SourceLocation StartLoc = access.expr->getBeginLoc();
             SourceLocation EndLoc = Lexer::getLocForEndOfToken(
@@ -796,12 +883,15 @@ bool FunctionAccessAnalyzer::generateTransformation(
         }
 
         // ---- Bool false: !p -> p_index == -1 ----
-        case PointerAccessKind::BoolFalse: {
+        case PointerAccessKind::BoolFalse:
+        {
             // Retained pointer: `!p` keeps testing the live pointer.
-            if (ptr_retained) break;
+            if (ptr_retained)
+                break;
             const Stmt *P = findParent(access.expr);
             const UnaryOperator *UO = P ? dyn_cast<UnaryOperator>(P) : nullptr;
-            if (!UO) break;
+            if (!UO)
+                break;
 
             SourceLocation StartLoc = UO->getBeginLoc();
             SourceLocation EndLoc = Lexer::getLocForEndOfToken(
@@ -818,15 +908,19 @@ bool FunctionAccessAnalyzer::generateTransformation(
         }
 
         // ---- PassedToAllowedFunc: sscanf(p, ...) -> sscanf(base + p_index, ...) ----
-        case PointerAccessKind::PassedToAllowedFunc: {
+        case PointerAccessKind::PassedToAllowedFunc:
+        {
             // Check if this same CallExpr is already covered by an AssignFromAllowedFunc
             // (e.g., s = strchr(s, c) — the assignment handler covers the whole call)
             const CallExpr *CE = dyn_cast<CallExpr>(access.enclosing_stmt);
-            if (CE) {
+            if (CE)
+            {
                 bool covered = false;
-                for (const auto &other : accesses) {
+                for (const auto &other : accesses)
+                {
                     if (other.kind == PointerAccessKind::AssignFromAllowedFunc &&
-                        other.enclosing_stmt == CE) {
+                        other.enclosing_stmt == CE)
+                    {
                         covered = true;
                         break;
                     }
@@ -851,8 +945,9 @@ bool FunctionAccessAnalyzer::generateTransformation(
         }
 
         // ---- AssignFromAllowedFunc: s = strchr(s, c) -> s_index = strchr_index(base, s_index, c) ----
-        case PointerAccessKind::AssignFromAllowedFunc: {
-            std::string func_name = access.offset_text;  // stored in offset_text field
+        case PointerAccessKind::AssignFromAllowedFunc:
+        {
+            std::string func_name = access.offset_text; // stored in offset_text field
             std::string wrapper_name = func_name + "_index_xj";
 
             // Re-walk the original call's args using the now-known base.
@@ -866,13 +961,17 @@ bool FunctionAccessAnalyzer::generateTransformation(
             // arg and a "too many arguments to function call" C error.
             std::string other_args;
             const CallExpr *CE = dyn_cast_or_null<CallExpr>(access.enclosing_stmt);
-            if (CE) {
-                for (unsigned i = 0; i < CE->getNumArgs(); i++) {
+            if (CE)
+            {
+                for (unsigned i = 0; i < CE->getNumArgs(); i++)
+                {
                     const Expr *Arg = CE->getArg(i)->IgnoreParenImpCasts();
-                    if (const DeclRefExpr *ArgDRE = dyn_cast<DeclRefExpr>(Arg)) {
+                    if (const DeclRefExpr *ArgDRE = dyn_cast<DeclRefExpr>(Arg))
+                    {
                         if (ArgDRE->getDecl() == PtrVar)
                             continue; // already passed as `start`
-                        if (const VarDecl *AVD = dyn_cast<VarDecl>(ArgDRE->getDecl())) {
+                        if (const VarDecl *AVD = dyn_cast<VarDecl>(ArgDRE->getDecl()))
+                        {
                             if (AVD->getNameAsString() == candidate.base_array_text)
                                 continue; // already passed as `base`
                         }
@@ -881,17 +980,21 @@ bool FunctionAccessAnalyzer::generateTransformation(
                     if (!candidate.base_array_text.empty() &&
                         arg_text == candidate.base_array_text)
                         continue; // text-level fallback
-                    if (!other_args.empty()) other_args += ", ";
+                    if (!other_args.empty())
+                        other_args += ", ";
                     other_args += arg_text;
                 }
-            } else {
+            }
+            else
+            {
                 other_args = access.operand_text; // fallback
             }
 
             // Find the enclosing assignment: p = func(...)
             const Stmt *P = findParent(access.expr);
             const BinaryOperator *BO = P ? dyn_cast<BinaryOperator>(P) : nullptr;
-            if (!BO) break;
+            if (!BO)
+                break;
 
             // Build replacement: p_index = func_index(base, p_index, other_args)
             std::string replacement = index_name + " = " + wrapper_name + "(" +
@@ -905,13 +1008,16 @@ bool FunctionAccessAnalyzer::generateTransformation(
             // In that case, append >= 0
             bool in_bool_context = false;
             const Stmt *AssignParent = skipTransparentParents(BO, Ctx);
-            if (AssignParent) {
+            if (AssignParent)
+            {
                 if (isa<IfStmt>(AssignParent) || isa<WhileStmt>(AssignParent) ||
-                    isa<ForStmt>(AssignParent) || isa<DoStmt>(AssignParent)) {
+                    isa<ForStmt>(AssignParent) || isa<DoStmt>(AssignParent))
+                {
                     in_bool_context = true;
                 }
                 // Also check for logical operators: (s = strchr(...)) && ...
-                if (const BinaryOperator *LogBO = dyn_cast<BinaryOperator>(AssignParent)) {
+                if (const BinaryOperator *LogBO = dyn_cast<BinaryOperator>(AssignParent))
+                {
                     if (LogBO->getOpcode() == BO_LAnd || LogBO->getOpcode() == BO_LOr)
                         in_bool_context = true;
                 }
@@ -933,7 +1039,8 @@ bool FunctionAccessAnalyzer::generateTransformation(
             edits.push_back(e);
 
             // Emit wrapper function if not already emitted
-            if (g_emitted_wrappers.find(wrapper_name) == g_emitted_wrappers.end()) {
+            if (g_emitted_wrappers.find(wrapper_name) == g_emitted_wrappers.end())
+            {
                 g_emitted_wrappers.insert(wrapper_name);
 
                 // Get the pointee type from the pointer
@@ -941,13 +1048,16 @@ bool FunctionAccessAnalyzer::generateTransformation(
                 std::string type_str = pointeeType.getAsString();
 
                 std::string wrapper;
-                if (func_name == "strchr") {
+                if (func_name == "strchr")
+                {
                     wrapper = "static int strchr_index_xj(const char *base, int start, int c) {\n"
                               "    const char *result = strchr(base + start, c);\n"
                               "    if (!result) return -1;\n"
                               "    return (int)(result - base);\n"
                               "}\n\n";
-                } else if (func_name == "strstr") {
+                }
+                else if (func_name == "strstr")
+                {
                     wrapper = "static int strstr_index_xj(const char *base, int start, const char *needle) {\n"
                               "    const char *result = strstr(base + start, needle);\n"
                               "    if (!result) return -1;\n"
@@ -955,7 +1065,8 @@ bool FunctionAccessAnalyzer::generateTransformation(
                               "}\n\n";
                 }
 
-                if (!wrapper.empty()) {
+                if (!wrapper.empty())
+                {
                     // Insert wrapper before the function definition
                     SourceLocation FuncStart = FD->getBeginLoc();
                     Edit we;
@@ -974,7 +1085,8 @@ bool FunctionAccessAnalyzer::generateTransformation(
         // is a RustSlice candidate: the slice pass reads the (base +
         // index) shape back out of the AST when it rebuilds the call
         // site, and the intermediate C stays valid either way.
-        case PointerAccessKind::PassedToFunc: {
+        case PointerAccessKind::PassedToFunc:
+        {
             SourceLocation StartLoc = access.expr->getBeginLoc();
             SourceLocation EndLoc = Lexer::getLocForEndOfToken(
                 access.expr->getEndLoc(), 0, SM, LO);
@@ -992,7 +1104,8 @@ bool FunctionAccessAnalyzer::generateTransformation(
         // ---- ReturnPtr: return p -> return base + index ----
         // Always the pointer form; if the slice pass later retypes the
         // function's return as int, it also shrinks this to a bare index.
-        case PointerAccessKind::ReturnPtr: {
+        case PointerAccessKind::ReturnPtr:
+        {
             SourceLocation StartLoc = access.expr->getBeginLoc();
             SourceLocation EndLoc = Lexer::getLocForEndOfToken(
                 access.expr->getEndLoc(), 0, SM, LO);
@@ -1012,7 +1125,8 @@ bool FunctionAccessAnalyzer::generateTransformation(
         }
     }
 
-    if (edits.empty()) {
+    if (edits.empty())
+    {
         if (VERBOSE)
             llvm::outs() << "[Warning] No edits generated for " << ptr_name << "\n";
         return false;
@@ -1020,8 +1134,8 @@ bool FunctionAccessAnalyzer::generateTransformation(
 
     if (VERBOSE)
         llvm::outs() << "[Transform] Applying " << edits.size() << " edits for "
-                      << ptr_name << " -> " << index_name
-                      << " (base: " << base_array << ")\n";
+                     << ptr_name << " -> " << index_name
+                     << " (base: " << base_array << ")\n";
 
     applyEdits(edits, SM);
     return true;
@@ -1042,7 +1156,8 @@ bool FunctionAccessAnalyzer::generateGlobalTransformation(
     const VarDecl *PtrVar,
     PointerCandidate &candidate,
     std::vector<PointerAccess> &accesses,
-    ASTContext &Ctx) {
+    ASTContext &Ctx)
+{
 
     SourceManager &SM = Ctx.getSourceManager();
     const LangOptions &LO = Ctx.getLangOpts();
@@ -1059,14 +1174,20 @@ bool FunctionAccessAnalyzer::generateGlobalTransformation(
 
     // Determine init value from the first init access
     std::string init_value = "0";
-    for (const auto &access : accesses) {
-        if (access.kind == PointerAccessKind::InitNull) {
+    for (const auto &access : accesses)
+    {
+        if (access.kind == PointerAccessKind::InitNull)
+        {
             init_value = "-1";
             break;
-        } else if (access.kind == PointerAccessKind::InitArray) {
+        }
+        else if (access.kind == PointerAccessKind::InitArray)
+        {
             init_value = "0";
             break;
-        } else if (access.kind == PointerAccessKind::InitArrayOffset) {
+        }
+        else if (access.kind == PointerAccessKind::InitArrayOffset)
+        {
             init_value = access.offset_text;
             break;
         }
@@ -1095,26 +1216,32 @@ bool FunctionAccessAnalyzer::generateGlobalTransformation(
     // Step 2: Replace all accesses (same logic as local pointer transformation)
     // ========================================================================
 
-    for (const auto &access : accesses) {
+    for (const auto &access : accesses)
+    {
         if (access.kind == PointerAccessKind::InitNull ||
             access.kind == PointerAccessKind::InitArray ||
             access.kind == PointerAccessKind::InitArrayOffset)
             continue;
 
-        auto findParent = [&](const Expr *E) -> const Stmt * {
+        auto findParent = [&](const Expr *E) -> const Stmt *
+        {
             return skipTransparentParents(E, Ctx);
         };
-        auto findGrandParent = [&](const Stmt *P) -> const Stmt * {
+        auto findGrandParent = [&](const Stmt *P) -> const Stmt *
+        {
             return skipTransparentParents(P, Ctx);
         };
 
-        switch (access.kind) {
+        switch (access.kind)
+        {
 
         case PointerAccessKind::Deref:
-        case PointerAccessKind::DerefWrite: {
+        case PointerAccessKind::DerefWrite:
+        {
             const Stmt *P = findParent(access.expr);
             const UnaryOperator *UO = P ? dyn_cast<UnaryOperator>(P) : nullptr;
-            if (!UO) break;
+            if (!UO)
+                break;
             SourceLocation StartLoc = UO->getBeginLoc();
             SourceLocation EndLoc = Lexer::getLocForEndOfToken(UO->getEndLoc(), 0, SM, LO);
             edits.push_back({Edit::Replace, SM.getFileOffset(StartLoc),
@@ -1123,13 +1250,16 @@ bool FunctionAccessAnalyzer::generateGlobalTransformation(
             break;
         }
 
-        case PointerAccessKind::DerefPostInc: {
+        case PointerAccessKind::DerefPostInc:
+        {
             const Stmt *P = findParent(access.expr);
             const UnaryOperator *IncOp = P ? dyn_cast<UnaryOperator>(P) : nullptr;
-            if (!IncOp) break;
+            if (!IncOp)
+                break;
             const Stmt *GP = findGrandParent(IncOp);
             const UnaryOperator *DerefOp = GP ? dyn_cast<UnaryOperator>(GP) : nullptr;
-            if (!DerefOp) break;
+            if (!DerefOp)
+                break;
             SourceLocation StartLoc = DerefOp->getBeginLoc();
             SourceLocation EndLoc = Lexer::getLocForEndOfToken(DerefOp->getEndLoc(), 0, SM, LO);
             edits.push_back({Edit::Replace, SM.getFileOffset(StartLoc),
@@ -1138,13 +1268,16 @@ bool FunctionAccessAnalyzer::generateGlobalTransformation(
             break;
         }
 
-        case PointerAccessKind::DerefPreInc: {
+        case PointerAccessKind::DerefPreInc:
+        {
             const Stmt *P = findParent(access.expr);
             const UnaryOperator *IncOp = P ? dyn_cast<UnaryOperator>(P) : nullptr;
-            if (!IncOp) break;
+            if (!IncOp)
+                break;
             const Stmt *GP = findGrandParent(IncOp);
             const UnaryOperator *DerefOp = GP ? dyn_cast<UnaryOperator>(GP) : nullptr;
-            if (!DerefOp) break;
+            if (!DerefOp)
+                break;
             SourceLocation StartLoc = DerefOp->getBeginLoc();
             SourceLocation EndLoc = Lexer::getLocForEndOfToken(DerefOp->getEndLoc(), 0, SM, LO);
             edits.push_back({Edit::Replace, SM.getFileOffset(StartLoc),
@@ -1153,13 +1286,16 @@ bool FunctionAccessAnalyzer::generateGlobalTransformation(
             break;
         }
 
-        case PointerAccessKind::DerefPostDec: {
+        case PointerAccessKind::DerefPostDec:
+        {
             const Stmt *P = findParent(access.expr);
             const UnaryOperator *DecOp = P ? dyn_cast<UnaryOperator>(P) : nullptr;
-            if (!DecOp) break;
+            if (!DecOp)
+                break;
             const Stmt *GP = findGrandParent(DecOp);
             const UnaryOperator *DerefOp = GP ? dyn_cast<UnaryOperator>(GP) : nullptr;
-            if (!DerefOp) break;
+            if (!DerefOp)
+                break;
             SourceLocation StartLoc = DerefOp->getBeginLoc();
             SourceLocation EndLoc = Lexer::getLocForEndOfToken(DerefOp->getEndLoc(), 0, SM, LO);
             edits.push_back({Edit::Replace, SM.getFileOffset(StartLoc),
@@ -1168,13 +1304,16 @@ bool FunctionAccessAnalyzer::generateGlobalTransformation(
             break;
         }
 
-        case PointerAccessKind::DerefPreDec: {
+        case PointerAccessKind::DerefPreDec:
+        {
             const Stmt *P = findParent(access.expr);
             const UnaryOperator *DecOp = P ? dyn_cast<UnaryOperator>(P) : nullptr;
-            if (!DecOp) break;
+            if (!DecOp)
+                break;
             const Stmt *GP = findGrandParent(DecOp);
             const UnaryOperator *DerefOp = GP ? dyn_cast<UnaryOperator>(GP) : nullptr;
-            if (!DerefOp) break;
+            if (!DerefOp)
+                break;
             SourceLocation StartLoc = DerefOp->getBeginLoc();
             SourceLocation EndLoc = Lexer::getLocForEndOfToken(DerefOp->getEndLoc(), 0, SM, LO);
             edits.push_back({Edit::Replace, SM.getFileOffset(StartLoc),
@@ -1184,10 +1323,13 @@ bool FunctionAccessAnalyzer::generateGlobalTransformation(
         }
 
         case PointerAccessKind::DerefOffset:
-        case PointerAccessKind::DerefOffsetWrite: {
+        case PointerAccessKind::DerefOffsetWrite:
+        {
             const UnaryOperator *DerefUO = access.enclosing_stmt
-                ? dyn_cast<UnaryOperator>(access.enclosing_stmt) : nullptr;
-            if (!DerefUO) break;
+                                               ? dyn_cast<UnaryOperator>(access.enclosing_stmt)
+                                               : nullptr;
+            if (!DerefUO)
+                break;
             SourceLocation StartLoc = DerefUO->getBeginLoc();
             SourceLocation EndLoc = Lexer::getLocForEndOfToken(
                 DerefUO->getEndLoc(), 0, SM, LO);
@@ -1198,10 +1340,12 @@ bool FunctionAccessAnalyzer::generateGlobalTransformation(
         }
 
         case PointerAccessKind::ArrowAccess:
-        case PointerAccessKind::ArrowWrite: {
+        case PointerAccessKind::ArrowWrite:
+        {
             const Stmt *P = findParent(access.expr);
             const MemberExpr *ME = P ? dyn_cast<MemberExpr>(P) : nullptr;
-            if (!ME) break;
+            if (!ME)
+                break;
             SourceLocation StartLoc = ME->getBeginLoc();
             SourceLocation EndLoc = Lexer::getLocForEndOfToken(ME->getEndLoc(), 0, SM, LO);
             edits.push_back({Edit::Replace, SM.getFileOffset(StartLoc),
@@ -1211,24 +1355,29 @@ bool FunctionAccessAnalyzer::generateGlobalTransformation(
         }
 
         case PointerAccessKind::Subscript:
-        case PointerAccessKind::SubscriptWrite: {
+        case PointerAccessKind::SubscriptWrite:
+        {
             const Stmt *P = findParent(access.expr);
             const ArraySubscriptExpr *ASE = P ? dyn_cast<ArraySubscriptExpr>(P) : nullptr;
-            if (!ASE) break;
+            if (!ASE)
+                break;
             SourceLocation StartLoc = ASE->getBeginLoc();
             SourceLocation EndLoc = Lexer::getLocForEndOfToken(ASE->getEndLoc(), 0, SM, LO);
             std::string index_expr = (access.subscript_text == "0")
-                ? index_name : index_name + " + " + access.subscript_text;
+                                         ? index_name
+                                         : index_name + " + " + access.subscript_text;
             edits.push_back({Edit::Replace, SM.getFileOffset(StartLoc),
                              StartLoc, EndLoc,
                              base_array + "[" + index_expr + "]"});
             break;
         }
 
-        case PointerAccessKind::Increment: {
+        case PointerAccessKind::Increment:
+        {
             const Stmt *P = findParent(access.expr);
             const UnaryOperator *UO = P ? dyn_cast<UnaryOperator>(P) : nullptr;
-            if (!UO) break;
+            if (!UO)
+                break;
             // See the longer comment on the Increment case in the
             // earlier transformer pass: when the result of `++p`/`p++`
             // is consumed as a pointer (call arg, return, assignment
@@ -1236,13 +1385,18 @@ bool FunctionAccessAnalyzer::generateGlobalTransformation(
             // the value type stays a pointer.
             bool wrap = false;
             const Stmt *GP = findGrandParent(UO);
-            if (GP) {
-                if (isa<CallExpr>(GP) || isa<ReturnStmt>(GP)) {
+            if (GP)
+            {
+                if (isa<CallExpr>(GP) || isa<ReturnStmt>(GP))
+                {
                     wrap = true;
-                } else if (const auto *BO = dyn_cast<BinaryOperator>(GP)) {
+                }
+                else if (const auto *BO = dyn_cast<BinaryOperator>(GP))
+                {
                     if (BO->isAssignmentOp() &&
                         BO->getRHS()->IgnoreParenImpCasts() == UO &&
-                        BO->getLHS()->getType()->isPointerType()) {
+                        BO->getLHS()->getType()->isPointerType())
+                    {
                         wrap = true;
                     }
                 }
@@ -1252,30 +1406,37 @@ bool FunctionAccessAnalyzer::generateGlobalTransformation(
             std::string repl;
             if (UO->getOpcode() == UO_PostInc)
                 repl = wrap
-                    ? ("(" + base_array + " + " + index_name + "++)")
-                    : (index_name + "++");
+                           ? ("(" + base_array + " + " + index_name + "++)")
+                           : (index_name + "++");
             else
                 repl = wrap
-                    ? ("(" + base_array + " + ++" + index_name + ")")
-                    : ("++" + index_name);
+                           ? ("(" + base_array + " + ++" + index_name + ")")
+                           : ("++" + index_name);
             edits.push_back({Edit::Replace, SM.getFileOffset(StartLoc),
                              StartLoc, EndLoc, repl});
             break;
         }
 
-        case PointerAccessKind::Decrement: {
+        case PointerAccessKind::Decrement:
+        {
             const Stmt *P = findParent(access.expr);
             const UnaryOperator *UO = P ? dyn_cast<UnaryOperator>(P) : nullptr;
-            if (!UO) break;
+            if (!UO)
+                break;
             bool wrap = false;
             const Stmt *GP = findGrandParent(UO);
-            if (GP) {
-                if (isa<CallExpr>(GP) || isa<ReturnStmt>(GP)) {
+            if (GP)
+            {
+                if (isa<CallExpr>(GP) || isa<ReturnStmt>(GP))
+                {
                     wrap = true;
-                } else if (const auto *BO = dyn_cast<BinaryOperator>(GP)) {
+                }
+                else if (const auto *BO = dyn_cast<BinaryOperator>(GP))
+                {
                     if (BO->isAssignmentOp() &&
                         BO->getRHS()->IgnoreParenImpCasts() == UO &&
-                        BO->getLHS()->getType()->isPointerType()) {
+                        BO->getLHS()->getType()->isPointerType())
+                    {
                         wrap = true;
                     }
                 }
@@ -1285,18 +1446,19 @@ bool FunctionAccessAnalyzer::generateGlobalTransformation(
             std::string repl;
             if (UO->getOpcode() == UO_PostDec)
                 repl = wrap
-                    ? ("(" + base_array + " + " + index_name + "--)")
-                    : (index_name + "--");
+                           ? ("(" + base_array + " + " + index_name + "--)")
+                           : (index_name + "--");
             else
                 repl = wrap
-                    ? ("(" + base_array + " + --" + index_name + ")")
-                    : ("--" + index_name);
+                           ? ("(" + base_array + " + --" + index_name + ")")
+                           : ("--" + index_name);
             edits.push_back({Edit::Replace, SM.getFileOffset(StartLoc),
                              StartLoc, EndLoc, repl});
             break;
         }
 
-        case PointerAccessKind::PlusAssign: {
+        case PointerAccessKind::PlusAssign:
+        {
             SourceLocation StartLoc = access.expr->getBeginLoc();
             SourceLocation EndLoc = Lexer::getLocForEndOfToken(access.expr->getEndLoc(), 0, SM, LO);
             edits.push_back({Edit::Replace, SM.getFileOffset(StartLoc),
@@ -1304,7 +1466,8 @@ bool FunctionAccessAnalyzer::generateGlobalTransformation(
             break;
         }
 
-        case PointerAccessKind::MinusAssign: {
+        case PointerAccessKind::MinusAssign:
+        {
             SourceLocation StartLoc = access.expr->getBeginLoc();
             SourceLocation EndLoc = Lexer::getLocForEndOfToken(access.expr->getEndLoc(), 0, SM, LO);
             edits.push_back({Edit::Replace, SM.getFileOffset(StartLoc),
@@ -1312,10 +1475,12 @@ bool FunctionAccessAnalyzer::generateGlobalTransformation(
             break;
         }
 
-        case PointerAccessKind::AssignNull: {
+        case PointerAccessKind::AssignNull:
+        {
             const Stmt *P = findParent(access.expr);
             const BinaryOperator *BO = P ? dyn_cast<BinaryOperator>(P) : nullptr;
-            if (!BO) break;
+            if (!BO)
+                break;
             SourceLocation StartLoc = BO->getBeginLoc();
             SourceLocation EndLoc = Lexer::getLocForEndOfToken(BO->getEndLoc(), 0, SM, LO);
             edits.push_back({Edit::Replace, SM.getFileOffset(StartLoc),
@@ -1324,10 +1489,12 @@ bool FunctionAccessAnalyzer::generateGlobalTransformation(
             break;
         }
 
-        case PointerAccessKind::AssignAddrOf: {
+        case PointerAccessKind::AssignAddrOf:
+        {
             const Stmt *P = findParent(access.expr);
             const BinaryOperator *BO = P ? dyn_cast<BinaryOperator>(P) : nullptr;
-            if (!BO) break;
+            if (!BO)
+                break;
             SourceLocation StartLoc = BO->getBeginLoc();
             SourceLocation EndLoc = Lexer::getLocForEndOfToken(BO->getEndLoc(), 0, SM, LO);
             edits.push_back({Edit::Replace, SM.getFileOffset(StartLoc),
@@ -1336,10 +1503,12 @@ bool FunctionAccessAnalyzer::generateGlobalTransformation(
             break;
         }
 
-        case PointerAccessKind::AssignArray: {
+        case PointerAccessKind::AssignArray:
+        {
             const Stmt *P = findParent(access.expr);
             const BinaryOperator *BO = P ? dyn_cast<BinaryOperator>(P) : nullptr;
-            if (!BO) break;
+            if (!BO)
+                break;
             SourceLocation StartLoc = BO->getBeginLoc();
             SourceLocation EndLoc = Lexer::getLocForEndOfToken(BO->getEndLoc(), 0, SM, LO);
             edits.push_back({Edit::Replace, SM.getFileOffset(StartLoc),
@@ -1348,10 +1517,12 @@ bool FunctionAccessAnalyzer::generateGlobalTransformation(
             break;
         }
 
-        case PointerAccessKind::AssignArrayOffset: {
+        case PointerAccessKind::AssignArrayOffset:
+        {
             const Stmt *P = findParent(access.expr);
             const BinaryOperator *BO = P ? dyn_cast<BinaryOperator>(P) : nullptr;
-            if (!BO) break;
+            if (!BO)
+                break;
             SourceLocation StartLoc = BO->getBeginLoc();
             SourceLocation EndLoc = Lexer::getLocForEndOfToken(BO->getEndLoc(), 0, SM, LO);
             edits.push_back({Edit::Replace, SM.getFileOffset(StartLoc),
@@ -1361,10 +1532,12 @@ bool FunctionAccessAnalyzer::generateGlobalTransformation(
         }
 
         case PointerAccessKind::ComparisonNull:
-        case PointerAccessKind::ComparisonExpr: {
+        case PointerAccessKind::ComparisonExpr:
+        {
             const Stmt *P = findParent(access.expr);
             const BinaryOperator *BO = P ? dyn_cast<BinaryOperator>(P) : nullptr;
-            if (!BO) break;
+            if (!BO)
+                break;
             SourceLocation StartLoc = BO->getBeginLoc();
             SourceLocation EndLoc = Lexer::getLocForEndOfToken(BO->getEndLoc(), 0, SM, LO);
             if (!access.field_name.empty())
@@ -1378,7 +1551,8 @@ bool FunctionAccessAnalyzer::generateGlobalTransformation(
             break;
         }
 
-        case PointerAccessKind::BoolTrue: {
+        case PointerAccessKind::BoolTrue:
+        {
             SourceLocation StartLoc = access.expr->getBeginLoc();
             SourceLocation EndLoc = Lexer::getLocForEndOfToken(
                 access.expr->getEndLoc(), 0, SM, LO);
@@ -1388,10 +1562,12 @@ bool FunctionAccessAnalyzer::generateGlobalTransformation(
             break;
         }
 
-        case PointerAccessKind::BoolFalse: {
+        case PointerAccessKind::BoolFalse:
+        {
             const Stmt *P = findParent(access.expr);
             const UnaryOperator *UO = P ? dyn_cast<UnaryOperator>(P) : nullptr;
-            if (!UO) break;
+            if (!UO)
+                break;
             SourceLocation StartLoc = UO->getBeginLoc();
             SourceLocation EndLoc = Lexer::getLocForEndOfToken(
                 UO->getEndLoc(), 0, SM, LO);
@@ -1401,13 +1577,17 @@ bool FunctionAccessAnalyzer::generateGlobalTransformation(
             break;
         }
 
-        case PointerAccessKind::PassedToAllowedFunc: {
+        case PointerAccessKind::PassedToAllowedFunc:
+        {
             const CallExpr *CE = dyn_cast<CallExpr>(access.enclosing_stmt);
-            if (CE) {
+            if (CE)
+            {
                 bool covered = false;
-                for (const auto &other : accesses) {
+                for (const auto &other : accesses)
+                {
                     if (other.kind == PointerAccessKind::AssignFromAllowedFunc &&
-                        other.enclosing_stmt == CE) {
+                        other.enclosing_stmt == CE)
+                    {
                         covered = true;
                         break;
                     }
@@ -1424,14 +1604,16 @@ bool FunctionAccessAnalyzer::generateGlobalTransformation(
             break;
         }
 
-        case PointerAccessKind::AssignFromAllowedFunc: {
+        case PointerAccessKind::AssignFromAllowedFunc:
+        {
             std::string func_name = access.offset_text;
             std::string wrapper_name = func_name + "_index_xj";
             std::string other_args = access.operand_text;
 
             const Stmt *P = findParent(access.expr);
             const BinaryOperator *BO = P ? dyn_cast<BinaryOperator>(P) : nullptr;
-            if (!BO) break;
+            if (!BO)
+                break;
 
             std::string replacement = index_name + " = " + wrapper_name + "(" +
                                       base_array + ", " + index_name;
@@ -1441,11 +1623,13 @@ bool FunctionAccessAnalyzer::generateGlobalTransformation(
 
             bool in_bool_context = false;
             const Stmt *AssignParent = skipTransparentParents(BO, Ctx);
-            if (AssignParent) {
+            if (AssignParent)
+            {
                 if (isa<IfStmt>(AssignParent) || isa<WhileStmt>(AssignParent) ||
                     isa<ForStmt>(AssignParent) || isa<DoStmt>(AssignParent))
                     in_bool_context = true;
-                if (const BinaryOperator *LogBO = dyn_cast<BinaryOperator>(AssignParent)) {
+                if (const BinaryOperator *LogBO = dyn_cast<BinaryOperator>(AssignParent))
+                {
                     if (LogBO->getOpcode() == BO_LAnd || LogBO->getOpcode() == BO_LOr)
                         in_bool_context = true;
                 }
@@ -1463,7 +1647,8 @@ bool FunctionAccessAnalyzer::generateGlobalTransformation(
             break;
         }
 
-        case PointerAccessKind::PassedToFunc: {
+        case PointerAccessKind::PassedToFunc:
+        {
             SourceLocation StartLoc = access.expr->getBeginLoc();
             SourceLocation EndLoc = Lexer::getLocForEndOfToken(
                 access.expr->getEndLoc(), 0, SM, LO);
@@ -1473,7 +1658,8 @@ bool FunctionAccessAnalyzer::generateGlobalTransformation(
             break;
         }
 
-        case PointerAccessKind::ReturnPtr: {
+        case PointerAccessKind::ReturnPtr:
+        {
             SourceLocation StartLoc = access.expr->getBeginLoc();
             SourceLocation EndLoc = Lexer::getLocForEndOfToken(
                 access.expr->getEndLoc(), 0, SM, LO);
@@ -1488,7 +1674,8 @@ bool FunctionAccessAnalyzer::generateGlobalTransformation(
         }
     }
 
-    if (edits.empty()) {
+    if (edits.empty())
+    {
         if (VERBOSE)
             llvm::outs() << "[Warning] No edits generated for global " << ptr_name << "\n";
         return false;
@@ -1496,8 +1683,8 @@ bool FunctionAccessAnalyzer::generateGlobalTransformation(
 
     if (VERBOSE)
         llvm::outs() << "[Transform] Applying " << edits.size()
-                      << " edits for global " << ptr_name << " -> " << index_name
-                      << " (base: " << base_array << ")\n";
+                     << " edits for global " << ptr_name << " -> " << index_name
+                     << " (base: " << base_array << ")\n";
 
     applyEdits(edits, SM);
     return true;


### PR DESCRIPTION
Generalize pointer xform fix for anonymous aggregates to multilevel anonymous aggregates (fix #436).

Fixing this exposes another bug that will be fixed in a subsequent PR.

