### PR TITLE
NULL pointer sentinel index bug

### DIFF
--- a/tests/pointer_transform/pointer_transform_cases/null_escapes_as_pointer/expected/null_escapes_as_pointer.c
+++ b/tests/pointer_transform/pointer_transform_cases/null_escapes_as_pointer/expected/null_escapes_as_pointer.c
@@ -1,0 +1,63 @@
+#include <stdio.h>
+#include <string.h>
+
+/* A NULL-able pointer is represented by the out-of-range index -1, so
+ * every site that turns an index back into a pointer has to map that
+ * sentinel back to a real null: `base + -1` addresses one element
+ * before the array and is *not* null, so a callee's null check would
+ * wrongly succeed.
+ *
+ * The two ways an index goes negative are covered here:
+ *   - an explicit NULL assignment (`pick`), and
+ *   - an allowlisted-function wrapper returning -1 for "not found"
+ *     (`first_comma`), where no NULL appears in the source at all.
+ *
+ * `observe` is deliberately left untransformed, so it sees whatever
+ * pointer the rewrite actually produces. */
+static void observe(const char *q, const char *tag) {
+    printf("%s=%s\n", tag, q ? "nonnull" : "null");
+}
+
+static int strchr_index_xj(const char *base, int start, int c) {
+    const char *result = strchr(base + start, c);
+    if (!result) return -1;
+    return (int)(result - base);
+}
+
+static void first_comma(const char *s) {
+    int p_index_xj = 0;
+
+    p_index_xj = strchr_index_xj(s, p_index_xj, ',');
+    observe((p_index_xj < 0 ? (void *)0 : s + p_index_xj), "comma");
+}
+
+static void pick(const char *s, int take) {
+    int p_index_xj = 0;
+
+    if (take)
+        p_index_xj = 1;
+    else
+        p_index_xj = -1;
+    observe((p_index_xj < 0 ? (void *)0 : s + p_index_xj), "pick");
+}
+
+/* The same sentinel crossing a return boundary rather than a call. */
+static const char *maybe_tail(const char *s, int take) {
+    int p_index_xj = 0;
+
+    if (take)
+        p_index_xj = 2;
+    else
+        p_index_xj = -1;
+    return (p_index_xj < 0 ? (void *)0 : s + p_index_xj);
+}
+
+int main(void) {
+    first_comma("a,b");
+    first_comma("nothing here");
+    pick("abc", 1);
+    pick("abc", 0);
+    observe(maybe_tail("abcdef", 1), "tail1");
+    observe(maybe_tail("abcdef", 0), "tail0");
+    return 0;
+}

--- a/tests/pointer_transform/pointer_transform_cases/null_escapes_as_pointer/expected_metadata.json
+++ b/tests/pointer_transform/pointer_transform_cases/null_escapes_as_pointer/expected_metadata.json
@@ -1,0 +1,37 @@
+{
+  "functions": {
+    "first_comma@null_escapes_as_pointer.c": {
+      "file": "null_escapes_as_pointer.c",
+      "pointers": [
+        {
+          "base_text": "s",
+          "index_var": "p_index_xj",
+          "name": "p",
+          "param_index": -1
+        }
+      ]
+    },
+    "maybe_tail@null_escapes_as_pointer.c": {
+      "file": "null_escapes_as_pointer.c",
+      "pointers": [
+        {
+          "base_text": "s",
+          "index_var": "p_index_xj",
+          "name": "p",
+          "param_index": -1
+        }
+      ]
+    },
+    "pick@null_escapes_as_pointer.c": {
+      "file": "null_escapes_as_pointer.c",
+      "pointers": [
+        {
+          "base_text": "s",
+          "index_var": "p_index_xj",
+          "name": "p",
+          "param_index": -1
+        }
+      ]
+    }
+  }
+}

--- a/tests/pointer_transform/pointer_transform_cases/null_escapes_as_pointer/expected_ptr/null_escapes_as_pointer.c
+++ b/tests/pointer_transform/pointer_transform_cases/null_escapes_as_pointer/expected_ptr/null_escapes_as_pointer.c
@@ -1,0 +1,63 @@
+#include <stdio.h>
+#include <string.h>
+
+/* A NULL-able pointer is represented by the out-of-range index -1, so
+ * every site that turns an index back into a pointer has to map that
+ * sentinel back to a real null: `base + -1` addresses one element
+ * before the array and is *not* null, so a callee's null check would
+ * wrongly succeed.
+ *
+ * The two ways an index goes negative are covered here:
+ *   - an explicit NULL assignment (`pick`), and
+ *   - an allowlisted-function wrapper returning -1 for "not found"
+ *     (`first_comma`), where no NULL appears in the source at all.
+ *
+ * `observe` is deliberately left untransformed, so it sees whatever
+ * pointer the rewrite actually produces. */
+static void observe(const char *q, const char *tag) {
+    printf("%s=%s\n", tag, q ? "nonnull" : "null");
+}
+
+static int strchr_index_xj(const char *base, int start, int c) {
+    const char *result = strchr(base + start, c);
+    if (!result) return -1;
+    return (int)(result - base);
+}
+
+static void first_comma(const char *s) {
+    int p_index_xj = 0;
+
+    p_index_xj = strchr_index_xj(s, p_index_xj, ',');
+    observe((p_index_xj < 0 ? (void *)0 : s + p_index_xj), "comma");
+}
+
+static void pick(const char *s, int take) {
+    int p_index_xj = 0;
+
+    if (take)
+        p_index_xj = 1;
+    else
+        p_index_xj = -1;
+    observe((p_index_xj < 0 ? (void *)0 : s + p_index_xj), "pick");
+}
+
+/* The same sentinel crossing a return boundary rather than a call. */
+static const char *maybe_tail(const char *s, int take) {
+    int p_index_xj = 0;
+
+    if (take)
+        p_index_xj = 2;
+    else
+        p_index_xj = -1;
+    return (p_index_xj < 0 ? (void *)0 : s + p_index_xj);
+}
+
+int main(void) {
+    first_comma("a,b");
+    first_comma("nothing here");
+    pick("abc", 1);
+    pick("abc", 0);
+    observe(maybe_tail("abcdef", 1), "tail1");
+    observe(maybe_tail("abcdef", 0), "tail0");
+    return 0;
+}

--- a/tests/pointer_transform/pointer_transform_cases/null_escapes_as_pointer/input/null_escapes_as_pointer.c
+++ b/tests/pointer_transform/pointer_transform_cases/null_escapes_as_pointer/input/null_escapes_as_pointer.c
@@ -1,0 +1,57 @@
+#include <stdio.h>
+#include <string.h>
+
+/* A NULL-able pointer is represented by the out-of-range index -1, so
+ * every site that turns an index back into a pointer has to map that
+ * sentinel back to a real null: `base + -1` addresses one element
+ * before the array and is *not* null, so a callee's null check would
+ * wrongly succeed.
+ *
+ * The two ways an index goes negative are covered here:
+ *   - an explicit NULL assignment (`pick`), and
+ *   - an allowlisted-function wrapper returning -1 for "not found"
+ *     (`first_comma`), where no NULL appears in the source at all.
+ *
+ * `observe` is deliberately left untransformed, so it sees whatever
+ * pointer the rewrite actually produces. */
+static void observe(const char *q, const char *tag) {
+    printf("%s=%s\n", tag, q ? "nonnull" : "null");
+}
+
+static void first_comma(const char *s) {
+    const char *p = s;
+
+    p = strchr(p, ',');
+    observe(p, "comma");
+}
+
+static void pick(const char *s, int take) {
+    const char *p;
+
+    if (take)
+        p = s + 1;
+    else
+        p = NULL;
+    observe(p, "pick");
+}
+
+/* The same sentinel crossing a return boundary rather than a call. */
+static const char *maybe_tail(const char *s, int take) {
+    const char *p;
+
+    if (take)
+        p = s + 2;
+    else
+        p = NULL;
+    return p;
+}
+
+int main(void) {
+    first_comma("a,b");
+    first_comma("nothing here");
+    pick("abc", 1);
+    pick("abc", 0);
+    observe(maybe_tail("abcdef", 1), "tail1");
+    observe(maybe_tail("abcdef", 0), "tail0");
+    return 0;
+}

--- a/xj-prepare-pointertransform/TransformationMethods.cpp
+++ b/xj-prepare-pointertransform/TransformationMethods.cpp
@@ -70,6 +70,55 @@ static std::string safeBase(const std::string &base)
 }
 
 // ============================================================================
+// Turning an index back into a pointer
+// ============================================================================
+//
+// A pointer that can hold NULL is represented by the out-of-range index
+// -1 (see PointerAccessKind::InitNull). This means that the correct way
+// to reconstruct the pointer's value is (p_index < 0 ? NULL : p + p_index).
+//
+// NB:
+// xj-prepare-slicetransform can identify this and simplify when possible,
+// so this should be kept in sync with collapseNullGuard in SliceRewriter.cpp.
+//
+// The sentinel -1 reaches an index from exactly three places. Two are
+// explicit nulls; additionally, the generated wrappers for
+// allowlisted functions return -1 for "not found" (see
+// PointerAccessKind::AssignFromAllowedFunc — `p = strchr(...)` becomes
+// `p_index = strchr_index_xj(...)`), so a strchr-derived pointer can be
+// null without any NULL ever appearing in the source.
+//
+// If a future access kind can assign the literal -1 to an index, it belongs
+// in this list.
+// As such, note that a *parameter* serving as its own base is not such a case:
+// there the index is a pure non-negative offset and the null-ness stays
+// in the base, which is left untouched.
+static bool pointerMayBeNull(const std::vector<PointerAccess> &accesses)
+{
+    for (const auto &access : accesses)
+    {
+        if (access.kind == PointerAccessKind::InitNull ||
+            access.kind == PointerAccessKind::AssignNull ||
+            access.kind == PointerAccessKind::AssignFromAllowedFunc)
+            return true;
+    }
+    return false;
+}
+
+// The pointer value for `index_name`, guarded only when the sentinel can
+// actually reach this site. Pointers that never hold NULL keep the bare
+// `base + index` spelling, which is what the slice pass already matches.
+static std::string pointerFromIndex(const std::string &base_array,
+                                    const std::string &index_name,
+                                    bool may_be_null)
+{
+    std::string ptr = base_array + " + " + index_name;
+    if (!may_be_null)
+        return ptr;
+    return "(" + index_name + " < 0 ? (void *)0 : " + ptr + ")";
+}
+
+// ============================================================================
 // Placing an index declaration alongside a pointer's declaration
 // ============================================================================
 //
@@ -195,6 +244,7 @@ bool FunctionAccessAnalyzer::generateTransformation(
     std::string ptr_name = PtrVar->getNameAsString();
     std::string index_name = indexNameFor(PtrVar);
     std::string base_array = safeBase(candidate.base_array_text);
+    bool may_be_null = pointerMayBeNull(accesses);
 
     // Note: the body is always rewritten in *plain* form — base params
     // kept, indices counted from the original base, comparisons against
@@ -939,7 +989,7 @@ bool FunctionAccessAnalyzer::generateTransformation(
             e.offset = SM.getFileOffset(StartLoc);
             e.start = StartLoc;
             e.end = EndLoc;
-            e.text = base_array + " + " + index_name;
+            e.text = pointerFromIndex(base_array, index_name, may_be_null);
             edits.push_back(e);
             break;
         }
@@ -1096,7 +1146,7 @@ bool FunctionAccessAnalyzer::generateTransformation(
             e.offset = SM.getFileOffset(StartLoc);
             e.start = StartLoc;
             e.end = EndLoc;
-            e.text = base_array + " + " + index_name;
+            e.text = pointerFromIndex(base_array, index_name, may_be_null);
             edits.push_back(e);
             break;
         }
@@ -1115,7 +1165,7 @@ bool FunctionAccessAnalyzer::generateTransformation(
             e.offset = SM.getFileOffset(StartLoc);
             e.start = StartLoc;
             e.end = EndLoc;
-            e.text = base_array + " + " + index_name;
+            e.text = pointerFromIndex(base_array, index_name, may_be_null);
             edits.push_back(e);
             break;
         }
@@ -1165,6 +1215,7 @@ bool FunctionAccessAnalyzer::generateGlobalTransformation(
     std::string ptr_name = PtrVar->getNameAsString();
     std::string index_name = ptr_name + "_index_xj";
     std::string base_array = safeBase(candidate.base_array_text);
+    bool may_be_null = pointerMayBeNull(accesses);
 
     std::vector<Edit> edits;
 
@@ -1600,7 +1651,7 @@ bool FunctionAccessAnalyzer::generateGlobalTransformation(
                 access.expr->getEndLoc(), 0, SM, LO);
             edits.push_back({Edit::Replace, SM.getFileOffset(StartLoc),
                              StartLoc, EndLoc,
-                             base_array + " + " + index_name});
+                             pointerFromIndex(base_array, index_name, may_be_null)});
             break;
         }
 
@@ -1654,7 +1705,7 @@ bool FunctionAccessAnalyzer::generateGlobalTransformation(
                 access.expr->getEndLoc(), 0, SM, LO);
             edits.push_back({Edit::Replace, SM.getFileOffset(StartLoc),
                              StartLoc, EndLoc,
-                             base_array + " + " + index_name});
+                             pointerFromIndex(base_array, index_name, may_be_null)});
             break;
         }
 
@@ -1665,7 +1716,7 @@ bool FunctionAccessAnalyzer::generateGlobalTransformation(
                 access.expr->getEndLoc(), 0, SM, LO);
             edits.push_back({Edit::Replace, SM.getFileOffset(StartLoc),
                              StartLoc, EndLoc,
-                             base_array + " + " + index_name});
+                             pointerFromIndex(base_array, index_name, may_be_null)});
             break;
         }
 

--- a/xj-prepare-slicetransform/SliceRewriter.cpp
+++ b/xj-prepare-slicetransform/SliceRewriter.cpp
@@ -30,6 +30,38 @@ namespace xj
         return getSourceText(E->getSourceRange(), SM, LO);
     }
 
+    // xj-prepare-pointertransform represents a NULL-able pointer as the
+    // out-of-range index -1, and spells the pointer value it hands to an
+    // untransformed callee as
+    //
+    //     (idx < 0 ? (void *)0 : base + idx)
+    //
+    // Wherever *this* pass moves a function into index space the guard is
+    // redundant — -1 means null again there — and it would otherwise stop
+    // the `base + idx` matching below from firing, leaving a pointer
+    // expression behind in a signature already retyped to int. Unwrap it
+    // and let the ordinary matching proceed.
+    static const Expr *stripNullGuard(const Expr *E, ASTContext &Ctx)
+    {
+        if (!E)
+            return E;
+        const Expr *S = E->IgnoreParenImpCasts();
+        const auto *CO = dyn_cast<ConditionalOperator>(S);
+        if (!CO)
+            return E;
+        // The null branch must actually be a null pointer constant; the
+        // other branch carries the `base + idx` we want.
+        const Expr *TrueE = CO->getTrueExpr()->IgnoreParenImpCasts();
+        const Expr *FalseE = CO->getFalseExpr()->IgnoreParenImpCasts();
+        if (TrueE->isNullPointerConstant(Ctx,
+                                         Expr::NPC_ValueDependentIsNotNull))
+            return FalseE;
+        if (FalseE->isNullPointerConstant(Ctx,
+                                          Expr::NPC_ValueDependentIsNotNull))
+            return TrueE;
+        return E;
+    }
+
     // Step up to the first parent that isn't an ImplicitCastExpr or ParenExpr.
     static const Stmt *skipTransparentParents(const Stmt *S, ASTContext &Ctx)
     {
@@ -797,8 +829,11 @@ namespace xj
                 if (!RetVal)
                     continue;
 
-                // `return base + idx;` -> `return idx;`
-                const Expr *Stripped = RetVal->IgnoreParenImpCasts();
+                // `return base + idx;` -> `return idx;`, including the
+                // NULL-guarded spelling the pointer pass emits for a
+                // NULL-able pointer, which collapses to the same index.
+                const Expr *Stripped =
+                    stripNullGuard(RetVal, Ctx)->IgnoreParenImpCasts();
                 while (const auto *C = dyn_cast<CStyleCastExpr>(Stripped))
                     Stripped = C->getSubExpr()->IgnoreParenImpCasts();
                 if (const auto *Add = dyn_cast<BinaryOperator>(Stripped))
@@ -1101,6 +1136,13 @@ namespace xj
         const FunctionDecl *CallerFD = CallerT.Def;
 
         ArgExpr = ArgExpr->IgnoreImpCasts();
+        if (const auto *PE = dyn_cast<ParenExpr>(ArgExpr))
+            ArgExpr = PE->getSubExpr()->IgnoreImpCasts();
+
+        // A NULL-able pointer reaches us wrapped in the pointer pass's
+        // null guard; in index space that collapses to the bare index, so
+        // unwrap before the `base + idx` matching below.
+        ArgExpr = stripNullGuard(ArgExpr, Ctx)->IgnoreImpCasts();
         if (const auto *PE = dyn_cast<ParenExpr>(ArgExpr))
             ArgExpr = PE->getSubExpr()->IgnoreImpCasts();
 


### PR DESCRIPTION
Consider:

```c
extern void moo(int *p);
void foo()
{
   int *p = ...;
   p++
   moo(p);
}
``` 

After the pointer transform pass, we will have

```c
void foo() 
{
  int *p = ...;
  int p_index = 0;
  p_index++;
  moo(p + p_index)
}
```

Now, zooming in on the `...`, if the source expression is `int *p = NULL;`, then we _actually_ have `int p_index = -1`. Then the materialization strategy (`p + p_index`) _fails_, producing an invalid pointer.

This PR fixes this by emitting `p_index < 0 ? (void*)0 : p + i_index` instead. This can be simplified if we know (via a cheap syntactic check) that `p_index` is never assigned `-1`.

Includes the necessary changes to teach the slice transform about this new shape as well.

Apparentl NULL + 0 is UB before C23. If we want to address this, it should be done in a different PR.