### PR TITLE
Add base pointer rewriting tool

### DIFF
--- a/cli/cli_subcommands.py
+++ b/cli/cli_subcommands.py
@@ -164,6 +164,7 @@ def do_build_star(capture_output: bool = False):
     do_build_xj_prepare_locatejoineddecls(capture_output=capture_output)
     do_build_xj_prepare_unionbitcasts(capture_output=capture_output)
     do_build_xj_prepare_pointertransform(capture_output=capture_output)
+    do_build_xj_prepare_baserewrite(capture_output=capture_output)
     do_build_xj_prepare_slicetransform(capture_output=capture_output)
     do_build_xj_localize_errno(capture_output=capture_output)
 
@@ -292,6 +293,36 @@ def do_build_xj_prepare_pointertransform(capture_output: bool = False):
                 "-GNinja",
                 "-S",
                 (root / "xj-prepare-pointertransform").as_posix(),
+                "-B",
+                builddir.as_posix(),
+            ],
+            cwd=root,
+            check=True,
+            capture_output=capture_output,
+        )
+
+    hermetic.run(
+        ["cmake", "--build", builddir.as_posix(), "--", "--quiet"],
+        cwd=root,
+        check=True,
+        capture_output=capture_output,
+    )
+
+
+def do_build_xj_prepare_baserewrite(capture_output: bool = False):
+    # This one builds xj-analysis itself, via add_subdirectory — so
+    # do_build_xj_analysis stays separate, for working on the library and
+    # its check tools rather than for the pipeline.
+    root = repo_root.find_repo_root_dir_Path()
+    builddir = hermetic.xj_prepare_baserewrite_build_dir(repo_root.localdir())
+
+    if not builddir.exists():
+        hermetic.run(
+            [
+                "cmake",
+                "-GNinja",
+                "-S",
+                (root / "xj-prepare-baserewrite").as_posix(),
                 "-B",
                 builddir.as_posix(),
             ],

--- a/cli/cli_subcommands.py
+++ b/cli/cli_subcommands.py
@@ -223,6 +223,37 @@ def do_build_xj_localize_errno(capture_output: bool = False):
     )
 
 
+def do_build_xj_analysis(capture_output: bool = False):
+    # Deliberately not part of `do_build_star`: nothing links this library
+    # yet, so a translation run has no reason to pay for it. Build it by
+    # hand with `10j build-analysis` while working on the must-equality
+    # domain.
+    root = repo_root.find_repo_root_dir_Path()
+    builddir = hermetic.xj_analysis_build_dir(repo_root.localdir())
+
+    if not builddir.exists():
+        hermetic.run(
+            [
+                "cmake",
+                "-GNinja",
+                "-S",
+                (root / "xj-analysis").as_posix(),
+                "-B",
+                builddir.as_posix(),
+            ],
+            cwd=root,
+            check=True,
+            capture_output=capture_output,
+        )
+
+    hermetic.run(
+        ["cmake", "--build", builddir.as_posix(), "--", "--quiet"],
+        cwd=root,
+        check=True,
+        capture_output=capture_output,
+    )
+
+
 def do_build_xj_prepare_unionbitcasts(capture_output: bool = False):
     root = repo_root.find_repo_root_dir_Path()
     builddir = hermetic.xj_prepare_unionbitcasts_build_dir(repo_root.localdir())

--- a/cli/hermetic.py
+++ b/cli/hermetic.py
@@ -107,6 +107,10 @@ def xj_localize_errno_build_dir(localdir: Path) -> Path:
     return localdir / "_build_localize_errno"
 
 
+def xj_analysis_build_dir(localdir: Path) -> Path:
+    return localdir / "_build_analysis"
+
+
 def mk_env_for(localdir: Path, with_tenjin_deps=True, env_ext=None, **kwargs) -> dict[str, str]:
     if isinstance(env_ext, dict) and env_ext.get("XJ_USE_LLVM14", "") == "1":
         llvm_root = xj_llvm14_root(localdir)

--- a/cli/hermetic.py
+++ b/cli/hermetic.py
@@ -99,6 +99,10 @@ def xj_prepare_pointertransform_build_dir(localdir: Path) -> Path:
     return localdir / "_build_pointertransform"
 
 
+def xj_prepare_baserewrite_build_dir(localdir: Path) -> Path:
+    return localdir / "_build_baserewrite"
+
+
 def xj_prepare_slicetransform_build_dir(localdir: Path) -> Path:
     return localdir / "_build_slicetransform"
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -324,6 +324,15 @@ def build_star():
 
 
 @cli.command()
+def build_analysis():
+    "Build xj-analysis and its tools (not part of `build-star`)"
+    try:
+        cli_subcommands.do_build_xj_analysis()
+    except subprocess.CalledProcessError:
+        sys.exit(1)
+
+
+@cli.command()
 def check_rs():
     try:
         cli_subcommands.do_check_rs()

--- a/cli/main.py
+++ b/cli/main.py
@@ -324,15 +324,6 @@ def build_star():
 
 
 @cli.command()
-def build_analysis():
-    "Build xj-analysis and its tools (not part of `build-star`)"
-    try:
-        cli_subcommands.do_build_xj_analysis()
-    except subprocess.CalledProcessError:
-        sys.exit(1)
-
-
-@cli.command()
 def check_rs():
     try:
         cli_subcommands.do_check_rs()

--- a/tests/analysis/test_musteq.py
+++ b/tests/analysis/test_musteq.py
@@ -23,7 +23,7 @@ import repo_root
 # (example, number of xj-expect annotations it carries)
 _EXAMPLES = [
     ("copy_propagation.c", 12),
-    ("field_paths.c", 10),
+    ("field_paths.c", 12),
     ("table_storage.c", 4),
     # The pre-transform shape, kept as documentation of what the pointer
     # pass sees. It has no annotations; what it must do is parse and run

--- a/tests/analysis/test_musteq.py
+++ b/tests/analysis/test_musteq.py
@@ -1,0 +1,63 @@
+"""Automated coverage for xj-analysis, the must-equality library.
+
+`xj-prepare-baserewrite` deletes a pointer and substitutes a base on the
+strength of what this library proves, so a wrong answer here is a
+miscompilation rather than a missed optimization. Its own test surface is
+annotation-driven: each `examples/*.c` carries `xj-expect` comments naming
+what every tracked pointer must resolve to, and `xj-musteq-check` exits
+non-zero when the analysis disagrees with any of them.
+
+The expected counts are asserted alongside the exit code on purpose. A
+file that loses its annotations still exits 0, and "0/0 expectations met"
+is the one failure mode a pass/fail check would not see.
+"""
+
+import re
+
+import pytest
+
+import cli_subcommands
+import hermetic
+import repo_root
+
+# (example, number of xj-expect annotations it carries)
+_EXAMPLES = [
+    ("copy_propagation.c", 12),
+    ("field_paths.c", 10),
+    ("table_storage.c", 4),
+    # The pre-transform shape, kept as documentation of what the pointer
+    # pass sees. It has no annotations; what it must do is parse and run
+    # the analysis without crashing.
+    ("table_storage_input.c", 0),
+]
+
+
+@pytest.fixture
+def analysis_builddir():
+    """Build xj-analysis and xj-musteq-check, and return the build dir.
+
+    Separate from the `root` fixture's `do_build_star`: the pipeline
+    builds this library through xj-prepare-baserewrite's own CMake, so
+    `_build_analysis` exists only for the check tool.
+    """
+    cli_subcommands.do_build_xj_analysis()
+    return hermetic.xj_analysis_build_dir(repo_root.localdir())
+
+
+@pytest.mark.parametrize("example,expected", _EXAMPLES)
+def test_musteq_annotations(analysis_builddir, example, expected):
+    source = repo_root.find_repo_root_dir_Path() / "xj-analysis" / "examples" / example
+    cp = hermetic.run(
+        [(analysis_builddir / "xj-musteq-check").as_posix(), source.as_posix(), "--", "-std=c11"],
+        capture_output=True,
+        check=False,
+    )
+    stderr = cp.stderr.decode("utf-8")
+    assert cp.returncode == 0, f"{example}: xj-musteq-check failed\n{stderr}"
+
+    match = re.search(r"(\d+)/(\d+) expectations met", stderr)
+    assert match, f"{example}: no expectation tally in output\n{stderr}"
+    met, total = int(match.group(1)), int(match.group(2))
+    assert (met, total) == (expected, expected), (
+        f"{example}: expected {expected} annotations all met, got {met}/{total}\n{stderr}"
+    )

--- a/xj-analysis/CMakeLists.txt
+++ b/xj-analysis/CMakeLists.txt
@@ -1,0 +1,67 @@
+cmake_minimum_required(VERSION 3.17)
+project(xj-analysis)
+
+# The must-equality library: a forward dataflow analysis (MustEqual) giving
+# the cells provably equal at each program point, plus clients that reduce
+# those states to a fact — ResolveParameter answers "does this pointer hold
+# the same value as some nameable lvalue at every one of its use sites?".
+# Design in base_resolution_domain_design.md.
+#
+# Built as a static library so that consumers pull it in with
+# `add_subdirectory` while staying their own CMake projects, as
+# base_resolution_library_design.md §3 describes. Nothing links it yet;
+# building it on its own is how the stub is typechecked.
+
+set(XJ_LLVM_ROOT "${CMAKE_CURRENT_LIST_DIR}/../_local/xj-llvm")
+
+include_directories("${XJ_LLVM_ROOT}/include")
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
+
+add_library(xj-analysis STATIC
+    Cell.cpp
+    SED.cpp
+    Escape.cpp
+    Transfer.cpp
+    MustEqual.cpp
+    VarMutation.cpp
+    ResolveParameter.cpp
+)
+
+set_target_properties(xj-analysis PROPERTIES
+    CXX_STANDARD 17
+    CXX_EXTENSIONS OFF
+)
+
+target_include_directories(xj-analysis PUBLIC "${CMAKE_CURRENT_LIST_DIR}")
+
+# No target_link_libraries on the library itself: a static library leaves
+# libclang-cpp / libLLVM to be resolved by whichever executable links it,
+# exactly as the xj-prepare-* tools already resolve them.
+
+# The annotation-driven test driver. This is the primary test surface for
+# the library; see examples/ and tests/analysis/.
+set(XJ_LLVM_LIB_DIR "${XJ_LLVM_ROOT}/lib")
+find_library(XJ_LLVM_LIBCLANG
+	NAMES libclang${CMAKE_SHARED_LIBRARY_SUFFIX}
+	PATHS "${XJ_LLVM_LIB_DIR}" REQUIRED NO_DEFAULT_PATH)
+find_library(XJ_LLVM_LIBCLANGCPP
+	NAMES libclang-cpp${CMAKE_SHARED_LIBRARY_SUFFIX}
+	PATHS "${XJ_LLVM_LIB_DIR}" REQUIRED NO_DEFAULT_PATH)
+find_library(XJ_LLVM_LIBLLVM
+	NAMES libLLVM${CMAKE_SHARED_LIBRARY_SUFFIX}
+	PATHS "${XJ_LLVM_LIB_DIR}" REQUIRED NO_DEFAULT_PATH)
+
+add_executable(xj-musteq-check tools/xj-musteq-check/main.cpp)
+
+set_target_properties(xj-musteq-check PROPERTIES
+    CXX_STANDARD 17
+    CXX_EXTENSIONS OFF
+)
+
+target_link_libraries(xj-musteq-check
+    xj-analysis
+    ${XJ_LLVM_LIBCLANG}
+    ${XJ_LLVM_LIBCLANGCPP}
+    ${XJ_LLVM_LIBLLVM}
+)

--- a/xj-analysis/CMakeLists.txt
+++ b/xj-analysis/CMakeLists.txt
@@ -5,12 +5,6 @@ project(xj-analysis)
 # the cells provably equal at each program point, plus clients that reduce
 # those states to a fact — ResolveParameter answers "does this pointer hold
 # the same value as some nameable lvalue at every one of its use sites?".
-# Design in base_resolution_domain_design.md.
-#
-# Built as a static library so that consumers pull it in with
-# `add_subdirectory` while staying their own CMake projects, as
-# base_resolution_library_design.md §3 describes. Nothing links it yet;
-# building it on its own is how the stub is typechecked.
 
 set(XJ_LLVM_ROOT "${CMAKE_CURRENT_LIST_DIR}/../_local/xj-llvm")
 

--- a/xj-analysis/Cell.cpp
+++ b/xj-analysis/Cell.cpp
@@ -122,11 +122,11 @@ namespace xj::analysis
       return std::nullopt;
     }
 
-    // Collects the alphabet: every variable the function names, and — at M2
-    // — every field path it mentions.
+    // Collects the alphabet: every variable the function names, plus every
+    // field path it mentions.
     //
     // "Every variable", rather than only the pointer-typed ones, is
-    // load-bearing at M2 and was not at M1. A store whose destination is not
+    // load-bearing once field paths are cells. A store whose destination is not
     // a cell is an *unresolvable* store, and T2 answers one of those by
     // detaching every cell not out of reach — which is every Deref-bearing
     // cell there is. So with `t->storage` in the alphabet, leaving `i` out

--- a/xj-analysis/Cell.cpp
+++ b/xj-analysis/Cell.cpp
@@ -161,7 +161,7 @@ namespace xj::analysis
       // Every `x.f` and `x->f` the body mentions, whatever its type. A
       // non-pointer field is never a resolution candidate worth reporting,
       // but it has to be a *cell*: `t->len = 0` must be a resolvable store
-      // before mayAlias can rule it disjoint from `t->storage`.
+      // before mayOverlap can rule it disjoint from `t->storage`.
       bool VisitMemberExpr(clang::MemberExpr *ME)
       {
         if (auto C = cellOf(ME))

--- a/xj-analysis/Cell.cpp
+++ b/xj-analysis/Cell.cpp
@@ -1,0 +1,285 @@
+#include "Cell.h"
+
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+
+#include "llvm/Support/raw_ostream.h"
+
+#include <utility>
+
+namespace xj::analysis
+{
+
+  Step Step::deref()
+  {
+    return Step(Kind::Deref, nullptr);
+  }
+
+  Step Step::field(const clang::FieldDecl *F)
+  {
+    return Step(Kind::Field, F);
+  }
+
+  bool operator==(Step A, Step B)
+  {
+    return A.K == B.K && A.F == B.F;
+  }
+
+  bool operator==(const Cell &A, const Cell &B)
+  {
+    if (A.Root != B.Root || A.Path.size() != B.Path.size())
+    {
+      return false;
+    }
+    for (unsigned I = 0, N = A.Path.size(); I != N; ++I)
+    {
+      if (A.Path[I] != B.Path[I])
+      {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  CellUniverse::CellUniverse() = default;
+
+  CellId CellUniverse::intern(const Cell &C)
+  {
+    if (C.Path.empty())
+    {
+      auto It = ByVar.find(C.Root);
+      if (It != ByVar.end())
+      {
+        return id(It->second);
+      }
+      unsigned Index = Cells.size();
+      Cells.push_back(C);
+      ByVar[C.Root] = Index;
+      return id(Index);
+    }
+    for (unsigned I = 0, N = Cells.size(); I != N; ++I)
+      if (Cells[I] == C)
+        return id(I);
+    Cells.push_back(C);
+    return id(Cells.size() - 1);
+  }
+
+  namespace
+  {
+
+    // The cell an expression names, or nullopt when this domain cannot name
+    // it: array subscripts, call results, casts between unrelated types,
+    // paths over the depth cap, anything not rooted at a `VarDecl`.
+    //
+    // Shared by `collect`, which interns what the body mentions, and by
+    // `lookup`, which asks the same question of one expression. They must
+    // never disagree about what is nameable: a `lookup` that succeeded where
+    // `collect` had not interned would silently make a store unresolvable,
+    // and one that failed where `collect` had would leave a dead cell in the
+    // alphabet.
+    std::optional<Cell> cellOf(const clang::Expr *E)
+    {
+      if (E == nullptr)
+        return std::nullopt;
+      E = E->IgnoreParens();
+
+      if (const auto *DRE = llvm::dyn_cast<clang::DeclRefExpr>(E))
+      {
+        const auto *VD = llvm::dyn_cast<clang::VarDecl>(DRE->getDecl());
+        if (VD == nullptr || VD->getName().empty() ||
+            VD->getType().isVolatileQualified())
+          return std::nullopt;
+        Cell C;
+        // A global can have several declarations; key on the canonical one
+        // so that two references to it land in the same cell.
+        C.Root = VD->getCanonicalDecl();
+        return C;
+      }
+
+      if (const auto *ME = llvm::dyn_cast<clang::MemberExpr>(E))
+      {
+        // An anonymous struct or union member arrives as an
+        // IndirectFieldDecl, which names storage this path grammar cannot
+        // spell. Not nameable, therefore not a cell.
+        const auto *FD = llvm::dyn_cast<clang::FieldDecl>(ME->getMemberDecl());
+        if (FD == nullptr || FD->getType().isVolatileQualified())
+          return std::nullopt;
+        // The base of `t->f` carries an lvalue-to-rvalue conversion, which
+        // does not change which object is named.
+        std::optional<Cell> C = cellOf(ME->getBase()->IgnoreParenImpCasts());
+        if (!C)
+          return std::nullopt;
+        if (ME->isArrow())
+          C->Path.push_back(Step::deref());
+        C->Path.push_back(Step::field(FD));
+        // Over the cap is simply not nameable, which makes a store through
+        // such a path an unresolvable store — lossy, never unsound.
+        if (C->Path.size() > CellUniverse::MaxPathDepth)
+          return std::nullopt;
+        return C;
+      }
+
+      return std::nullopt;
+    }
+
+    // Collects the alphabet: every variable the function names, and — at M2
+    // — every field path it mentions.
+    //
+    // "Every variable", rather than only the pointer-typed ones, is
+    // load-bearing at M2 and was not at M1. A store whose destination is not
+    // a cell is an *unresolvable* store, and T2 answers one of those by
+    // detaching every cell not out of reach — which is every Deref-bearing
+    // cell there is. So with `t->storage` in the alphabet, leaving `i` out
+    // of it means the `i++` in
+    //
+    //     for (unsigned i = 0; i < t->len; i++)  sum += p[i];
+    //
+    // clears the base on every iteration and `p` resolves to nothing.
+    // Non-pointer cells are not a precision nicety here; without them the
+    // field paths they surround are unusable.
+    class CellCollector : public clang::RecursiveASTVisitor<CellCollector>
+    {
+    public:
+      CellCollector(llvm::SmallVectorImpl<Cell> &Out)
+          : Out(Out) {}
+
+      bool VisitDeclStmt(clang::DeclStmt *DS)
+      {
+        for (const clang::Decl *D : DS->decls())
+          if (const auto *VD = llvm::dyn_cast<clang::VarDecl>(D))
+            addVar(VD);
+        return true;
+      }
+
+      bool VisitDeclRefExpr(clang::DeclRefExpr *DRE)
+      {
+        if (const auto *VD = llvm::dyn_cast<clang::VarDecl>(DRE->getDecl()))
+          addVar(VD);
+        return true;
+      }
+
+      // Every `x.f` and `x->f` the body mentions, whatever its type. A
+      // non-pointer field is never a resolution candidate worth reporting,
+      // but it has to be a *cell*: `t->len = 0` must be a resolvable store
+      // before mayAlias can rule it disjoint from `t->storage`.
+      bool VisitMemberExpr(clang::MemberExpr *ME)
+      {
+        if (auto C = cellOf(ME))
+          Out.push_back(std::move(*C));
+        return true;
+      }
+
+    private:
+      void addVar(const clang::VarDecl *VD)
+      {
+        if (VD == nullptr || VD->getName().empty() ||
+            VD->getType().isVolatileQualified())
+          return;
+        Out.push_back(Cell{VD->getCanonicalDecl(), {}});
+      }
+
+      llvm::SmallVectorImpl<Cell> &Out;
+    };
+
+  } // namespace
+
+  CellUniverse CellUniverse::collect(clang::ASTContext &Ctx,
+                                     const clang::FunctionDecl &FD)
+  {
+    (void)Ctx;
+
+    CellUniverse U;
+
+    // Parameters first, so that ids are stable and parameters sort ahead of
+    // locals when a resolution has to pick a preferred candidate.
+    for (const clang::ParmVarDecl *P : FD.parameters())
+      if (!P->getName().empty() && !P->getType().isVolatileQualified())
+        U.intern(Cell{P, {}});
+
+    llvm::SmallVector<Cell, 16> Mentioned;
+    if (const clang::Stmt *Body = FD.getBody())
+    {
+      CellCollector CC(Mentioned);
+      CC.TraverseStmt(const_cast<clang::Stmt *>(Body));
+    }
+    for (const Cell &C : Mentioned)
+      U.intern(C);
+
+    return U;
+  }
+
+  std::optional<CellId> CellUniverse::lookup(const clang::Expr *E) const
+  {
+    std::optional<Cell> C = cellOf(E);
+    if (!C)
+      return std::nullopt;
+    if (C->Path.empty())
+      return lookup(C->Root);
+    // A nameable path the alphabet does not contain cannot arise from a body
+    // `collect` walked, but returning nullopt is the sound answer if it ever
+    // does: the store becomes unresolvable rather than silently untracked.
+    for (unsigned I = 0, N = Cells.size(); I != N; ++I)
+      if (Cells[I] == *C)
+        return id(I);
+    return std::nullopt;
+  }
+
+  std::optional<CellId> CellUniverse::lookup(const clang::VarDecl *V) const
+  {
+    if (V == nullptr)
+      return std::nullopt;
+    auto It = ByVar.find(V->getCanonicalDecl());
+    if (It == ByVar.end())
+      return std::nullopt;
+    return id(It->second);
+  }
+
+  const Cell &CellUniverse::get(CellId C) const
+  {
+    return Cells[index(C)];
+  }
+
+  clang::QualType CellUniverse::typeOf(CellId C) const
+  {
+    const Cell &Cl = get(C);
+    clang::QualType T = Cl.Root->getType();
+    for (const Step &S : Cl.Path)
+      T = S.kind() == Step::Kind::Deref ? T->getPointeeType()
+                                        : S.field()->getType();
+    return T;
+  }
+
+  std::string CellUniverse::print(CellId C) const
+  {
+    const Cell &Cl = get(C);
+    std::string S = Cl.Root->getName().str();
+    // A Deref immediately followed by a Field prints as `->`; a bare Deref
+    // prints as a prefix `*`, which needs the prefix parenthesized.
+    for (unsigned I = 0, N = Cl.Path.size(); I != N; ++I)
+    {
+      if (Cl.Path[I].kind() == Step::Kind::Deref)
+      {
+        if (I + 1 < N && Cl.Path[I + 1].kind() == Step::Kind::Field)
+        {
+          S += "->";
+          S += Cl.Path[I + 1].field()->getName();
+          ++I;
+        }
+        else
+        {
+          S = "(*" + S + ")";
+        }
+        continue;
+      }
+      S += ".";
+      S += Cl.Path[I].field()->getName();
+    }
+    return S;
+  }
+
+  unsigned CellUniverse::size() const
+  {
+    return Cells.size();
+  }
+
+} // namespace xj::analysis

--- a/xj-analysis/Cell.h
+++ b/xj-analysis/Cell.h
@@ -1,0 +1,144 @@
+// Cell — the alphabet of the must-equality domain.
+//
+// A cell is an abstract unit of storage, named by an access path
+// `Root Step*`:
+//
+//     buf          Var(buf)
+//     x.buf        Var(x) . Field(buf)
+//     t->storage   Var(t) . Deref . Field(storage)
+//     (supporting indices would require reasoning about arithmetic)
+//
+// Cells are interned; `CellId` is the identity used everywhere else, and
+// nothing outside `CellUniverse` compares paths structurally.
+//
+// The cell set for a function is fixed by `collect` before the fixpoint
+// starts and never grows.
+#pragma once
+
+#include "clang/AST/Decl.h"
+#include "clang/AST/Expr.h"
+#include "clang/AST/Type.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/Sequence.h"
+
+#include <optional>
+#include <string>
+
+namespace clang
+{
+  class ASTContext;
+} // namespace clang
+
+namespace xj::analysis
+{
+
+  // Interned identity of a cell. Ids are dense in [0, CellUniverse::size()),
+  // so iteration over cells is a loop over indices.
+  enum class CellId : unsigned
+  {
+  };
+} // namespace xj::analysis
+
+namespace llvm
+{
+  template <>
+  struct enum_iteration_traits<xj::analysis::CellId>
+  {
+    static constexpr bool is_iterable = true;
+  };
+} // namespace llvm
+
+namespace xj::analysis
+{
+  // One step of an access path.
+  class Step
+  {
+  public:
+    enum class Kind : unsigned char
+    {
+      Deref,
+      Field
+    };
+
+    static Step deref();
+    static Step field(const clang::FieldDecl *F);
+
+    Kind kind() const { return K; }
+    // Non-null iff `kind() == Kind::Field`.
+    const clang::FieldDecl *field() const { return F; }
+
+    friend bool operator==(Step A, Step B);
+    friend bool operator!=(Step A, Step B) { return !(A == B); }
+
+  private:
+    Step(Kind K, const clang::FieldDecl *F) : K(K), F(F) {}
+
+    Kind K;
+    const clang::FieldDecl *F;
+  };
+
+  // An abstract memory cell. `Root` is a parameter, a local, or a global;
+  // globals are cells (so a store through one is modelled) but are never
+  // offered as resolution candidates.
+  struct Cell
+  {
+    const clang::VarDecl *Root = nullptr;
+    llvm::SmallVector<Step, 2> Path;
+
+    friend bool operator==(const Cell &A, const Cell &B);
+    friend bool operator!=(const Cell &A, const Cell &B) { return !(A == B); }
+  };
+
+  // The finite set of cells the analysis of one function may mention.
+  class CellUniverse
+  {
+  public:
+    // Access paths longer than this are not nameable, and expressions that
+    // would need one evaluate to unknown.
+    static constexpr unsigned MaxPathDepth = 2;
+
+    // Every named, non-volatile variable whatever its
+    // type, plus every `x.f` / `x->f` the body mentions, up to
+    // `MaxPathDepth`. The non-pointer variables are not decoration; see the
+    // note on `CellCollector` in `Cell.cpp`. A store whose destination is
+    // not a cell havocs every cell not out of reach, and every
+    // Deref-bearing cell is in that set, so an `i++` standing beside a
+    // `t->storage` would clear it on every iteration.
+    static CellUniverse collect(clang::ASTContext &Ctx,
+                                const clang::FunctionDecl &FD);
+
+    // The cell `E` names, or nullopt when this domain cannot name it:
+    // array subscripts, call results, casts between unrelated types, paths
+    // over the depth cap, anything not rooted at a `VarDecl`. A nullopt
+    // here is what makes a store an *unresolvable* store.
+    std::optional<CellId> lookup(const clang::Expr *E) const;
+    std::optional<CellId> lookup(const clang::VarDecl *V) const;
+
+    const Cell &get(CellId C) const;
+    clang::QualType typeOf(CellId C) const;
+    // The spelling a resolution reports, e.g. "t->storage".
+    std::string print(CellId C) const;
+
+    unsigned size() const;
+
+    auto ids() const { return llvm::enum_seq(id(0), id(size())); }
+    auto idsFrom(CellId From) const { return llvm::enum_seq(From, id(size())); }
+    static CellId id(unsigned Index) { return static_cast<CellId>(Index); }
+    static unsigned index(CellId C) { return static_cast<unsigned>(C); }
+    static CellId next(CellId C) { return id(index(C) + 1); }
+
+  private:
+    CellUniverse();
+
+    // Interns `C`, returning the existing id if the path is already known.
+    CellId intern(const Cell &C);
+
+    llvm::SmallVector<Cell, 16> Cells;
+    // Fast path for the deref-free, field-free case, which is every cell at
+    // M1 and most of them at M2.
+    llvm::DenseMap<const clang::VarDecl *, unsigned> ByVar;
+  };
+
+} // namespace xj::analysis

--- a/xj-analysis/Cell.h
+++ b/xj-analysis/Cell.h
@@ -136,8 +136,8 @@ namespace xj::analysis
     CellId intern(const Cell &C);
 
     llvm::SmallVector<Cell, 16> Cells;
-    // Fast path for the deref-free, field-free case, which is every cell at
-    // M1 and most of them at M2.
+    // Fast path for the deref-free, field-free case, which is most cells in
+    // most functions.
     llvm::DenseMap<const clang::VarDecl *, unsigned> ByVar;
   };
 

--- a/xj-analysis/Escape.cpp
+++ b/xj-analysis/Escape.cpp
@@ -120,9 +120,11 @@ namespace xj::analysis
     const Cell &A = Cells.get(P);
     const Cell &B = Cells.get(Q);
 
+    // We are writing into cell P. Can this change the value stored in Q?
+    // Not if Q is out of reach (couldn't have reached P) and vice versa.
     if (A.Root != B.Root)
-      return !(isOutOfReach(P, Cells, Escapes) ||
-               isOutOfReach(Q, Cells, Escapes));
+      return (!isOutOfReach(P, Cells, Escapes) &&
+              !isOutOfReach(Q, Cells, Escapes));
 
     // Same root: walk the shared prefix.
     const unsigned N = std::min(A.Path.size(), B.Path.size());

--- a/xj-analysis/Escape.cpp
+++ b/xj-analysis/Escape.cpp
@@ -111,8 +111,21 @@ namespace xj::analysis
     return true;
   }
 
-  bool mayAlias(CellId P, CellId Q, const CellUniverse &Cells,
-                const EscapeInfo &Escapes)
+  namespace
+  {
+    // Do the steps of `Path` from `From` onwards leave the storage the path
+    // had reached by then, by going out through a pointer?
+    bool tailContainsDeref(llvm::ArrayRef<Step> Path, unsigned From)
+    {
+      for (unsigned I = From, N = Path.size(); I != N; ++I)
+        if (Path[I].kind() == Step::Kind::Deref)
+          return true;
+      return false;
+    }
+  } // namespace
+
+  bool mayOverlap(CellId P, CellId Q, const CellUniverse &Cells,
+                  const EscapeInfo &Escapes)
   {
     if (P == Q)
       return true;
@@ -132,17 +145,31 @@ namespace xj::analysis
     while (I != N && A.Path[I] == B.Path[I])
       ++I;
 
-    // One path is a prefix of the other. `x` and `x.f` overlap by
-    // containment; `t` and `t->f` do not, but answering true for both is
-    // sound and this is not where the precision that matters lives.
     if (I == N)
-      return true;
+    {
+      // same root, one path a prefix of the other.
+      // Suppose we have x.e1 = ...;
+      // When might this touch x.e2.e3?
 
-    // They diverge. Distinct members of one struct do not overlap — a fact
-    // about C's object model, not an assumption, and the only clause here
-    // that buys anything. It is what lets `t->len = n` leave `t->storage`
-    // alone, which is the whole of examples/table_storage.c's third case.
-    //
+      // One path is a prefix of the other. Cells are interned, so `P != Q`
+      // means one of them is strictly longer.
+      const bool AIsShorter = A.Path.size() < B.Path.size();
+      const CellId Shorter = AIsShorter ? P : Q;
+      const Cell &Longer = AIsShorter ? B : A;
+
+      // The extra steps stay inside the shorter cell, so the
+      // longer one is a sub-object of it and a write to either reaches the
+      // other: `x` and `x.buf`, whatever either address has done.
+      if (!tailContainsDeref(Longer.Path, I))
+        return true;
+
+      // The extra steps leave through a pointer, so if the shorter
+      // path is out of reach, it can not be the target of the longer
+      // path's dereference.
+      return !isOutOfReach(Shorter, Cells, Escapes);
+    }
+
+    // They diverge. Distinct members of one struct do not overlap.
     // Union members are excluded deliberately: that is where type punning
     // lives, and two members of a union share storage by construction.
     const Step &SA = A.Path[I];
@@ -154,6 +181,33 @@ namespace xj::analysis
       return false;
 
     return true;
+  }
+
+  bool denotationDependsOn(CellId C, CellId Stored, const CellUniverse &Cells)
+  {
+    if (C == Stored)
+      return false;
+
+    const Cell &Cl = Cells.get(C);
+    const Cell &S = Cells.get(Stored);
+
+    // Only storage a path actually walks through can move it, and a path
+    // walks through nothing but its own proper prefixes — which share its
+    // root. A store that merely *overlaps* such a prefix moves it too, and
+    // that case is left to `mayOverlap`: the pair is either two cells with
+    // different roots, both necessarily in reach, or two union members.
+    if (Cl.Root != S.Root || S.Path.size() >= Cl.Path.size())
+      return false;
+    for (unsigned I = 0, N = S.Path.size(); I != N; ++I)
+      if (S.Path[I] != Cl.Path[I])
+        return false;
+
+    // Reaching `C` from `Stored` has to go out through a pointer for the
+    // store to move anything. If the remaining steps are all fields then
+    // `C` sits at a fixed offset inside `Stored`, and the store changes
+    // what `C` holds rather than where `C` is — `mayOverlap`'s containment
+    // case, and not this one.
+    return tailContainsDeref(Cl.Path, S.Path.size());
   }
 
 } // namespace xj::analysis

--- a/xj-analysis/Escape.cpp
+++ b/xj-analysis/Escape.cpp
@@ -1,0 +1,157 @@
+#include "Escape.h"
+
+#include "clang/AST/Expr.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+
+#include <algorithm>
+
+namespace xj::analysis
+{
+
+  namespace
+  {
+
+    class EscapeCollector : public clang::RecursiveASTVisitor<EscapeCollector>
+    {
+    public:
+      explicit EscapeCollector(llvm::DenseSet<const clang::VarDecl *> &Out)
+          : Out(Out) {}
+
+      bool VisitUnaryOperator(clang::UnaryOperator *UO)
+      {
+        if (UO->getOpcode() == clang::UO_AddrOf)
+          add(UO->getSubExpr());
+        return true;
+      }
+
+      bool VisitImplicitCastExpr(clang::ImplicitCastExpr *ICE)
+      {
+        // An array decays to a pointer to its first element, which hands
+        // the object's address to whoever receives it. That is an escape as
+        // surely as `&x` is.
+        if (ICE->getCastKind() == clang::CK_ArrayToPointerDecay)
+          add(ICE->getSubExpr());
+        return true;
+      }
+
+    private:
+      void add(const clang::Expr *E)
+      {
+        // Walk out to the variable whose storage this names. `&x.buf` hands
+        // out a pointer *into* `x`, so it escapes `x` as surely as `&x`
+        // does — and without this, `x.buf` stays out of reach at every call
+        // while a callee holds a pointer to it.
+        //
+        // An arrow stops the walk. `&t->storage` names storage inside the
+        // pointee, not inside `t`, and nothing a callee does with it can
+        // write the variable `t`. The cell `t->storage` needs no help from
+        // this rule: a path with a Deref is never out of reach anyway.
+        while (E != nullptr)
+        {
+          E = E->IgnoreParenImpCasts();
+          const auto *ME = llvm::dyn_cast<clang::MemberExpr>(E);
+          if (ME == nullptr || ME->isArrow())
+            break;
+          E = ME->getBase();
+        }
+        if (E == nullptr)
+          return;
+        if (const auto *DRE = llvm::dyn_cast<clang::DeclRefExpr>(E))
+          if (const auto *VD = llvm::dyn_cast<clang::VarDecl>(DRE->getDecl()))
+            Out.insert(VD->getCanonicalDecl());
+      }
+
+      llvm::DenseSet<const clang::VarDecl *> &Out;
+    };
+
+  } // namespace
+
+  EscapeInfo::EscapeInfo() = default;
+
+  EscapeInfo EscapeInfo::compute(const clang::FunctionDecl &FD)
+  {
+    EscapeInfo E;
+    if (const clang::Stmt *Body = FD.getBody())
+    {
+      EscapeCollector C(E.AddressTaken);
+      C.TraverseStmt(const_cast<clang::Stmt *>(Body));
+    }
+    return E;
+  }
+
+  bool EscapeInfo::addressTaken(const clang::VarDecl *V) const
+  {
+    return V != nullptr && AddressTaken.count(V->getCanonicalDecl()) != 0;
+  }
+
+  bool EscapeInfo::escapes(const clang::VarDecl *V) const
+  {
+    if (V == nullptr)
+      return true;
+    // A parameter is a local: it has automatic storage, and nothing outside
+    // the function can name it. `hasLocalStorage` is false for globals,
+    // static locals and externs, all of which anyone may reach.
+    if (!V->hasLocalStorage())
+      return true;
+    return addressTaken(V);
+  }
+
+  bool isOutOfReach(CellId C, const CellUniverse &Cells,
+                    const EscapeInfo &Escapes)
+  {
+    const Cell &Cl = Cells.get(C);
+    if (Escapes.escapes(Cl.Root))
+      return false;
+    // A path with a Deref names storage somewhere else entirely, and the
+    // locality of the pointer says nothing about the locality of its
+    // pointee.
+    for (const Step &S : Cl.Path)
+      if (S.kind() == Step::Kind::Deref)
+        return false;
+    return true;
+  }
+
+  bool mayAlias(CellId P, CellId Q, const CellUniverse &Cells,
+                const EscapeInfo &Escapes)
+  {
+    if (P == Q)
+      return true;
+
+    const Cell &A = Cells.get(P);
+    const Cell &B = Cells.get(Q);
+
+    if (A.Root != B.Root)
+      return !(isOutOfReach(P, Cells, Escapes) ||
+               isOutOfReach(Q, Cells, Escapes));
+
+    // Same root: walk the shared prefix.
+    const unsigned N = std::min(A.Path.size(), B.Path.size());
+    unsigned I = 0;
+    while (I != N && A.Path[I] == B.Path[I])
+      ++I;
+
+    // One path is a prefix of the other. `x` and `x.f` overlap by
+    // containment; `t` and `t->f` do not, but answering true for both is
+    // sound and this is not where the precision that matters lives.
+    if (I == N)
+      return true;
+
+    // They diverge. Distinct members of one struct do not overlap — a fact
+    // about C's object model, not an assumption, and the only clause here
+    // that buys anything. It is what lets `t->len = n` leave `t->storage`
+    // alone, which is the whole of examples/table_storage.c's third case.
+    //
+    // Union members are excluded deliberately: that is where type punning
+    // lives, and two members of a union share storage by construction.
+    const Step &SA = A.Path[I];
+    const Step &SB = B.Path[I];
+    if (SA.kind() == Step::Kind::Field && SB.kind() == Step::Kind::Field &&
+        SA.field() != SB.field() &&
+        SA.field()->getParent() == SB.field()->getParent() &&
+        SA.field()->getParent()->isStruct())
+      return false;
+
+    return true;
+  }
+
+} // namespace xj::analysis

--- a/xj-analysis/Escape.h
+++ b/xj-analysis/Escape.h
@@ -29,17 +29,32 @@ namespace xj::analysis
 
   // The cell can not be modified except through a path with the same root
   // or: can not be modified via a pointer dereference.
-  // int x =
   // E.g.
   //  x whose address is never taken:  out of reach.
   //  (*x) in reach, since x may have an alias.
   bool isOutOfReach(CellId C, const CellUniverse &Cells,
                     const EscapeInfo &Escapes);
 
-  // 1. May a write to P's storage change the contents of Q's storage?
-  // 2. May a write to P change _which storage_ Q _denotes_?
-  // Since we track paths,
-  bool mayAlias(CellId P, CellId Q, const CellUniverse &Cells,
-                const EscapeInfo &Escapes);
+  // A store invalidates a cell two ways, and they are different questions
+  // with different answers. `mayOverlap` is the first, `denotationDependsOn`
+  // the second; T1's weak kill is their disjunction.
+
+  // Can a write to P change the value stored in Q?
+  bool mayOverlap(CellId P, CellId Q, const CellUniverse &Cells,
+                  const EscapeInfo &Escapes);
+
+  // 2. May a write to `Stored` change _which storage_ `C` _denotes_?
+  //
+  // A cell is a syntactic path, so what it names is a function of the
+  // pointers it walks through. After `t = u`, `t->storage` names a field of
+  // a different object although not one byte of the old object moved: the
+  // recorded equality was about storage the path no longer reaches, so `C`
+  // must leave its class. Nothing overlapped anything.
+  //
+  // True when `Stored` is a proper prefix of `C` and the steps below it
+  // pass through at least one Deref. Deliberately no escape test — this is
+  // not an aliasing question, and it holds whether or not anything in sight
+  // is addressable.
+  bool denotationDependsOn(CellId C, CellId Stored, const CellUniverse &Cells);
 
 } // namespace xj::analysis

--- a/xj-analysis/Escape.h
+++ b/xj-analysis/Escape.h
@@ -1,18 +1,4 @@
-// Escape, out-of-reach, and may-alias — the memory reasoning.
-//
-// Every *negative* judgment the analysis makes comes from here, and all
-// of it is syntactic: no clause consults the dataflow state, and — the
-// invariant to check any future rule against — no clause concludes
-// disjointness from two cells merely being distinct. Negative answers come
-// from escape (nobody else can name the object) or from C's object model
-// (distinct members of one struct do not overlap).
-//
-// With `CellUniverse::collect(..., /*MemoryCandidates=*/false)` every path
-// is empty and all three functions collapse to something trivial, which is
-// why M1 is plain copy propagation and M2 is the same analysis over a
-// bigger alphabet.
-//
-// See base_resolution_domain_design.md §2.
+// Memory queries for MustEquals
 
 #pragma once
 
@@ -23,7 +9,7 @@
 namespace xj::analysis
 {
 
-  // E1. A variable escapes if the *text* of the function lets anyone else
+  // A variable escapes if the *text* of the function lets anyone else
   // name it. Nothing here is a dataflow fact.
   class EscapeInfo
   {
@@ -41,41 +27,18 @@ namespace xj::analysis
     llvm::DenseSet<const clang::VarDecl *> AddressTaken;
   };
 
-  // E2. Nothing outside this function can name the cell: its root is a
-  // non-escaping local *and* its path contains no Deref step. Both halves
-  // are required —
-  //
-  //     struct S x;  char *p = x.buf;   g();  // x.buf: out of reach
-  //     struct S *q; char *p = q->buf;  g();  // q->buf: not, the pointee
-  //                                           // is somebody else's object
-  //
-  // A deref-free path rooted at a non-escaping local names storage inside
-  // that local; a path with a deref names storage somewhere else entirely,
-  // and the locality of the pointer says nothing about its pointee.
+  // The cell can not be modified except through a path with the same root
+  // or: can not be modified via a pointer dereference.
+  // int x =
+  // E.g.
+  //  x whose address is never taken:  out of reach.
+  //  (*x) in reach, since x may have an alias.
   bool isOutOfReach(CellId C, const CellUniverse &Cells,
                     const EscapeInfo &Escapes);
 
-  // E3. May the two cells denote overlapping storage?
-  //
-  //   P == Q                                        -> true
-  //   different roots                               -> !(outOfReach(P) ||
-  //                                                      outOfReach(Q))
-  //   same root, one path a prefix of the other      -> true
-  //   same root, diverge at distinct struct fields   -> false
-  //   otherwise (union members, anything else)       -> true
-  //
-  // Only the struct clause buys anything, and it buys a lot: `t->len = n`
-  // no longer kills `t->storage`, because the shared prefix `Var(t).Deref`
-  // names one object on any execution and distinct members of one struct
-  // do not overlap. That is a fact about C's object model, not an
-  // assumption — and it is precision the clang::dataflow route could not
-  // have had, where cells are opaque locations whose distinctness proves
-  // nothing.
-  //
-  // Union members alias, which is where the punning rule lives. The rest
-  // of punning — stores through `char *`, `void *`, or a cast — needs no
-  // rule, because such a destination has no cell and is handled as an
-  // unresolvable store.
+  // 1. May a write to P's storage change the contents of Q's storage?
+  // 2. May a write to P change _which storage_ Q _denotes_?
+  // Since we track paths,
   bool mayAlias(CellId P, CellId Q, const CellUniverse &Cells,
                 const EscapeInfo &Escapes);
 

--- a/xj-analysis/Escape.h
+++ b/xj-analysis/Escape.h
@@ -1,0 +1,82 @@
+// Escape, out-of-reach, and may-alias — the memory reasoning.
+//
+// Every *negative* judgment the analysis makes comes from here, and all
+// of it is syntactic: no clause consults the dataflow state, and — the
+// invariant to check any future rule against — no clause concludes
+// disjointness from two cells merely being distinct. Negative answers come
+// from escape (nobody else can name the object) or from C's object model
+// (distinct members of one struct do not overlap).
+//
+// With `CellUniverse::collect(..., /*MemoryCandidates=*/false)` every path
+// is empty and all three functions collapse to something trivial, which is
+// why M1 is plain copy propagation and M2 is the same analysis over a
+// bigger alphabet.
+//
+// See base_resolution_domain_design.md §2.
+
+#pragma once
+
+#include "Cell.h"
+
+#include "llvm/ADT/DenseSet.h"
+
+namespace xj::analysis
+{
+
+  // E1. A variable escapes if the *text* of the function lets anyone else
+  // name it. Nothing here is a dataflow fact.
+  class EscapeInfo
+  {
+  public:
+    static EscapeInfo compute(const clang::FunctionDecl &FD);
+
+    // `&V` appears anywhere in the body.
+    bool addressTaken(const clang::VarDecl *V) const;
+    // Address taken, or not a local at all: global, static local, extern.
+    bool escapes(const clang::VarDecl *V) const;
+
+  private:
+    EscapeInfo();
+
+    llvm::DenseSet<const clang::VarDecl *> AddressTaken;
+  };
+
+  // E2. Nothing outside this function can name the cell: its root is a
+  // non-escaping local *and* its path contains no Deref step. Both halves
+  // are required —
+  //
+  //     struct S x;  char *p = x.buf;   g();  // x.buf: out of reach
+  //     struct S *q; char *p = q->buf;  g();  // q->buf: not, the pointee
+  //                                           // is somebody else's object
+  //
+  // A deref-free path rooted at a non-escaping local names storage inside
+  // that local; a path with a deref names storage somewhere else entirely,
+  // and the locality of the pointer says nothing about its pointee.
+  bool isOutOfReach(CellId C, const CellUniverse &Cells,
+                    const EscapeInfo &Escapes);
+
+  // E3. May the two cells denote overlapping storage?
+  //
+  //   P == Q                                        -> true
+  //   different roots                               -> !(outOfReach(P) ||
+  //                                                      outOfReach(Q))
+  //   same root, one path a prefix of the other      -> true
+  //   same root, diverge at distinct struct fields   -> false
+  //   otherwise (union members, anything else)       -> true
+  //
+  // Only the struct clause buys anything, and it buys a lot: `t->len = n`
+  // no longer kills `t->storage`, because the shared prefix `Var(t).Deref`
+  // names one object on any execution and distinct members of one struct
+  // do not overlap. That is a fact about C's object model, not an
+  // assumption — and it is precision the clang::dataflow route could not
+  // have had, where cells are opaque locations whose distinctness proves
+  // nothing.
+  //
+  // Union members alias, which is where the punning rule lives. The rest
+  // of punning — stores through `char *`, `void *`, or a cast — needs no
+  // rule, because such a destination has no cell and is handled as an
+  // unresolvable store.
+  bool mayAlias(CellId P, CellId Q, const CellUniverse &Cells,
+                const EscapeInfo &Escapes);
+
+} // namespace xj::analysis

--- a/xj-analysis/Evidence.h
+++ b/xj-analysis/Evidence.h
@@ -1,0 +1,35 @@
+// Justification — why an answer came out the way it did.
+//
+// No consumer ever branches on this. Every shipped rule is sound, so there
+// is no trust gradient to express and no `tier` field anywhere in the
+// interface; a field-path resolution and a bare-parameter one are equally
+// reliable and differ only in how much work it took to establish them,
+// which is the reader's business and not the consumer's.
+//
+// What it is for is making a *wrong* answer diagnosable. The useful thing
+// to print is not "declined" but "agreed at 3 of 4 sites; disagreed at
+// hash.c:52".
+
+#pragma once
+
+#include "llvm/ADT/SmallVector.h"
+
+#include <string>
+
+namespace xj::analysis
+{
+
+  struct Justification
+  {
+    // One line, e.g. "same symbol at 4/4 sites".
+    std::string Summary;
+    // Per-site detail and the reasons behind any disagreement, e.g.
+    // "hash.c:52: t->storage cleared by the call at hash.c:47".
+    llvm::SmallVector<std::string, 4> Notes;
+
+    unsigned SitesTotal = 0;
+    unsigned SitesAgreed = 0;
+    unsigned SitesUnreachable = 0;
+  };
+
+} // namespace xj::analysis

--- a/xj-analysis/MustEqual.cpp
+++ b/xj-analysis/MustEqual.cpp
@@ -1,0 +1,130 @@
+#include "MustEqual.h"
+
+#include "Escape.h"
+#include "Transfer.h"
+
+#include "clang/AST/ASTContext.h"
+#include "clang/Analysis/AnalysisDeclContext.h"
+#include "clang/Analysis/CFG.h"
+#include "clang/Analysis/CFGStmtMap.h"
+#include "clang/Analysis/FlowSensitive/DataflowWorklist.h"
+
+#include <utility>
+#include <vector>
+
+namespace xj::analysis
+{
+
+  // Everything the driver needs and no consumer does.
+  struct MustEqualAnalysis::Impl
+  {
+    Impl(clang::ASTContext &Ctx, CellUniverse Cells, EscapeInfo Escapes)
+        : Ctx(&Ctx), Cells(std::move(Cells)), Escapes(std::move(Escapes)) {}
+
+    clang::ASTContext *Ctx;
+    CellUniverse Cells;
+    EscapeInfo Escapes;
+
+    std::unique_ptr<clang::AnalysisDeclContext> ADC;
+
+    // In-state per block, indexed by CFGBlock::getBlockID().
+    std::vector<SED> BlockIn;
+  };
+
+  MustEqualAnalysis::MustEqualAnalysis() = default;
+  MustEqualAnalysis::MustEqualAnalysis(MustEqualAnalysis &&) = default;
+  MustEqualAnalysis &MustEqualAnalysis::operator=(MustEqualAnalysis &&) = default;
+  MustEqualAnalysis::~MustEqualAnalysis() = default;
+
+  llvm::Expected<MustEqualAnalysis>
+  MustEqualAnalysis::run(clang::ASTContext &Ctx, const clang::FunctionDecl &FD,
+                         Options Opts)
+  {
+    if (!FD.doesThisDeclarationHaveABody())
+      return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                     "function has no body");
+    if (Transfer::declines(FD))
+      return llvm::createStringError(
+          llvm::inconvertibleErrorCode(),
+          "declined: setjmp, computed goto, or asm with a memory clobber");
+
+    MustEqualAnalysis A;
+    A.P = std::make_unique<Impl>(
+        Ctx,
+        CellUniverse::collect(Ctx, FD),
+        EscapeInfo::compute(FD));
+    Impl &I = *A.P;
+
+    I.ADC = std::make_unique<clang::AnalysisDeclContext>(
+        nullptr, const_cast<clang::FunctionDecl *>(&FD));
+    I.ADC->getCFGBuildOptions().setAllAlwaysAdd();
+    I.ADC->getCFGBuildOptions().PruneTriviallyFalseEdges = true;
+    clang::CFG *G = I.ADC->getCFG();
+    if (G == nullptr)
+      return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                     "CFG::buildCFG failed");
+
+    Transfer Xfer(Ctx, I.Cells, I.Escapes);
+
+    // --- the fixpoint ---------------------------------------------------
+    I.BlockIn.assign(G->getNumBlockIDs(), SED::bottom(I.Cells));
+    I.BlockIn[G->getEntry().getBlockID()] = SED::atEntry(I.Cells);
+
+    clang::ForwardDataflowWorklist W(*G, *I.ADC);
+    W.enqueueBlock(&G->getEntry());
+    unsigned Visits = 0;
+    while (const clang::CFGBlock *B = W.dequeue())
+    {
+      if (++Visits > Opts.MaxBlockVisits)
+        return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                       "block visit cap reached");
+      SED Out = I.BlockIn[B->getBlockID()];
+      if (Out.isBottom())
+        continue;
+      for (const clang::CFGElement &Elt : *B)
+        Xfer.apply(Elt, Out);
+      for (const clang::CFGBlock *S : B->succs())
+        if (S != nullptr && I.BlockIn[S->getBlockID()].join(Out))
+          W.enqueueBlock(S);
+    }
+
+    return std::move(A);
+  }
+
+  void MustEqualAnalysis::forEachStmt(
+      llvm::function_ref<void(const clang::Stmt *, const SED &)> F) const
+  {
+    Transfer Xfer(*P->Ctx, P->Cells, P->Escapes);
+    for (const clang::CFGBlock *B : cfg())
+    {
+      if (B == nullptr || P->BlockIn[B->getBlockID()].isBottom())
+        continue;
+      SED Cur = P->BlockIn[B->getBlockID()];
+      for (const clang::CFGElement &Elt : *B)
+      {
+        if (auto CS = Elt.getAs<clang::CFGStmt>())
+          F(CS->getStmt(), Cur);
+        Xfer.apply(Elt, Cur);
+      }
+    }
+  }
+
+  bool MustEqualAnalysis::isReachable(const clang::Stmt *S) const
+  {
+    clang::CFGStmtMap *SM = P->ADC->getCFGStmtMap();
+    const clang::CFGBlock *B = SM ? SM->getBlock(S) : nullptr;
+    return B != nullptr && !P->BlockIn[B->getBlockID()].isBottom();
+  }
+
+  const CellUniverse &MustEqualAnalysis::cells() const { return P->Cells; }
+
+  const EscapeInfo &MustEqualAnalysis::escapes() const { return P->Escapes; }
+
+  const clang::CFG &MustEqualAnalysis::cfg() const { return *P->ADC->getCFG(); }
+
+  const SED &MustEqualAnalysis::stateAtEntryOf(const clang::CFGBlock &B) const
+  {
+    return P->BlockIn[B.getBlockID()];
+  }
+
+} // namespace xj::analysis

--- a/xj-analysis/MustEqual.h
+++ b/xj-analysis/MustEqual.h
@@ -1,0 +1,83 @@
+// MustEqualAnalysis — the facade.
+//
+// Runs the forward fixpoint over one function and exposes the resulting
+// must-equality state at every program point: which cells provably hold the
+// same value here, and what value a class carries if it carries a nameable
+// one.
+
+#pragma once
+
+#include "Cell.h"
+#include "Escape.h"
+#include "SED.h"
+
+#include "clang/AST/Decl.h"
+
+#include "llvm/ADT/STLFunctionalExtras.h"
+#include "llvm/Support/Error.h"
+
+#include <memory>
+
+namespace clang
+{
+  class ASTContext;
+  class CFG;
+  class CFGBlock;
+  class Stmt;
+} // namespace clang
+
+namespace xj::analysis
+{
+
+  struct Options
+  {
+    // Backstop against a non-converging fixpoint.
+    unsigned MaxBlockVisits = 20000;
+  };
+
+  class MustEqualAnalysis
+  {
+  public:
+    // Fails only when the function is declined (`Transfer::declines`)
+    // or the CFG could not be built.
+    static llvm::Expected<MustEqualAnalysis> run(clang::ASTContext &Ctx,
+                                                 const clang::FunctionDecl &FD,
+                                                 Options Opts = {});
+
+    MustEqualAnalysis(MustEqualAnalysis &&);
+    MustEqualAnalysis &operator=(MustEqualAnalysis &&);
+    MustEqualAnalysis(const MustEqualAnalysis &) = delete;
+    MustEqualAnalysis &operator=(const MustEqualAnalysis &) = delete;
+    ~MustEqualAnalysis();
+
+    const CellUniverse &cells() const;
+    // The escape facts the transfer was run under. Exposed because a client
+    // asking what a value may be substituted for needs the same judgments.
+    const EscapeInfo &escapes() const;
+    const clang::CFG &cfg() const;
+
+    // In-state of the block, i.e. the join over its predecessors.
+    const SED &stateAtEntryOf(const clang::CFGBlock &B) const;
+
+    // Calls `F` with every statement of every reachable block and the state
+    // just before it, in CFG order. Per-statement states are replayed from
+    // the block in-states rather than stored, so this walk is how a client
+    // reads them.
+    void forEachStmt(
+        llvm::function_ref<void(const clang::Stmt *, const SED &)> F) const;
+
+    // False when `S` sits in a block the fixpoint never reached, or the CFG
+    // has no block for it at all.
+    bool isReachable(const clang::Stmt *S) const;
+
+  private:
+    MustEqualAnalysis();
+
+    // The driver's state — AnalysisDeclContext and the per-block states —
+    // is deliberately not in the header: it is not part of the interface,
+    // and keeping it out means consumers do not pull in clang/Analysis.
+    struct Impl;
+    std::unique_ptr<Impl> P;
+  };
+
+} // namespace xj::analysis

--- a/xj-analysis/ResolveParameter.cpp
+++ b/xj-analysis/ResolveParameter.cpp
@@ -179,7 +179,8 @@ namespace xj::analysis
   }
 
   std::optional<Resolution>
-  ParameterResolver::resolve(const clang::VarDecl *B) const
+  ParameterResolver::resolve(const clang::VarDecl *B,
+                             llvm::function_ref<bool(CellId)> Accept) const
   {
     // `&p` reads the variable's *storage*, not its value, so a cursor whose
     // address is taken is not substitutable however well its value agrees:
@@ -219,6 +220,13 @@ namespace xj::analysis
                                   }),
                    Agreed.end());
     }
+
+    // Narrowing after the fold rather than at each site: `Accept` is a
+    // property of the cell, so filtering commutes with the intersection.
+    Agreed.erase(std::remove_if(Agreed.begin(), Agreed.end(),
+                                [&](CellId C)
+                                { return !Accept(C); }),
+                 Agreed.end());
 
     if (Count == 0 || Agreed.empty())
       return std::nullopt;

--- a/xj-analysis/ResolveParameter.cpp
+++ b/xj-analysis/ResolveParameter.cpp
@@ -1,0 +1,297 @@
+#include "ResolveParameter.h"
+
+#include "clang/AST/RecursiveASTVisitor.h"
+
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <algorithm>
+#include <string>
+
+namespace xj::analysis
+{
+
+  namespace
+  {
+
+    // The syntactic pre-pass: which pointers to track, where they are read,
+    // and which reads are actually writes in disguise.
+    class UseCollector : public clang::RecursiveASTVisitor<UseCollector>
+    {
+    public:
+      bool VisitDeclStmt(clang::DeclStmt *DS)
+      {
+        for (const clang::Decl *D : DS->decls())
+          if (const auto *VD = llvm::dyn_cast<clang::VarDecl>(D))
+            if (VD->getType()->isPointerType() && VD->hasLocalStorage() &&
+                !VD->getName().empty() &&
+                !VD->getType().isVolatileQualified())
+              Locals.push_back(VD);
+        return true;
+      }
+
+      bool VisitDeclRefExpr(clang::DeclRefExpr *DRE)
+      {
+        Refs.push_back(DRE);
+        return true;
+      }
+
+      bool VisitBinaryOperator(clang::BinaryOperator *BO)
+      {
+        if (BO->isAssignmentOp())
+          if (const auto *DRE = llvm::dyn_cast<clang::DeclRefExpr>(
+                  BO->getLHS()->IgnoreParenImpCasts()))
+            Defs.insert(DRE);
+        return true;
+      }
+
+      bool VisitUnaryOperator(clang::UnaryOperator *UO)
+      {
+        if (!UO->isIncrementDecrementOp())
+          return true;
+        if (const auto *DRE = llvm::dyn_cast<clang::DeclRefExpr>(
+                UO->getSubExpr()->IgnoreParenImpCasts()))
+          Defs.insert(DRE);
+        return true;
+      }
+
+      // A use is a read: every DeclRefExpr except the LHS occurrence of an
+      // assignment and the operand of ++/--. That is what makes
+      //
+      //     p = t->storage;  use(p);  p = NULL;
+      //
+      // resolve: every *use* agrees, and deleting `p` deletes the dead
+      // store with it.
+      bool isDef(const clang::DeclRefExpr *DRE) const
+      {
+        return Defs.count(DRE) != 0;
+      }
+
+      llvm::SmallVector<const clang::VarDecl *, 8> Locals;
+      llvm::SmallVector<clang::DeclRefExpr *, 32> Refs;
+
+    private:
+      llvm::DenseSet<const clang::DeclRefExpr *> Defs;
+    };
+
+    CandidateKind kindOf(const Cell &C)
+    {
+      if (!C.Path.empty())
+        return CandidateKind::LValue;
+      return llvm::isa<clang::ParmVarDecl>(C.Root) ? CandidateKind::Param
+                                                   : CandidateKind::Local;
+    }
+
+    // param > local > lvalue, then shortest path, then spelling. Ties have
+    // to break deterministically or the corpus run is not reproducible.
+    bool preferredOver(CellId A, CellId B, const CellUniverse &Cells)
+    {
+      const Cell &CA = Cells.get(A);
+      const Cell &CB = Cells.get(B);
+      CandidateKind KA = kindOf(CA);
+      CandidateKind KB = kindOf(CB);
+      if (KA != KB)
+        return static_cast<int>(KA) < static_cast<int>(KB);
+      if (CA.Path.size() != CB.Path.size())
+        return CA.Path.size() < CB.Path.size();
+      return Cells.print(A) < Cells.print(B);
+    }
+
+  } // namespace
+
+  ParameterResolver ParameterResolver::run(const clang::FunctionDecl &FD,
+                                           const MustEqualAnalysis &A)
+  {
+    ParameterResolver R(A);
+
+    const CellUniverse &Cells = A.cells();
+    for (CellId C : Cells.ids())
+      if (Cells.get(C).Root->hasLocalStorage())
+        R.Candidates.push_back(C);
+
+    UseCollector UC;
+    UC.TraverseStmt(const_cast<clang::Stmt *>(FD.getBody()));
+    R.Tracked = UC.Locals;
+
+    llvm::DenseMap<const clang::Stmt *, const clang::VarDecl *> UseOf;
+    for (clang::DeclRefExpr *DRE : UC.Refs)
+    {
+      if (UC.isDef(DRE))
+        continue;
+      const auto *VD = llvm::dyn_cast<clang::VarDecl>(DRE->getDecl());
+      if (VD == nullptr || !llvm::is_contained(R.Tracked, VD))
+        continue;
+      UseOf[DRE] = VD;
+    }
+
+    llvm::DenseSet<const clang::Stmt *> Seen;
+    A.forEachStmt([&](const clang::Stmt *S, const SED &State)
+                  {
+      auto It = UseOf.find(S);
+      if (It == UseOf.end())
+        return;
+      Seen.insert(S);
+      R.Sites[It->second].push_back(
+          R.factAt(It->second, llvm::cast<clang::DeclRefExpr>(S), State)); });
+
+    // A use the walk never reached is either in an unreachable block — in
+    // which case it is skipped, because dead code must not veto a good fact
+    // — or something the CFG did not surface as an element, which we cannot
+    // vouch for and so record as disagreement.
+    for (clang::DeclRefExpr *DRE : UC.Refs)
+    {
+      auto It = UseOf.find(DRE);
+      if (It == UseOf.end() || Seen.count(DRE) != 0)
+        continue;
+      SiteFact F;
+      F.Use = DRE;
+      F.Loc = DRE->getBeginLoc();
+      F.Reachable = A.isReachable(DRE);
+      R.Sites[It->second].push_back(std::move(F));
+    }
+
+    return R;
+  }
+
+  SiteFact ParameterResolver::factAt(const clang::VarDecl *V,
+                                     const clang::DeclRefExpr *Use,
+                                     const SED &State) const
+  {
+    SiteFact F;
+    F.Use = Use;
+    F.Loc = Use->getBeginLoc();
+    F.Reachable = true;
+
+    auto Self = A->cells().lookup(V);
+    if (!Self)
+      return F;
+    F.Value = State.labelOf(*Self);
+
+    // `membersOf(*Self)` minus itself, intersected with the candidate set —
+    // spelled as a walk over the candidates so that `Agreeing` comes back
+    // in candidate order. Note what is *not* here: no test that the class
+    // carries a label. An unlabelled class is a perfectly good equality,
+    // and demanding a label would be the old T test in a new costume.
+    for (CellId C : Candidates)
+      if (C != *Self && State.sameClass(C, *Self))
+        F.Agreeing.push_back(C);
+    return F;
+  }
+
+  std::optional<Resolution>
+  ParameterResolver::resolve(const clang::VarDecl *B) const
+  {
+    // `&p` reads the variable's *storage*, not its value, so a cursor whose
+    // address is taken is not substitutable however well its value agrees:
+    // rewriting `take(&p)` to `take(&buf)` hands out the address of a
+    // different object, and the cursor cannot be deleted while something
+    // still points at it. This is the distinction `UseCollector` draws for
+    // the LHS of an assignment, one level up — there it decides what counts
+    // as a site, here it decides whether any number of agreeing sites can be
+    // believed.
+    if (A->escapes().addressTaken(B))
+      return std::nullopt;
+
+    auto It = Sites.find(B);
+    if (It == Sites.end() || It->second.empty())
+      return std::nullopt; // zero uses is not vacuous truth
+
+    llvm::SmallVector<CellId, 4> Agreed;
+    unsigned Count = 0;
+    bool First = true;
+
+    for (const SiteFact &F : It->second)
+    {
+      if (!F.Reachable)
+        continue; // dead code does not veto a good fact
+      ++Count;
+      if (First)
+      {
+        Agreed.assign(F.Agreeing.begin(), F.Agreeing.end());
+        First = false;
+        continue;
+      }
+      // Intersection
+      Agreed.erase(std::remove_if(Agreed.begin(), Agreed.end(),
+                                  [&](CellId C)
+                                  {
+                                    return !llvm::is_contained(F.Agreeing, C);
+                                  }),
+                   Agreed.end());
+    }
+
+    if (Count == 0 || Agreed.empty())
+      return std::nullopt;
+
+    CellId Best = Agreed.front();
+    for (CellId C : Agreed)
+      if (preferredOver(C, Best, A->cells()))
+        Best = C;
+
+    Resolution R;
+    R.Cell = Best;
+    R.Kind = kindOf(A->cells().get(Best));
+    R.Sites = Count;
+
+    // Root-anchored: the class holds the parameter's *incoming* value, so
+    // the pointer equals the caller's argument and not merely whatever the
+    // parameter holds at the use. `InitOf` is the label only the entry
+    // state can produce, which is what makes this a check on the label
+    // rather than a separate capture of the entry state.
+    //
+    // Every reachable site has to carry it, not just the first: the label
+    // can be lost at one site and re-established at another only for
+    // `AddrOf` and `Const`, never for `InitOf`, but the quantifier is the
+    // same one `Agreed` is folded under and it costs one pass to be exact.
+    if (R.Kind == CandidateKind::Param)
+    {
+      const Label Anchor = Label::initOf(Best);
+      R.EntryAnchored = true;
+      for (const SiteFact &F : It->second)
+        if (F.Reachable && F.Value != Anchor)
+          R.EntryAnchored = false;
+    }
+    return R;
+  }
+
+  llvm::ArrayRef<SiteFact>
+  ParameterResolver::sitesFor(const clang::VarDecl *B) const
+  {
+    auto It = Sites.find(B);
+    if (It == Sites.end())
+      return {};
+    return It->second;
+  }
+
+  Justification ParameterResolver::explain(const clang::VarDecl *B) const
+  {
+    Justification J;
+    llvm::ArrayRef<SiteFact> Facts = sitesFor(B);
+    J.SitesTotal = Facts.size();
+    for (const SiteFact &F : Facts)
+    {
+      if (!F.Reachable)
+      {
+        ++J.SitesUnreachable;
+        continue;
+      }
+      if (!F.Agreeing.empty())
+        ++J.SitesAgreed;
+    }
+
+    std::string S;
+    llvm::raw_string_ostream OS(S);
+    if (auto R = resolve(B))
+      OS << "same class at " << R->Sites << "/" << J.SitesTotal
+         << " sites: " << A->cells().print(R->Cell);
+    else if (A->escapes().addressTaken(B))
+      OS << "address taken: not substitutable at any number of sites";
+    else if (J.SitesTotal == 0)
+      OS << "no use sites";
+    else
+      OS << "no candidate agreed at all " << J.SitesTotal << " sites";
+    J.Summary = OS.str();
+    return J;
+  }
+
+} // namespace xj::analysis

--- a/xj-analysis/ResolveParameter.h
+++ b/xj-analysis/ResolveParameter.h
@@ -17,6 +17,7 @@
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/SmallVector.h"
 
 #include <optional>
@@ -36,8 +37,15 @@ namespace xj::analysis
   //
   //     p = t->storage;  use(p);  p = NULL;   /* no uses after */
   //
-  // resolves — every use agrees, and reconstruction deleting `p` also
-  // deletes the dead store.
+  // resolves — every use agrees, and the trailing store is dead.
+  //
+  // Excluding stores from the site set is only half of what makes that
+  // safe: a store the consumer cannot *delete* would have the base
+  // substituted into its left-hand side, turning a dead store to `p` into
+  // a live one to `t->storage`. So `xj-prepare-baserewrite` reconstructs
+  // only pointers whose every store is one it can delete — the left arm
+  // of the comma the pointer pass emits, which is the form that store
+  // arrives in by the time it gets there.
   struct SiteFact
   {
     const clang::DeclRefExpr *Use = nullptr;
@@ -90,7 +98,19 @@ namespace xj::analysis
 
     // When several candidates survive, the preferred one is param > local
     // > lvalue, then shortest path, then spelling, for determinism.
-    std::optional<Resolution> resolve(const clang::VarDecl *B) const;
+    std::optional<Resolution> resolve(const clang::VarDecl *B) const
+    {
+      return resolve(B, [](CellId) { return true; });
+    }
+
+    // The same, with the surviving candidates narrowed: `Accept` is
+    // consulted for every cell that agreed everywhere, before the
+    // preference order picks among them, and `std::nullopt` comes back if
+    // it rejects them all. `xj-prepare-baserewrite` uses this to avoid
+    // naming a pointer it is itself about to delete.
+    std::optional<Resolution>
+    resolve(const clang::VarDecl *B,
+            llvm::function_ref<bool(CellId)> Accept) const;
 
     // The unreduced form: `resolve` is exactly this folded by
     // intersection.

--- a/xj-analysis/ResolveParameter.h
+++ b/xj-analysis/ResolveParameter.h
@@ -1,0 +1,123 @@
+// ParameterResolver — a client of MustEqualAnalysis.
+//
+// Answers, per tracked pointer, "does this hold the same value as some
+// nameable thing at every one of its use sites?", by reading the
+// must-equality state at each site out of a finished analysis.
+
+#pragma once
+
+#include "Cell.h"
+#include "Evidence.h"
+#include "MustEqual.h"
+#include "SED.h"
+
+#include "clang/AST/Decl.h"
+#include "clang/AST/Expr.h"
+#include "clang/Basic/SourceLocation.h"
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include <optional>
+
+namespace xj::analysis
+{
+  enum class CandidateKind : unsigned char
+  {
+    Param,
+    Local,
+    LValue
+  };
+
+  // One use site of a tracked pointer, and the candidates that agreed
+  // there. A "use" is a read: every DeclRefExpr to the pointer except the
+  // LHS occurrence of an assignment to it, so that
+  //
+  //     p = t->storage;  use(p);  p = NULL;   /* no uses after */
+  //
+  // resolves — every use agrees, and reconstruction deleting `p` also
+  // deletes the dead store.
+  struct SiteFact
+  {
+    const clang::DeclRefExpr *Use = nullptr;
+    clang::SourceLocation Loc;
+    // False for sites in blocks the fixpoint never reached. Such a site is
+    // *skipped*, not counted as disagreement — otherwise dead code
+    // silently vetoes a good fact.
+    bool Reachable = false;
+    // The label on the class the pointer was in here, if it carried one.
+    // Reporting only: what makes a candidate agree is sharing the pointer's
+    // class, not sharing a label — an unlabelled class is still a class.
+    std::optional<Label> Value;
+    llvm::SmallVector<CellId, 4> Agreeing;
+  };
+
+  // The reduced, flow-insensitive fact.
+  struct Resolution
+  {
+    // The cell to substitute, and also the grouping key the slice pass
+    // should use in place of `base_text` equality: two pointers share a
+    // base iff they resolve to the same cell. A class is not available for
+    // that job — it exists only within one program point's partition,
+    // whereas this is a fact about the whole function.
+    CellId Cell{};
+    CandidateKind Kind = CandidateKind::LValue;
+
+    // `Kind::Param` only: at every reachable use site the pointer's class
+    // was labelled `InitOf(Cell)`
+    bool EntryAnchored = false;
+
+    // Size of the site set that had to agree. Never 0 — a decl with no
+    // uses resolves to nothing.
+    unsigned Sites = 0;
+  };
+
+  class ParameterResolver
+  {
+  public:
+    // Collects the use sites of every tracked pointer of `FD` and the
+    // candidates that agreed at each. `A` must be a finished analysis of
+    // `FD`, and must outlive the resolver.
+    static ParameterResolver run(const clang::FunctionDecl &FD,
+                                 const MustEqualAnalysis &A);
+
+    // Every pointer the resolver tracked, in declaration order.
+    llvm::ArrayRef<const clang::VarDecl *> tracked() const { return Tracked; }
+
+    // `B` resolves to `C` iff `B` has at least one use site and, at
+    // *every* reachable use site, both cells are in the same class.
+
+    // When several candidates survive, the preferred one is param > local
+    // > lvalue, then shortest path, then spelling, for determinism.
+    std::optional<Resolution> resolve(const clang::VarDecl *B) const;
+
+    // The unreduced form: `resolve` is exactly this folded by
+    // intersection.
+    llvm::ArrayRef<SiteFact> sitesFor(const clang::VarDecl *B) const;
+
+    Justification explain(const clang::VarDecl *B) const;
+
+    const CellUniverse &cells() const { return A->cells(); }
+
+  private:
+    explicit ParameterResolver(const MustEqualAnalysis &A) : A(&A) {}
+
+    // The per-site comparison: the label on `V`'s class here, and which
+    // candidates shared that class.
+    SiteFact factAt(const clang::VarDecl *V, const clang::DeclRefExpr *Use,
+                    const SED &State) const;
+
+    const MustEqualAnalysis *A;
+
+    llvm::SmallVector<const clang::VarDecl *, 8> Tracked;
+    llvm::DenseMap<const clang::VarDecl *, llvm::SmallVector<SiteFact, 4>> Sites;
+
+    // Candidates a resolution may name: every cell except those rooted at a
+    // global or a static local. A signal handler can fire between two
+    // statements with no call in between, so a global is never a stable
+    // enough thing to substitute.
+    llvm::SmallVector<CellId, 16> Candidates;
+  };
+
+} // namespace xj::analysis

--- a/xj-analysis/SED.cpp
+++ b/xj-analysis/SED.cpp
@@ -1,0 +1,315 @@
+#include "SED.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <cassert>
+#include <utility>
+
+namespace xj::analysis
+{
+
+  Label Label::initOf(CellId C)
+  {
+    return Label(Kind::InitOf, C, llvm::APSInt());
+  }
+
+  Label Label::addrOf(CellId C)
+  {
+    return Label(Kind::AddrOf, C, llvm::APSInt());
+  }
+
+  Label Label::constant(const llvm::APSInt &V)
+  {
+    return Label(Kind::Const, CellId{}, V);
+  }
+
+  bool operator==(const Label &A, const Label &B)
+  {
+    if (A.K != B.K)
+      return false;
+    if (A.K == Label::Kind::Const)
+      // Not `APSInt::operator==`, which requires equal bit widths.
+      return llvm::APSInt::isSameValue(A.V, B.V);
+    return A.C == B.C;
+  }
+
+  std::string Label::print(const CellUniverse &Cells) const
+  {
+    std::string Out;
+    llvm::raw_string_ostream OS(Out);
+    switch (K)
+    {
+    case Kind::InitOf:
+      OS << "init(" << Cells.print(C) << ")";
+      break;
+    case Kind::AddrOf:
+      OS << "&" << Cells.print(C);
+      break;
+    case Kind::Const:
+      OS << V;
+      break;
+    }
+    return OS.str();
+  }
+
+  SED::SED(const CellUniverse &U) : Cells(&U), Leader(U.size()), LabelOf(U.size())
+  {
+    // Every cell alone in its own class, so every cell leads.
+    for (CellId C : Cells->ids())
+      Leader[CellUniverse::index(C)] = C;
+  }
+
+  SED SED::bottom(const CellUniverse &Cells)
+  {
+    SED S(Cells);
+    S.Bottom = true;
+    return S;
+  }
+
+  SED SED::atEntry(const CellUniverse &Cells)
+  {
+    SED S(Cells);
+    S.Bottom = false;
+    for (CellId C : S.Cells->ids())
+      S.LabelOf[CellUniverse::index(C)] = Label::initOf(C);
+    return S;
+  }
+
+  std::optional<CellId> SED::nextMember(CellId L) const
+  {
+    // A leader is the smallest index in its class, so the rest of the class
+    // lies above it.
+    for (CellId J : Cells->idsFrom(CellUniverse::next(L)))
+    {
+      if (Leader[CellUniverse::index(J)] == L)
+        return J;
+    }
+    return std::nullopt;
+  }
+
+  SED::Class SED::classOf(CellId C) const
+  {
+    assert(!Bottom && "classOf on an unreached block");
+    CellId L = Leader[CellUniverse::index(C)];
+    return Class(L, LabelOf[CellUniverse::index(L)]);
+  }
+
+  SED::Class SED::classFor(const Label &L) const
+  {
+    assert(!Bottom && "classFor on an unreached block");
+    // At most one class carries a given label, so the first hit is the only
+    // one.
+    for (CellId C : Cells->ids())
+    {
+      auto I = CellUniverse::index(C);
+      if (isLeader(C) && LabelOf[I] && *LabelOf[I] == L)
+        return Class(C, L);
+    }
+    return Class(std::nullopt, L);
+  }
+
+  std::optional<Label> SED::labelOf(CellId C) const
+  {
+    if (Bottom)
+      return std::nullopt;
+    return LabelOf[CellUniverse::index(Leader[CellUniverse::index(C)])];
+  }
+
+  bool SED::sameClass(CellId A, CellId B) const
+  {
+    if (Bottom)
+      return false;
+    return Leader[CellUniverse::index(A)] == Leader[CellUniverse::index(B)];
+  }
+
+  llvm::SmallVector<CellId, 4> SED::membersOf(CellId C) const
+  {
+    llvm::SmallVector<CellId, 4> Members;
+    if (Bottom)
+      return Members;
+    for (CellId C : Cells->idsFrom(C))
+      if (Leader[CellUniverse::index(C)] == C)
+        Members.push_back(C);
+    return Members;
+  }
+
+  void SED::detach(CellId C)
+  {
+    // No execution reaches an unreached block, so there is nothing to
+    // forget there.
+    if (Bottom)
+      return;
+
+    unsigned I = CellUniverse::index(C);
+    unsigned Old = CellUniverse::index(Leader[I]);
+    std::optional<Label> OldLabel = LabelOf[Old];
+
+    Leader[I] = C;
+    LabelOf[I] = std::nullopt;
+
+    if (Old != I)
+      return; // `C` did not lead; the class it left is otherwise unchanged.
+
+    // `C` led its class, so leadership passes to the next member, and the
+    // label with it. If there is no next member the class is gone, and its
+    // label is gone too — which for `InitOf` is exactly right: once nothing
+    // holds a cell's incoming value, that value is no longer nameable.
+    std::optional<CellId> Next = nextMember(C);
+    if (!Next)
+      return;
+
+    // for (unsigned J = *Next, N = Leader.size(); J != N; ++J)
+    for (CellId J : Cells->idsFrom(*Next))
+    {
+      if (Leader[CellUniverse::index(J)] == C)
+        Leader[CellUniverse::index(J)] = *Next;
+    }
+    LabelOf[CellUniverse::index(*Next)] = std::move(OldLabel);
+  }
+  void SED::move(CellId C, Label L)
+  {
+    move(C, classFor(L));
+  }
+
+  void SED::move(CellId C, CellId Dest)
+  {
+    move(C, classOf(Dest));
+  }
+
+  void SED::move(CellId C, const Class &K)
+  {
+    assert(!Bottom && "move on an unreached block");
+
+    // The paper's line-5 guard, read as node identity rather than type
+    // equality: skip the move only when `C` is already in `K`. An empty
+    // class compares equal to nothing, so this never skips a creation.
+    if (K == classOf(C))
+      return;
+
+    // Read `K` out before detaching, since the detach may change which cell
+    // leads the class `C` is leaving.
+    std::optional<CellId> Target = K.Leader;
+    std::optional<Label> Wanted = K.TheLabel;
+
+    detach(C);
+    unsigned I = CellUniverse::index(C);
+
+    if (!Target)
+    {
+      // An empty class: the detach has already made `C` an unlabelled
+      // singleton, so all that is left is the label the class was described
+      // by, if any.
+      assert((!Wanted || classFor(*Wanted).isEmpty()) &&
+             "some class already carries this label");
+      LabelOf[I] = std::move(Wanted);
+      return;
+    }
+
+    CellId L = *Target;
+    assert(L != C && "the guard above should have skipped this move");
+    if (C > L)
+    {
+      Leader[I] = L;
+      return;
+    }
+
+    // `C` is now the smallest index in the class, so it takes over as
+    // leader — the label moves with the leadership, not with the cell.
+    for (CellId J : Cells->ids())
+      if (Leader[CellUniverse::index(J)] == L)
+        Leader[CellUniverse::index(J)] = C;
+    LabelOf[I] = std::move(LabelOf[CellUniverse::index(L)]);
+    LabelOf[CellUniverse::index(L)] = std::nullopt;
+  }
+
+  bool SED::join(const SED &Other)
+  {
+    if (Other.Bottom)
+      return false;
+    if (Bottom)
+    {
+      Leader = Other.Leader;
+      LabelOf = Other.LabelOf;
+      Bottom = false;
+      return true;
+    }
+    assert(Leader.size() == Other.Leader.size() &&
+           "joining states over different cell universes");
+
+    // The product construction, in one pass: two cells land in one class of
+    // the result iff they were in one class on *both* sides, so keying each
+    // cell by the pair of leaders it has here and there is the whole join.
+    // Visiting cells in index order makes the first cell carrying a key its
+    // leader, which keeps the result canonical without sorting.
+    const unsigned N = Leader.size();
+    llvm::SmallVector<CellId, 16> NewLeader(N);
+    llvm::SmallVector<std::optional<Label>, 16> NewLabelOf(N);
+    llvm::DenseMap<std::pair<CellId, CellId>, CellId> LeaderForKey;
+
+    for (CellId C : Cells->ids())
+    {
+      auto I = CellUniverse::index(C);
+      auto Key = std::make_pair(Leader[I], Other.Leader[I]);
+      CellId NewL = LeaderForKey.insert({Key, C}).first->second;
+      NewLeader[I] = NewL;
+      if (NewL != C)
+        continue;
+
+      // A label survives only where both sides' classes carried it. Each
+      // side had at most one class carrying it, so the result does too.
+      const std::optional<Label> &Mine = LabelOf[CellUniverse::index(Leader[I])];
+      const std::optional<Label> &Theirs = Other.LabelOf[CellUniverse::index(Other.Leader[I])];
+      if (Mine && Theirs && *Mine == *Theirs)
+        NewLabelOf[I] = Mine;
+    }
+
+    // Both arrays are canonical, so this compare is exactly "the state
+    // changed" — no normalization pass needed.
+    bool Changed = NewLeader != Leader || NewLabelOf != LabelOf;
+    Leader = std::move(NewLeader);
+    LabelOf = std::move(NewLabelOf);
+    return Changed;
+  }
+
+  bool SED::operator==(const SED &Other) const
+  {
+    if (Bottom != Other.Bottom)
+      return false;
+    if (Bottom)
+      return true;
+    return Leader == Other.Leader && LabelOf == Other.LabelOf;
+  }
+
+  std::string SED::print(const CellUniverse &Cells) const
+  {
+    std::string Out;
+    llvm::raw_string_ostream OS(Out);
+    if (Bottom)
+    {
+      OS << "_|_";
+      return OS.str();
+    }
+
+    const char *Sep = "";
+    for (CellId C : Cells.ids())
+    {
+      auto I = CellUniverse::index(C);
+      if (!isLeader(C))
+        continue;
+      OS << Sep << "{";
+      const char *MemberSep = "";
+      for (CellId M : membersOf(C))
+      {
+        OS << MemberSep << Cells.print(M);
+        MemberSep = ", ";
+      }
+      OS << "}";
+      if (LabelOf[I])
+        OS << " = " << LabelOf[I]->print(Cells);
+      Sep = "\n";
+    }
+    return OS.str();
+  }
+
+} // namespace xj::analysis

--- a/xj-analysis/SED.h
+++ b/xj-analysis/SED.h
@@ -1,0 +1,181 @@
+// SED — the must-equality domain: a partition of cells, with labels.
+//
+//     Label  =  InitOf(CellId) | AddrOf(CellId) | Const(APSInt)
+//     State  =  _|_ | (P, L)     P a partition of Cells
+//                                L a partial, injective map Class -> Label
+//
+// Two cells in one class provably hold the same value on every execution
+// reaching the program point; every member of a labelled class provably
+// holds that label's value.
+//
+// This is Gulwani and Necula's Strong Equivalence DAG (SAS 2004, §3)
+// restricted to the case where there are no operation nodes: a node
+// `<V, t>` is one class `V` plus its optional label `t`.
+
+#pragma once
+
+#include "Cell.h"
+
+#include "llvm/ADT/APSInt.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include <optional>
+#include <string>
+
+namespace xj::analysis
+{
+
+  // The one value, nameable without reference to the partition itself,
+  // that every member of a labelled class holds.
+  class Label
+  {
+  public:
+    enum class Kind : unsigned char
+    {
+      InitOf, // Denotes the initial value of a function parameter
+      AddrOf,
+      Const
+    };
+
+    // The value `C` held at function entry.
+    static Label initOf(CellId C);
+    // The address of `C`. Earns its place on array-to-pointer decay alone:
+    // `char buf[64]; char *p = buf;`.
+    static Label addrOf(CellId C);
+    // An integer or null pointer constant.
+    static Label constant(const llvm::APSInt &V);
+
+    Kind kind() const { return K; }
+    CellId cell() const
+    {
+      assert(kind() == Kind::InitOf || kind() == Kind::AddrOf);
+      return C;
+    }
+    const llvm::APSInt &value() const
+    {
+      assert(kind() == Kind::Const);
+      return V;
+    }
+
+    friend bool operator==(const Label &A, const Label &B);
+    friend bool operator!=(const Label &A, const Label &B) { return !(A == B); }
+
+    std::string print(const CellUniverse &Cells) const;
+
+  private:
+    Label(Kind K, CellId C, llvm::APSInt V)
+        : K(K), C(C), V(std::move(V)) {}
+
+    Kind K;
+    CellId C{};     // InitOf, AddrOf
+    llvm::APSInt V; // Const
+  };
+
+  class SED
+  {
+  public:
+    // Which class an operation means.
+    //
+    // A class with members is named by its leader. A class with none
+    // cannot be — there is no cell to name it after — so the two classes
+    // an assignment can conjure out of thin air travel as a *description*
+    // and are created by `move`: "the class carrying this label" when no
+    // class carries it yet, and "a class of its own" for an opaque
+    // right-hand side.
+    class Class
+    {
+    public:
+      bool isEmpty() const { return !Leader.has_value(); }
+
+      const std::optional<Label> &label() const { return TheLabel; }
+
+      // An empty class equals nothing, not even itself
+      friend bool operator==(const Class &A, const Class &B)
+      {
+        return A.Leader && B.Leader && *A.Leader == *B.Leader;
+      }
+      friend bool operator!=(const Class &A, const Class &B)
+      {
+        return !(A == B);
+      }
+
+    private:
+      friend class SED;
+
+      Class(std::optional<CellId> Leader, std::optional<Label> L)
+          : Leader(Leader), TheLabel(std::move(L)) {}
+
+      std::optional<CellId> Leader;
+      std::optional<Label> TheLabel;
+    };
+
+    static SED bottom(const CellUniverse &Cells);
+    static SED atEntry(const CellUniverse &Cells);
+
+    bool isBottom() const { return Bottom; }
+    unsigned size() const { return Leader.size(); }
+    // The label on `C`'s class, if any.
+    std::optional<Label> labelOf(CellId C) const;
+
+    // `A` and `B` are known equal.
+    bool sameClass(CellId A, CellId B) const;
+
+    // `C`'s class, in ascending cell order (`C` included).
+    llvm::SmallVector<CellId, 4> membersOf(CellId C) const;
+
+    // `C` leaves its class and becomes an unlabelled singleton.
+    void detach(CellId C);
+
+    void move(CellId C, Label L);
+    void move(CellId C, CellId Dest);
+
+    // `*this = *this join Other`; returns whether `*this` changed. This is
+    // the worklist's change test, so it must be exact.
+    bool join(const SED &Other);
+
+    bool operator==(const SED &Other) const;
+    bool operator!=(const SED &Other) const { return !(*this == Other); }
+
+    // One class per line, e.g. "{p, q, t->storage} = &buf".
+    std::string print(const CellUniverse &Cells) const;
+
+  private:
+    // `detach(C)`, then add `C` to `K` — creating `K` if it was an empty
+    // class. Applied only where the statement makes `C` equal to `K`'s
+    // members, or makes it compute `K`'s label.
+    void move(CellId C, const Class &K);
+
+    // A class with no members and no label
+    // `move(c, newClass())` is exactly `detach(c)`.
+    static Class newClass() { return Class(std::nullopt, std::nullopt); }
+
+    // The class containing `C`.
+    Class classOf(CellId C) const;
+
+    // The class carrying `L`, or an empty class describing it when no class
+    // does.
+    Class classFor(const Label &L) const;
+
+    explicit SED(const CellUniverse &Cells);
+
+    // Whether `I` is the smallest cell index in its class.
+    bool isLeader(CellId I) const { return Leader[CellUniverse::index(I)] == I; }
+    // The smallest member of the class led by `L` other than `L` itself, if
+    // the class has one.
+    std::optional<CellId> nextMember(CellId L) const;
+    const CellUniverse *Cells;
+    // Cell index -> the smallest cell index in its class. Choosing the
+    // smallest makes the representation canonical, so two states are equal
+    // iff their arrays are equal and the worklist's change test needs no
+    // normalization pass. `detach`, `move`, `sameClass` and `membersOf` are
+    // O(|cells|) scans over a few dozen elements; a flat array beats
+    // union-find here precisely because no class merge ever happens, and
+    // because `join` and equality want a canonical dense form anyway.
+    llvm::SmallVector<CellId, 16> Leader;
+    // Indexed by leader. Held at `nullopt` for every non-leader index, so
+    // that the array compare above stays a valid state equality.
+    llvm::SmallVector<std::optional<Label>, 16> LabelOf;
+    bool Bottom = true;
+  };
+
+} // namespace xj::analysis

--- a/xj-analysis/Transfer.cpp
+++ b/xj-analysis/Transfer.cpp
@@ -260,7 +260,7 @@ namespace xj::analysis
       break;
     }
 
-    havocAliases(Dest, State);
+    havocInvalidated(Dest, State);
   }
 
   void Transfer::havocReachable(SED &State) const
@@ -273,11 +273,17 @@ namespace xj::analysis
     }
   }
 
-  void Transfer::havocAliases(CellId Dest, SED &State) const
+  void Transfer::havocInvalidated(CellId Dest, SED &State) const
   {
     for (CellId C : Cells.ids())
     {
-      if (C != Dest && mayAlias(C, Dest, Cells, Escapes))
+      if (C == Dest)
+        continue;
+      // The two ways a store falsifies a recorded equality, which are not
+      // the same question: the store may have changed what `C`'s storage
+      // *holds*, or it may have changed *which storage* `C` names.
+      if (denotationDependsOn(C, Dest, Cells) ||
+          mayOverlap(C, Dest, Cells, Escapes))
         State.detach(C);
     }
   }

--- a/xj-analysis/Transfer.cpp
+++ b/xj-analysis/Transfer.cpp
@@ -1,0 +1,293 @@
+#include "Transfer.h"
+
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/Expr.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/AST/Stmt.h"
+#include "clang/Analysis/CFG.h"
+
+namespace xj::analysis
+{
+
+  namespace
+  {
+
+    // Strip only the wrappers that do not change the value: parentheses,
+    // the lvalue-to-rvalue conversion, and no-op casts. Anything else — an
+    // integral-to-pointer cast, a bitcast between unrelated pointer types —
+    // is left in place, because it is exactly the kind of thing that must
+    // classify as Opaque rather than be seen through.
+    const clang::Expr *stripToValue(const clang::Expr *E)
+    {
+      while (E != nullptr)
+      {
+        if (const auto *P = llvm::dyn_cast<clang::ParenExpr>(E))
+        {
+          E = P->getSubExpr();
+          continue;
+        }
+        if (const auto *ICE = llvm::dyn_cast<clang::ImplicitCastExpr>(E))
+        {
+          if (ICE->getCastKind() == clang::CK_LValueToRValue ||
+              ICE->getCastKind() == clang::CK_NoOp)
+          {
+            E = ICE->getSubExpr();
+            continue;
+          }
+        }
+        break;
+      }
+      return E;
+    }
+
+    // The constructs that make the CFG an unsound model of the function's
+    // control flow. A clobber at the call site does not repair a missing
+    // edge, so the only sound response is to decline the function.
+    class DeclineDetector : public clang::RecursiveASTVisitor<DeclineDetector>
+    {
+    public:
+      bool Declined = false;
+
+      bool VisitIndirectGotoStmt(clang::IndirectGotoStmt *)
+      {
+        Declined = true;
+        return false;
+      }
+
+      bool VisitAddrLabelExpr(clang::AddrLabelExpr *)
+      {
+        Declined = true;
+        return false;
+      }
+
+      bool VisitGCCAsmStmt(clang::GCCAsmStmt *A)
+      {
+        for (unsigned I = 0, N = A->getNumClobbers(); I != N; ++I)
+          if (A->getClobber(I) == "memory")
+          {
+            Declined = true;
+            return false;
+          }
+        return true;
+      }
+
+      bool VisitCallExpr(clang::CallExpr *CE)
+      {
+        const clang::FunctionDecl *Callee = CE->getDirectCallee();
+        if (Callee == nullptr)
+          return true;
+        // `longjmp` re-enters at the `setjmp` point along an edge the CFG
+        // does not contain, so the fixpoint would be computed over a graph
+        // missing paths.
+        llvm::StringRef Name = Callee->getName();
+        if (Name == "setjmp" || Name == "_setjmp" || Name == "sigsetjmp" ||
+            Name == "__builtin_setjmp")
+        {
+          Declined = true;
+          return false;
+        }
+        return true;
+      }
+    };
+
+  } // namespace
+
+  RValue classify(const clang::Expr *E, const CellUniverse &Cells,
+                  clang::ASTContext &Ctx)
+  {
+    RValue R;
+    if (E == nullptr)
+      return R;
+
+    const clang::Expr *S = stripToValue(E);
+
+    if (const auto *UO = llvm::dyn_cast<clang::UnaryOperator>(S))
+    {
+      if (UO->getOpcode() == clang::UO_AddrOf)
+        if (auto C = Cells.lookup(UO->getSubExpr()))
+        {
+          R.K = RValue::Kind::Address;
+          R.Cell = *C;
+        }
+      return R;
+    }
+
+    if (const auto *ICE = llvm::dyn_cast<clang::ImplicitCastExpr>(S))
+    {
+      if (ICE->getCastKind() == clang::CK_ArrayToPointerDecay)
+        if (auto C = Cells.lookup(ICE->getSubExpr()))
+        {
+          R.K = RValue::Kind::Address;
+          R.Cell = *C;
+        }
+      return R;
+    }
+
+    if (auto C = Cells.lookup(S))
+    {
+      R.K = RValue::Kind::CellRead;
+      R.Cell = *C;
+      return R;
+    }
+
+    if (E->isNullPointerConstant(Ctx, clang::Expr::NPC_ValueDependentIsNotNull))
+    {
+      R.K = RValue::Kind::Constant;
+      R.Value = llvm::APSInt::get(0);
+      return R;
+    }
+    if (const auto *IL = llvm::dyn_cast<clang::IntegerLiteral>(S))
+    {
+      R.K = RValue::Kind::Constant;
+      R.Value = llvm::APSInt(IL->getValue(), /*isUnsigned=*/false);
+      return R;
+    }
+
+    return R;
+  }
+
+  Transfer::Transfer(clang::ASTContext &Ctx, const CellUniverse &Cells,
+                     const EscapeInfo &Escapes)
+      : Ctx(Ctx), Cells(Cells), Escapes(Escapes) {}
+
+  bool Transfer::declines(const clang::FunctionDecl &FD)
+  {
+    const clang::Stmt *Body = FD.getBody();
+    if (Body == nullptr)
+      return true;
+    DeclineDetector D;
+    D.TraverseStmt(const_cast<clang::Stmt *>(Body));
+    return D.Declined;
+  }
+
+  void Transfer::apply(const clang::CFGElement &Elt, SED &State) const
+  {
+    if (State.isBottom())
+      return;
+
+    auto CS = Elt.getAs<clang::CFGStmt>();
+    if (!CS)
+      return; // scope markers and lifetime ends write nothing
+
+    const clang::Stmt *St = CS->getStmt();
+
+    // T1, via a declaration's initialiser.
+    if (const auto *DS = llvm::dyn_cast<clang::DeclStmt>(St))
+    {
+      for (const clang::Decl *D : DS->decls())
+      {
+        const auto *VD = llvm::dyn_cast<clang::VarDecl>(D);
+        if (VD == nullptr)
+          continue;
+        auto Dest = Cells.lookup(VD);
+        if (!Dest)
+          continue;
+        if (const clang::Expr *Init = VD->getInit())
+          store(*Dest, classify(Init, Cells, Ctx), State);
+        else
+          // Re-entering the scope produces a new, indeterminate object; it
+          // is not still holding whatever the last iteration left.
+          State.detach(*Dest);
+      }
+      return;
+    }
+
+    if (const auto *BO = llvm::dyn_cast<clang::BinaryOperator>(St))
+    {
+      if (!BO->isAssignmentOp())
+        return; // arithmetic and comparison write nothing
+      auto Dest = Cells.lookup(BO->getLHS());
+      // A compound assignment computes from the old value, which this
+      // domain does not model, so its result is Opaque whatever the RHS is.
+      RValue V; // default-constructs as Opaque
+      if (BO->getOpcode() == clang::BO_Assign)
+        V = classify(BO->getRHS(), Cells, Ctx);
+      if (!Dest)
+      {
+        // T2: the destination is not nameable, so the store could have
+        // landed anywhere the writer can reach.
+        havocReachable(State);
+        return;
+      }
+      store(*Dest, V, State);
+      return;
+    }
+
+    if (const auto *UO = llvm::dyn_cast<clang::UnaryOperator>(St))
+    {
+      if (!UO->isIncrementDecrementOp())
+        return;
+      auto Dest = Cells.lookup(UO->getSubExpr());
+      if (!Dest)
+      {
+        // The store could have landed anywhere
+        havocReachable(State);
+        return;
+      }
+      RValue Opaque; // Essentially just detach Dest
+      store(*Dest, Opaque, State);
+      return;
+    }
+
+    if (llvm::isa<clang::CallExpr>(St))
+    {
+      havocReachable(State);
+      return;
+    }
+
+    if (llvm::isa<clang::Expr>(St))
+      return;
+
+    // fail-safe
+    havocAll(State);
+  }
+
+  void Transfer::store(CellId Dest, const RValue &V, SED &State) const
+  {
+    switch (V.K)
+    {
+    case RValue::Kind::CellRead:
+      State.move(Dest, V.Cell);
+      break;
+    case RValue::Kind::Address:
+      State.move(Dest, Label::addrOf(V.Cell));
+      break;
+    case RValue::Kind::Constant:
+      State.move(Dest, Label::constant(V.Value));
+      break;
+    case RValue::Kind::Opaque:
+      State.detach(Dest);
+      break;
+    }
+
+    havocAliases(Dest, State);
+  }
+
+  void Transfer::havocReachable(SED &State) const
+  {
+    for (unsigned I = 0, N = Cells.size(); I != N; ++I)
+    {
+      CellId C = CellUniverse::id(I);
+      if (!isOutOfReach(C, Cells, Escapes))
+        State.detach(C);
+    }
+  }
+
+  void Transfer::havocAliases(CellId Dest, SED &State) const
+  {
+    for (CellId C : Cells.ids())
+    {
+      if (C != Dest && mayAlias(C, Dest, Cells, Escapes))
+        State.detach(C);
+    }
+  }
+
+  void Transfer::havocAll(SED &State) const
+  {
+    for (CellId C : Cells.ids())
+    {
+      State.detach(C);
+    }
+  }
+
+} // namespace xj::analysis

--- a/xj-analysis/Transfer.h
+++ b/xj-analysis/Transfer.h
@@ -7,7 +7,9 @@
 //               Constant(k) -> classFor(Const(k))
 //               Opaque      -> a new empty class
 //         move D into K,
-//         then detach every other cell that mayAlias(D)
+//         then detach every other cell the store invalidates: those whose
+//         storage mayOverlap(D), and those whose path walks through D and
+//         so no longer denotes what it did
 //   T2  a store whose destination is not nameable
 //                                         -> detach every cell not out of reach
 //   T3  a call                            -> detach every cell not out of reach
@@ -65,7 +67,7 @@ namespace xj::analysis
 
   private:
     // T1: move `Dest` into the class the rvalue denotes, then detach
-    // everything that may alias it.
+    // everything the store invalidates.
     void store(CellId Dest, const RValue &V, SED &State) const;
 
     // T2/T3: detach every cell not out of reach. A callee cannot name a
@@ -74,9 +76,13 @@ namespace xj::analysis
     // destination this function could not name. Everything else, it might.
     void havocReachable(SED &State) const;
 
-    // The weak kill of T1: detach mayAlias(`Dest`) other than `Dest`, which
-    // the caller has already moved.
-    void havocAliases(CellId Dest, SED &State) const;
+    // The weak kill of T1: detach every cell the store to `Dest`
+    // invalidates, other than `Dest`, which the caller has already moved.
+    // Two disjoint reasons — see Escape.h. A cell may have had its
+    // *contents* rewritten (`mayOverlap`), or it may have kept its contents
+    // and lost its *meaning*, because the store moved a pointer the cell's
+    // path walks through (`denotationDependsOn`).
+    void havocInvalidated(CellId Dest, SED &State) const;
 
     // T4, the blanket rule: detach the entire universe.
     void havocAll(SED &State) const;

--- a/xj-analysis/Transfer.h
+++ b/xj-analysis/Transfer.h
@@ -1,0 +1,89 @@
+// Transfer — the abstract semantics, in five rules.
+//
+//   T1  x = e,  destination cell D known
+//         let K = the class the RHS denotes:
+//               CellRead(c) -> classOf(c)
+//               Address(c)  -> classFor(AddrOf(c))
+//               Constant(k) -> classFor(Const(k))
+//               Opaque      -> a new empty class
+//         move D into K,
+//         then detach every other cell that mayAlias(D)
+//   T2  a store whose destination is not nameable
+//                                         -> detach every cell not out of reach
+//   T3  a call                            -> detach every cell not out of reach
+//   T4  any element not matched above     -> detach every cell
+//   T5  reads, casts, anything without an effect          -> no change
+//
+// T1 is the standard "strong update plus weak kill". T4 is the blanket
+// rule. A DeclStmt initialiser is T1 with `D` the declared variable.
+#pragma once
+
+#include "Cell.h"
+#include "Escape.h"
+#include "SED.h"
+
+#include "llvm/ADT/APSInt.h"
+
+namespace clang
+{
+  class ASTContext;
+  class CFGElement;
+  class FunctionDecl;
+} // namespace clang
+
+namespace xj::analysis
+{
+
+  struct RValue
+  {
+    enum class Kind
+    {
+      CellRead,
+      Address,
+      Constant,
+      Opaque
+    };
+
+    Kind K = Kind::Opaque;
+    CellId Cell{};      // CellRead, Address
+    llvm::APSInt Value; // Constant
+  };
+
+  RValue classify(const clang::Expr *E, const CellUniverse &Cells,
+                  clang::ASTContext &Ctx);
+
+  class Transfer
+  {
+  public:
+    Transfer(clang::ASTContext &Ctx, const CellUniverse &Cells,
+             const EscapeInfo &Escapes);
+
+    void apply(const clang::CFGElement &Elt, SED &State) const;
+
+    // Whether we can analyze this function (reasons for declining: contains setjmp, computed goto, etc)
+    static bool declines(const clang::FunctionDecl &FD);
+
+  private:
+    // T1: move `Dest` into the class the rvalue denotes, then detach
+    // everything that may alias it.
+    void store(CellId Dest, const RValue &V, SED &State) const;
+
+    // T2/T3: detach every cell not out of reach. A callee cannot name a
+    // non-escaping local, so it cannot write one — under any aliasing,
+    // through any global, via any callback; and neither can a store whose
+    // destination this function could not name. Everything else, it might.
+    void havocReachable(SED &State) const;
+
+    // The weak kill of T1: detach mayAlias(`Dest`) other than `Dest`, which
+    // the caller has already moved.
+    void havocAliases(CellId Dest, SED &State) const;
+
+    // T4, the blanket rule: detach the entire universe.
+    void havocAll(SED &State) const;
+
+    clang::ASTContext &Ctx;
+    const CellUniverse &Cells;
+    const EscapeInfo &Escapes;
+  };
+
+} // namespace xj::analysis

--- a/xj-analysis/VarMutation.cpp
+++ b/xj-analysis/VarMutation.cpp
@@ -1,0 +1,65 @@
+#include "VarMutation.h"
+
+#include "clang/AST/Expr.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+
+namespace xj::analysis
+{
+
+  namespace
+  {
+
+    class MutationFinder : public clang::RecursiveASTVisitor<MutationFinder>
+    {
+    public:
+      explicit MutationFinder(const clang::VarDecl *V)
+          : V(V->getCanonicalDecl()) {}
+
+      bool Mutated = false;
+
+      bool VisitBinaryOperator(clang::BinaryOperator *BO)
+      {
+        if (BO->isAssignmentOp() && isTarget(BO->getLHS()))
+          Mutated = true;
+        return !Mutated;
+      }
+
+      bool VisitUnaryOperator(clang::UnaryOperator *UO)
+      {
+        // `&x` counts as a possible write: an escaping local can be written
+        // by anyone holding the pointer.
+        if ((UO->isIncrementDecrementOp() ||
+             UO->getOpcode() == clang::UO_AddrOf) &&
+            isTarget(UO->getSubExpr()))
+          Mutated = true;
+        return !Mutated;
+      }
+
+    private:
+      bool isTarget(const clang::Expr *E) const
+      {
+        if (E == nullptr)
+          return false;
+        const auto *DRE =
+            llvm::dyn_cast<clang::DeclRefExpr>(E->IgnoreParenImpCasts());
+        if (DRE == nullptr)
+          return false;
+        const auto *VD = llvm::dyn_cast<clang::VarDecl>(DRE->getDecl());
+        return VD != nullptr && VD->getCanonicalDecl() == V;
+      }
+
+      const clang::VarDecl *V;
+    };
+
+  } // namespace
+
+  bool neverReassigned(const clang::VarDecl *V, const clang::FunctionDecl &FD)
+  {
+    if (V == nullptr || FD.getBody() == nullptr)
+      return false;
+    MutationFinder F(V);
+    F.TraverseStmt(const_cast<clang::Stmt *>(FD.getBody()));
+    return !F.Mutated;
+  }
+
+} // namespace xj::analysis

--- a/xj-analysis/VarMutation.h
+++ b/xj-analysis/VarMutation.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "clang/AST/Decl.h"
+
+namespace xj::analysis
+{
+
+  // `V` is never the target of an assignment, never incremented or
+  // decremented, and never has its address taken, anywhere in `FD`.
+  // Address-taken counts as a possible write: an escaping local can be
+  // written by anyone holding the pointer.
+  bool neverReassigned(const clang::VarDecl *V, const clang::FunctionDecl &FD);
+
+} // namespace xj::analysis

--- a/xj-analysis/examples/copy_propagation.c
+++ b/xj-analysis/examples/copy_propagation.c
@@ -1,0 +1,181 @@
+/* The first thing to get working: M1, which is plain copy propagation.
+ *
+ * No structs appear anywhere in this file, so no `x.f` / `x->f` cell can
+ * exist and the alphabet is variables whichever way `Options`
+ * `MemoryCandidates` is set. That is the point — nothing here needs an
+ * access path, a may-alias test, or any of §2's extensions beyond the
+ * address-taken half of the out-of-reach rule.
+ *
+ * The functions are in implementation order. Each adds exactly one
+ * mechanism to the one above it, so the file doubles as a checklist:
+ * `copy_of_param` alone requires the cell universe, the entry store, T1's
+ * CellRead arm, the worklist, and the all-sites fold, and is a reasonable
+ * definition of "the analysis is alive".
+ */
+
+extern void use(char *);
+extern char *get(void);
+extern void g(void);
+extern void take(char **);
+
+/* 1. The whole pipeline, once. Cells {buf, p}; entry store binds each to
+   Fresh(cell, entry()); T1 copies buf's symbol to p; one use site agrees.
+   `buf` is a parameter that is never reassigned, so the shared symbol is
+   Fresh(buf, entry()) and the resolution is additionally entry-anchored —
+   which is what `detectRoots` needs and the only kind of base slicing can
+   consume. */
+void copy_of_param(char *buf)
+{
+    char *p = buf;
+    use(p); /* xj-expect: copy_of_param: p -> buf */
+}
+
+/* 2. The fold. Two sites, both agreeing; the answer is their
+   intersection, not their union. */
+void two_uses(char *buf)
+{
+    char *p = buf;
+    use(p);
+    use(p); /* xj-expect: two_uses: p -> buf */
+}
+
+/* 3. The fold actually intersecting. Site one has {a}, site two has {b},
+   and there is no single text that can be substituted at both. Getting
+   this wrong — unioning instead of intersecting — produces an answer that
+   looks plausible and is useless. */
+void disagreeing_uses(char *a, char *b)
+{
+    char *p = a;
+    use(p);
+    p = b;
+    use(p); /* xj-expect: disagreeing_uses: p -> none */
+}
+
+/* 4. T1's Opaque arm. A call result is not a value this domain models, so
+   the destination is havoc'd rather than left holding its previous symbol.
+   Leaving it is exactly the defect the M0 spike found in clang::dataflow
+   (FINDINGS.md, F4), which produced 7 false must-equalities in 16 over the
+   corpus, so this case is worth having early. */
+void opaque_rhs(char *buf)
+{
+    char *p = buf;
+    p = get();
+    use(p); /* xj-expect: opaque_rhs: p -> none */
+}
+
+/* 5. The join. The branches disagree, so the lattice join yields T, and T
+   is not an equivalence class: two cells at T are not equal to each
+   other. */
+void join_disagrees(char *a, char *b, int c)
+{
+    char *p;
+    if (c)
+        p = a;
+    else
+        p = b;
+    use(p); /* xj-expect: join_disagrees: p -> none */
+}
+
+/* 6. The one clobber rule M1 exercises. Both cells are deref-free paths
+   rooted at non-escaping locals — a C parameter is a local — so the callee
+   cannot name either one and cannot write either one, under any aliasing.
+   A call changes what a pointer parameter points *at*, never the parameter
+   variable itself, and a named candidate does not depend on the pointee. */
+void call_does_not_kill_a_local(char *buf)
+{
+    char *p = buf;
+    g();
+    use(p); /* xj-expect: call_does_not_kill_a_local: p -> buf */
+}
+
+/* 7. The other half of the same rule. `&buf` appears, so `buf` escapes and
+   is no longer out of reach: `take` may have written through the pointer
+   it was handed. `buf` is havoc'd at the call while `p` keeps its symbol,
+   so they part company. Pairing this with 6 is the entire M1 soundness
+   argument, and the two differ only in whether the base's address is
+   taken. */
+void address_taken_escapes(char *buf)
+{
+    char *p = buf;
+    take(&buf);
+    use(p); /* xj-expect: address_taken_escapes: p -> none */
+}
+
+/* 8. The address of the *cursor* rather than of the base, which is a
+   different rule and not a clobber rule at all. `p`'s value agrees with
+   `buf` at the only site there is, and the fact is still unusable: `&p`
+   reads p's storage, not its value, so rewriting it to `&buf` would hand
+   `take` the address of a different object — and `p` cannot be deleted
+   while something still points at it.
+
+   `UseCollector` already draws this line for the LHS of an assignment and
+   for the operand of `++`. Excluding `&p` from the site set is not enough
+   here, because then a lone `use(p)` elsewhere would carry the resolution
+   and the pass would delete a variable whose address is taken. So the
+   address-taken cursor is vetoed outright, and this reports `none` where
+   every site agreed. */
+void address_of_cursor(char *buf)
+{
+    char *p = buf;
+    take(&p); /* xj-expect: address_of_cursor: p -> none */
+}
+
+/* 9. The base parameter itself is reassigned — the M1 counterpart of
+   `field_paths.c`'s `reassign_base`, which reassigns the pointer a base
+   path is *rooted at*. Here the base cell simply is the parameter, so the
+   store detaches it directly rather than through the prefix rule, and the
+   class `p` sits in keeps the `InitOf(buf)` label with no `buf` in it. The
+   answer is `none` and nothing about the substitution needed to know: what
+   makes it `none` is that a candidate has to agree at *every* site. */
+void param_reassigned_before_use(char *buf, char *other)
+{
+    char *p = buf;
+    buf = other;
+    use(p); /* xj-expect: param_reassigned_before_use: p -> none */
+}
+
+/* 10. The same store, after the only site rather than before it, and the
+   resolution stands. A parameter being reassigned *somewhere* is not a
+   veto — the fold quantifies over use sites, and a store past the last one
+   is not one. This is the half worth stating explicitly, because the
+   conservative reading (a mutated base is unusable) is the one a reader
+   expects and would be a real loss: substitution is textual at each site,
+   and at every site here `p` and `buf` are the same value. */
+void param_reassigned_after_use(char *buf, char *other)
+{
+    char *p = buf;
+    use(p); /* xj-expect: param_reassigned_after_use: p -> buf */
+    buf = other;
+    use(buf);
+}
+
+/* 11. The copy taken after the store. `p`, `buf` and `other` share one
+   class, so `buf` agrees and the resolution is `buf` — by the spelling
+   tie-break, not because `buf` is what was copied.
+
+   This is the case `EntryAnchored` exists to separate, and the only one in
+   this file where it is false: `p` equals what `buf` holds *here*, not what
+   the caller passed. Both facts license the substitution; only the stronger
+   one licenses treating the base as the incoming argument. The annotation
+   syntax names the cell alone, so what is pinned here is the resolution —
+   `--dump` is where the anchoring shows. */
+void copy_after_reassign(char *buf, char *other)
+{
+    buf = other;
+    char *p = buf;
+    use(p); /* xj-expect: copy_after_reassign: p -> buf */
+}
+
+/* 12. The store and the use in the same loop, so the back edge carries a
+   state where `buf` has already moved. The join at the loop head is what
+   answers, and it answers `none` — the reason a site-by-site reading of 10
+   ("the store is textually after the use") is not the rule. */
+void param_reassigned_in_loop(char *buf, char *other, int n)
+{
+    char *p = buf;
+    for (int i = 0; i < n; i++)
+    {
+        use(p); /* xj-expect: param_reassigned_in_loop: p -> none */
+        buf = other;
+    }
+}

--- a/xj-analysis/examples/copy_propagation.c
+++ b/xj-analysis/examples/copy_propagation.c
@@ -1,16 +1,6 @@
-/* The first thing to get working: M1, which is plain copy propagation.
- *
- * No structs appear anywhere in this file, so no `x.f` / `x->f` cell can
- * exist and the alphabet is variables whichever way `Options`
- * `MemoryCandidates` is set. That is the point — nothing here needs an
- * access path, a may-alias test, or any of §2's extensions beyond the
- * address-taken half of the out-of-reach rule.
- *
- * The functions are in implementation order. Each adds exactly one
- * mechanism to the one above it, so the file doubles as a checklist:
- * `copy_of_param` alone requires the cell universe, the entry store, T1's
- * CellRead arm, the worklist, and the all-sites fold, and is a reasonable
- * definition of "the analysis is alive".
+/* Copy propagation over variables. Each function is the smallest C program
+ * that exercises one rule about when a copied pointer can be replaced by the
+ * name it was copied from.
  */
 
 extern void use(char *);
@@ -18,20 +8,16 @@ extern char *get(void);
 extern void g(void);
 extern void take(char **);
 
-/* 1. The whole pipeline, once. Cells {buf, p}; entry store binds each to
-   Fresh(cell, entry()); T1 copies buf's symbol to p; one use site agrees.
-   `buf` is a parameter that is never reassigned, so the shared symbol is
-   Fresh(buf, entry()) and the resolution is additionally entry-anchored —
-   which is what `detectRoots` needs and the only kind of base slicing can
-   consume. */
+/* 1. A copy of a parameter that is never reassigned. `p` and `buf` are the
+   same pointer at the use, and it is the pointer the caller passed — which is
+   what `detectRoots` requires of a slicing base. */
 void copy_of_param(char *buf)
 {
     char *p = buf;
     use(p); /* xj-expect: copy_of_param: p -> buf */
 }
 
-/* 2. The fold. Two sites, both agreeing; the answer is their
-   intersection, not their union. */
+/* 2. Two uses reached by the same copy. */
 void two_uses(char *buf)
 {
     char *p = buf;
@@ -39,10 +25,8 @@ void two_uses(char *buf)
     use(p); /* xj-expect: two_uses: p -> buf */
 }
 
-/* 3. The fold actually intersecting. Site one has {a}, site two has {b},
-   and there is no single text that can be substituted at both. Getting
-   this wrong — unioning instead of intersecting — produces an answer that
-   looks plausible and is useless. */
+/* 3. `p` is `a` at the first use and `b` at the second, so no single name can
+   replace it at both. */
 void disagreeing_uses(char *a, char *b)
 {
     char *p = a;
@@ -51,11 +35,7 @@ void disagreeing_uses(char *a, char *b)
     use(p); /* xj-expect: disagreeing_uses: p -> none */
 }
 
-/* 4. T1's Opaque arm. A call result is not a value this domain models, so
-   the destination is havoc'd rather than left holding its previous symbol.
-   Leaving it is exactly the defect the M0 spike found in clang::dataflow
-   (FINDINGS.md, F4), which produced 7 false must-equalities in 16 over the
-   corpus, so this case is worth having early. */
+/* 4. The call's return value is not known to equal anything. */
 void opaque_rhs(char *buf)
 {
     char *p = buf;
@@ -63,9 +43,7 @@ void opaque_rhs(char *buf)
     use(p); /* xj-expect: opaque_rhs: p -> none */
 }
 
-/* 5. The join. The branches disagree, so the lattice join yields T, and T
-   is not an equivalence class: two cells at T are not equal to each
-   other. */
+/* 5. `p` is `a` on one path and `b` on the other. */
 void join_disagrees(char *a, char *b, int c)
 {
     char *p;
@@ -76,11 +54,8 @@ void join_disagrees(char *a, char *b, int c)
     use(p); /* xj-expect: join_disagrees: p -> none */
 }
 
-/* 6. The one clobber rule M1 exercises. Both cells are deref-free paths
-   rooted at non-escaping locals — a C parameter is a local — so the callee
-   cannot name either one and cannot write either one, under any aliasing.
-   A call changes what a pointer parameter points *at*, never the parameter
-   variable itself, and a named candidate does not depend on the pointee. */
+/* 6. `g` cannot name `buf` or `p`, so it cannot change either one. Passing a
+   pointer parameter to a callee does not expose the parameter itself. */
 void call_does_not_kill_a_local(char *buf)
 {
     char *p = buf;
@@ -88,12 +63,8 @@ void call_does_not_kill_a_local(char *buf)
     use(p); /* xj-expect: call_does_not_kill_a_local: p -> buf */
 }
 
-/* 7. The other half of the same rule. `&buf` appears, so `buf` escapes and
-   is no longer out of reach: `take` may have written through the pointer
-   it was handed. `buf` is havoc'd at the call while `p` keeps its symbol,
-   so they part company. Pairing this with 6 is the entire M1 soundness
-   argument, and the two differ only in whether the base's address is
-   taken. */
+/* 7. ...but `take` is handed `&buf` and may store through it, leaving `p`
+   with the old value. */
 void address_taken_escapes(char *buf)
 {
     char *p = buf;
@@ -101,32 +72,17 @@ void address_taken_escapes(char *buf)
     use(p); /* xj-expect: address_taken_escapes: p -> none */
 }
 
-/* 8. The address of the *cursor* rather than of the base, which is a
-   different rule and not a clobber rule at all. `p`'s value agrees with
-   `buf` at the only site there is, and the fact is still unusable: `&p`
-   reads p's storage, not its value, so rewriting it to `&buf` would hand
-   `take` the address of a different object — and `p` cannot be deleted
-   while something still points at it.
-
-   `UseCollector` already draws this line for the LHS of an assignment and
-   for the operand of `++`. Excluding `&p` from the site set is not enough
-   here, because then a lone `use(p)` elsewhere would carry the resolution
-   and the pass would delete a variable whose address is taken. So the
-   address-taken cursor is vetoed outright, and this reports `none` where
-   every site agreed. */
+/* 8. `p` and `buf` agree at every use, but `&p` needs `p` to have storage of
+   its own, so `p` cannot be deleted. Ignoring `&p` as a use site is not
+   enough: a `use(p)` elsewhere would then license the rewrite anyway. */
 void address_of_cursor(char *buf)
 {
     char *p = buf;
     take(&p); /* xj-expect: address_of_cursor: p -> none */
 }
 
-/* 9. The base parameter itself is reassigned — the M1 counterpart of
-   `field_paths.c`'s `reassign_base`, which reassigns the pointer a base
-   path is *rooted at*. Here the base cell simply is the parameter, so the
-   store detaches it directly rather than through the prefix rule, and the
-   class `p` sits in keeps the `InitOf(buf)` label with no `buf` in it. The
-   answer is `none` and nothing about the substitution needed to know: what
-   makes it `none` is that a candidate has to agree at *every* site. */
+/* 9. `buf` is reassigned before the use, so it names a different pointer
+   there. */
 void param_reassigned_before_use(char *buf, char *other)
 {
     char *p = buf;
@@ -134,13 +90,8 @@ void param_reassigned_before_use(char *buf, char *other)
     use(p); /* xj-expect: param_reassigned_before_use: p -> none */
 }
 
-/* 10. The same store, after the only site rather than before it, and the
-   resolution stands. A parameter being reassigned *somewhere* is not a
-   veto — the fold quantifies over use sites, and a store past the last one
-   is not one. This is the half worth stating explicitly, because the
-   conservative reading (a mutated base is unusable) is the one a reader
-   expects and would be a real loss: substitution is textual at each site,
-   and at every site here `p` and `buf` are the same value. */
+/* 10. The same store, but no use of `p` follows it. A reassigned base is not
+   by itself a reason to give up. */
 void param_reassigned_after_use(char *buf, char *other)
 {
     char *p = buf;
@@ -149,16 +100,9 @@ void param_reassigned_after_use(char *buf, char *other)
     use(buf);
 }
 
-/* 11. The copy taken after the store. `p`, `buf` and `other` share one
-   class, so `buf` agrees and the resolution is `buf` — by the spelling
-   tie-break, not because `buf` is what was copied.
-
-   This is the case `EntryAnchored` exists to separate, and the only one in
-   this file where it is false: `p` equals what `buf` holds *here*, not what
-   the caller passed. Both facts license the substitution; only the stronger
-   one licenses treating the base as the incoming argument. The annotation
-   syntax names the cell alone, so what is pinned here is the resolution —
-   `--dump` is where the anchoring shows. */
+/* 11. `p` equals `buf` at the use, but not the pointer the caller passed.
+   That is enough to substitute the name, and not enough to treat the base as
+   an incoming argument; `EntryAnchored` records the difference. */
 void copy_after_reassign(char *buf, char *other)
 {
     buf = other;
@@ -166,10 +110,8 @@ void copy_after_reassign(char *buf, char *other)
     use(p); /* xj-expect: copy_after_reassign: p -> buf */
 }
 
-/* 12. The store and the use in the same loop, so the back edge carries a
-   state where `buf` has already moved. The join at the loop head is what
-   answers, and it answers `none` — the reason a site-by-site reading of 10
-   ("the store is textually after the use") is not the rule. */
+/* 12. The store reaches the use around the back edge, so `buf` may already
+   have moved by the time `p` is used. */
 void param_reassigned_in_loop(char *buf, char *other, int n)
 {
     char *p = buf;

--- a/xj-analysis/examples/field_paths.c
+++ b/xj-analysis/examples/field_paths.c
@@ -22,6 +22,8 @@ struct table
     unsigned len;
 };
 
+extern void use2(struct table *);
+
 struct box
 {
     char *buf;
@@ -151,13 +153,50 @@ void store_through_pointer(struct table *t, char **q)
    pointer is reassigned. `t->storage` after `t = u` is a different object,
    so the equality `p` had with it cannot survive.
 
-   Nothing special handles this. `Var(t)` is a prefix of `Var(t).Deref.
-   Field(storage)`, so the weak kill of the assignment to `t` detaches the
-   path — which is why mayAlias answers true for a prefix even when the
-   extra steps begin with a Deref and there is no containment. */
+   This is the whole reason `denotationDependsOn` exists beside
+   `mayOverlap`. Not one byte of the old `*t` is written by `t = u`, and
+   the two cells do not overlap: `Var(t)` is the pointer variable,
+   `Var(t).Deref.Field(storage)` is a field of somebody else's object. What
+   breaks is that the path no longer *reaches* the storage the equality was
+   about. `Var(t)` is a proper prefix of the path and the steps below it go
+   out through a Deref, so the store moves it. */
 void reassign_base(struct table *t, struct table *u)
 {
     char *p = t->storage;
     t = u;
     use(p); /* xj-expect: reassign_base: p -> none */
+}
+
+/* 11. The converse of 10, and what the prefix/overlap split bought. The
+   store goes *through* `t` rather than to it, so `t`'s own value is
+   untouched: `t->len` is storage in the pointee, `t` is a pointer variable
+   whose address is never taken, and nothing can point back into it. The
+   equality `t` has with `s` survives.
+
+   Under the old single `mayAlias` this reported `none`. The prefix case
+   answered true in both directions, so the analysis was more precise about
+   the fields of `*t` — case 4 — than about `t` itself. */
+void store_through_pointer_keeps_root(struct table *s, unsigned n)
+{
+    struct table *t = s;
+    t->len = n;
+    use2(t); /* xj-expect: store_through_pointer_keeps_root: t -> s */
+}
+
+/* 12. ...and the guard on 11, which is why the narrowed clause asks about
+   reach rather than answering false outright. `t` is punned to point at
+   its own storage, so `(*t).storage` — the first member — *is* the bytes of
+   `t`, and `t->storage = q` writes `t` after all. Forming that pointer
+   needs `&t`, which puts `t` in reach and brings the overlap back.
+
+   Strictly this program is a strict-aliasing violation, so one could argue
+   the clause could be unconditional. The analysis declines to rely on
+   that: tenjin translates C that is routinely built -fno-strict-aliasing,
+   and the reach test costs one comparison. */
+void self_pointing(char *q)
+{
+    struct table *t = (struct table *)&t;
+    struct table *u = t; /* class {t, u} */
+    t->storage = q;      /* writes *t, which is t */
+    use2(u);             /* xj-expect: self_pointing: u -> none */
 }

--- a/xj-analysis/examples/field_paths.c
+++ b/xj-analysis/examples/field_paths.c
@@ -1,0 +1,163 @@
+/* M2: the alphabet is access paths, and §2's memory reasoning starts to
+ * carry weight. `table_storage.c` is the motivating shape; this file is the
+ * rule-by-rule checklist beside it, in the same style as
+ * `copy_propagation.c` — one mechanism per function, each the smallest C
+ * that exercises it.
+ *
+ * Everything here reports `none` under `--no-memory-candidates`, since
+ * without field-path cells there is no candidate to name and no store to
+ * rule disjoint. That is the point of the file: every answer below is a
+ * consequence of M2, and half of them are answers M2 must be careful *not*
+ * to get wrong.
+ */
+
+extern void use(char *);
+extern void take(char **);
+extern char *get(void);
+extern void g(void);
+
+struct table
+{
+    char *storage;
+    unsigned len;
+};
+
+struct box
+{
+    char *buf;
+};
+
+struct inner
+{
+    char *buf;
+};
+
+struct outer
+{
+    struct inner *in;
+};
+
+union pun
+{
+    char *a;
+    char *b;
+};
+
+/* 1. The join case, which is the headline of partition_domain_design.md §0
+   with a field path in place of a variable. Neither branch's value survives
+   the join, but `t->storage` survives as a *class*, so the copy has
+   something to attach to and the equality is recovered. Under the symbol
+   domain both cells were T and the copy recorded nothing. */
+void join_then_copy(struct table *t, char *a, char *b, int c)
+{
+    if (c)
+        t->storage = a;
+    else
+        t->storage = b;
+    char *p = t->storage;
+    use(p); /* xj-expect: join_then_copy: p -> t->storage */
+}
+
+/* 2. A call cannot reach a field of a non-escaping local: nothing outside
+   the function can name `x`, so nothing outside it can name `x.buf`. This
+   is the field-path half of `call_does_not_kill_a_local`. */
+void non_escaping_field(void)
+{
+    struct box x;
+    x.buf = get();
+    char *p = x.buf;
+    g();
+    use(p); /* xj-expect: non_escaping_field: p -> x.buf */
+}
+
+/* 3. ...unless the field's address was taken. `&x.buf` hands out a pointer
+   *into* `x`, so the callee may write it, and the escape has to attach to
+   the root — a rule the M1 escape collector did not need, because with no
+   field paths there was nothing between `&` and a variable. */
+void escaping_field(void)
+{
+    struct box x;
+    x.buf = get();
+    char *p = x.buf;
+    take(&x.buf);
+    g();
+    use(p); /* xj-expect: escaping_field: p -> none */
+}
+
+/* 4. Two distinct members of one struct do not overlap, so a store to the
+   sibling leaves the base alone. The clause that buys everything — and the
+   same one `checksum_and_reset` turns on. */
+void sibling_field_is_disjoint(struct table *t, unsigned n)
+{
+    char *p = t->storage;
+    t->len = n;
+    use(p); /* xj-expect: sibling_field_is_disjoint: p -> t->storage */
+}
+
+/* 5. Two members of a *union* share storage by construction, which is where
+   type punning lives. The struct clause must not fire here. */
+void union_members_alias(union pun *m, char *q)
+{
+    char *p = m->a;
+    m->b = q;
+    use(p); /* xj-expect: union_members_alias: p -> none */
+}
+
+/* 6. A whole-object store writes every field of it. This is the rule that
+   forces non-pointer variables into the alphabet: were `x` not a cell,
+   `x = y` would be an *unresolvable* store, and T2 spares everything out of
+   reach — which `x.buf` is. */
+void whole_struct_assign(struct box y)
+{
+    struct box x;
+    x.buf = get();
+    char *p = x.buf;
+    x = y;
+    use(p); /* xj-expect: whole_struct_assign: p -> none */
+}
+
+/* 7. Same root, but the paths diverge before any field: `s->storage` and
+   `t->storage` are the same path through different pointers, and nothing
+   says the pointers differ. Distinctness of cells never proves
+   disjointness. */
+void two_objects(struct table *s, struct table *t, char *q)
+{
+    char *p = t->storage;
+    s->storage = q;
+    use(p); /* xj-expect: two_objects: p -> none */
+}
+
+/* 8. Over `MaxPathDepth`, so the destination is not nameable and the store
+   is unresolvable — lossy, never unsound. */
+void over_depth_cap(struct outer *o, struct table *t, char *q)
+{
+    char *p = t->storage;
+    o->in->buf = q;
+    use(p); /* xj-expect: over_depth_cap: p -> none */
+}
+
+/* 9. A store through a pointer with no cell of its own. There is no Index
+   step and no bare-Deref cell, so this is the shape every unresolvable
+   store reduces to. */
+void store_through_pointer(struct table *t, char **q)
+{
+    char *p = t->storage;
+    *q = 0;
+    use(p); /* xj-expect: store_through_pointer: p -> none */
+}
+
+/* 10. The one an access-path alphabet must not get wrong: a cell named
+   through a mutable pointer stops denoting the same storage when that
+   pointer is reassigned. `t->storage` after `t = u` is a different object,
+   so the equality `p` had with it cannot survive.
+
+   Nothing special handles this. `Var(t)` is a prefix of `Var(t).Deref.
+   Field(storage)`, so the weak kill of the assignment to `t` detaches the
+   path — which is why mayAlias answers true for a prefix even when the
+   extra steps begin with a Deref and there is no containment. */
+void reassign_base(struct table *t, struct table *u)
+{
+    char *p = t->storage;
+    t = u;
+    use(p); /* xj-expect: reassign_base: p -> none */
+}

--- a/xj-analysis/examples/field_paths.c
+++ b/xj-analysis/examples/field_paths.c
@@ -1,14 +1,7 @@
-/* M2: the alphabet is access paths, and §2's memory reasoning starts to
- * carry weight. `table_storage.c` is the motivating shape; this file is the
- * rule-by-rule checklist beside it, in the same style as
- * `copy_propagation.c` — one mechanism per function, each the smallest C
- * that exercises it.
- *
- * Everything here reports `none` under `--no-memory-candidates`, since
- * without field-path cells there is no candidate to name and no store to
- * rule disjoint. That is the point of the file: every answer below is a
- * consequence of M2, and half of them are answers M2 must be careful *not*
- * to get wrong.
+/* Bases that are field paths rather than variable names, and the rules that
+ * decide when a store or a call disturbs one. `table_storage.c` is the
+ * motivating program; this is the case-by-case checklist beside it, in the
+ * same style as `copy_propagation.c`.
  */
 
 extern void use(char *);
@@ -45,11 +38,8 @@ union pun
     char *b;
 };
 
-/* 1. The join case, which is the headline of partition_domain_design.md §0
-   with a field path in place of a variable. Neither branch's value survives
-   the join, but `t->storage` survives as a *class*, so the copy has
-   something to attach to and the equality is recovered. Under the symbol
-   domain both cells were T and the copy recorded nothing. */
+/* 1. Which pointer `t->storage` holds is unknown after the branch, but `p` is
+   a copy of whatever it holds. */
 void join_then_copy(struct table *t, char *a, char *b, int c)
 {
     if (c)
@@ -60,9 +50,7 @@ void join_then_copy(struct table *t, char *a, char *b, int c)
     use(p); /* xj-expect: join_then_copy: p -> t->storage */
 }
 
-/* 2. A call cannot reach a field of a non-escaping local: nothing outside
-   the function can name `x`, so nothing outside it can name `x.buf`. This
-   is the field-path half of `call_does_not_kill_a_local`. */
+/* 2. `g` cannot name `x`, so it cannot name `x.buf` either. */
 void non_escaping_field(void)
 {
     struct box x;
@@ -72,10 +60,7 @@ void non_escaping_field(void)
     use(p); /* xj-expect: non_escaping_field: p -> x.buf */
 }
 
-/* 3. ...unless the field's address was taken. `&x.buf` hands out a pointer
-   *into* `x`, so the callee may write it, and the escape has to attach to
-   the root — a rule the M1 escape collector did not need, because with no
-   field paths there was nothing between `&` and a variable. */
+/* 3. ...but `&x.buf` is handed out, so a later call may write the field. */
 void escaping_field(void)
 {
     struct box x;
@@ -86,9 +71,8 @@ void escaping_field(void)
     use(p); /* xj-expect: escaping_field: p -> none */
 }
 
-/* 4. Two distinct members of one struct do not overlap, so a store to the
-   sibling leaves the base alone. The clause that buys everything — and the
-   same one `checksum_and_reset` turns on. */
+/* 4. `len` and `storage` are different members of the same struct, so the
+   store cannot touch the base. */
 void sibling_field_is_disjoint(struct table *t, unsigned n)
 {
     char *p = t->storage;
@@ -96,8 +80,8 @@ void sibling_field_is_disjoint(struct table *t, unsigned n)
     use(p); /* xj-expect: sibling_field_is_disjoint: p -> t->storage */
 }
 
-/* 5. Two members of a *union* share storage by construction, which is where
-   type punning lives. The struct clause must not fire here. */
+/* 5. Members of a union are the same storage, which is how type punning
+   works, so the rule above must not fire. */
 void union_members_alias(union pun *m, char *q)
 {
     char *p = m->a;
@@ -105,10 +89,7 @@ void union_members_alias(union pun *m, char *q)
     use(p); /* xj-expect: union_members_alias: p -> none */
 }
 
-/* 6. A whole-object store writes every field of it. This is the rule that
-   forces non-pointer variables into the alphabet: were `x` not a cell,
-   `x = y` would be an *unresolvable* store, and T2 spares everything out of
-   reach — which `x.buf` is. */
+/* 6. Assigning a whole struct writes every member of it, `x.buf` included. */
 void whole_struct_assign(struct box y)
 {
     struct box x;
@@ -118,10 +99,8 @@ void whole_struct_assign(struct box y)
     use(p); /* xj-expect: whole_struct_assign: p -> none */
 }
 
-/* 7. Same root, but the paths diverge before any field: `s->storage` and
-   `t->storage` are the same path through different pointers, and nothing
-   says the pointers differ. Distinctness of cells never proves
-   disjointness. */
+/* 7. The same path through two different pointers: `s` and `t` may be the
+   same table. */
 void two_objects(struct table *s, struct table *t, char *q)
 {
     char *p = t->storage;
@@ -129,8 +108,8 @@ void two_objects(struct table *s, struct table *t, char *q)
     use(p); /* xj-expect: two_objects: p -> none */
 }
 
-/* 8. Over `MaxPathDepth`, so the destination is not nameable and the store
-   is unresolvable — lossy, never unsound. */
+/* 8. `o->in->buf` is deeper than `MaxPathDepth`, so the store cannot be named
+   and could be to anything. */
 void over_depth_cap(struct outer *o, struct table *t, char *q)
 {
     char *p = t->storage;
@@ -138,9 +117,7 @@ void over_depth_cap(struct outer *o, struct table *t, char *q)
     use(p); /* xj-expect: over_depth_cap: p -> none */
 }
 
-/* 9. A store through a pointer with no cell of its own. There is no Index
-   step and no bare-Deref cell, so this is the shape every unresolvable
-   store reduces to. */
+/* 9. `*q` could be `t->storage`. */
 void store_through_pointer(struct table *t, char **q)
 {
     char *p = t->storage;
@@ -148,18 +125,9 @@ void store_through_pointer(struct table *t, char **q)
     use(p); /* xj-expect: store_through_pointer: p -> none */
 }
 
-/* 10. The one an access-path alphabet must not get wrong: a cell named
-   through a mutable pointer stops denoting the same storage when that
-   pointer is reassigned. `t->storage` after `t = u` is a different object,
-   so the equality `p` had with it cannot survive.
-
-   This is the whole reason `denotationDependsOn` exists beside
-   `mayOverlap`. Not one byte of the old `*t` is written by `t = u`, and
-   the two cells do not overlap: `Var(t)` is the pointer variable,
-   `Var(t).Deref.Field(storage)` is a field of somebody else's object. What
-   breaks is that the path no longer *reaches* the storage the equality was
-   about. `Var(t)` is a proper prefix of the path and the steps below it go
-   out through a Deref, so the store moves it. */
+/* 10. `t = u` writes no byte of the old `*t`, but `t->storage` now names a
+   field of a different object, so `p` no longer agrees with it.
+   `denotationDependsOn` is the test for this; overlap alone would miss it. */
 void reassign_base(struct table *t, struct table *u)
 {
     char *p = t->storage;
@@ -167,15 +135,7 @@ void reassign_base(struct table *t, struct table *u)
     use(p); /* xj-expect: reassign_base: p -> none */
 }
 
-/* 11. The converse of 10, and what the prefix/overlap split bought. The
-   store goes *through* `t` rather than to it, so `t`'s own value is
-   untouched: `t->len` is storage in the pointee, `t` is a pointer variable
-   whose address is never taken, and nothing can point back into it. The
-   equality `t` has with `s` survives.
-
-   Under the old single `mayAlias` this reported `none`. The prefix case
-   answered true in both directions, so the analysis was more precise about
-   the fields of `*t` — case 4 — than about `t` itself. */
+/* 11. The converse: writing through `t` does not change `t` itself. */
 void store_through_pointer_keeps_root(struct table *s, unsigned n)
 {
     struct table *t = s;
@@ -183,16 +143,12 @@ void store_through_pointer_keeps_root(struct table *s, unsigned n)
     use2(t); /* xj-expect: store_through_pointer_keeps_root: t -> s */
 }
 
-/* 12. ...and the guard on 11, which is why the narrowed clause asks about
-   reach rather than answering false outright. `t` is punned to point at
-   its own storage, so `(*t).storage` — the first member — *is* the bytes of
-   `t`, and `t->storage = q` writes `t` after all. Forming that pointer
-   needs `&t`, which puts `t` in reach and brings the overlap back.
+/* 12. ...unless `t` points at itself, in which case its first member is `t`
+   and `t->storage = q` does write it. Building such a pointer needs `&t`,
+   which is what the test for it looks at.
 
-   Strictly this program is a strict-aliasing violation, so one could argue
-   the clause could be unconditional. The analysis declines to rely on
-   that: tenjin translates C that is routinely built -fno-strict-aliasing,
-   and the reach test costs one comparison. */
+   This program violates strict aliasing, and the analysis still handles it:
+   tenjin translates C that is routinely built -fno-strict-aliasing. */
 void self_pointing(char *q)
 {
     struct table *t = (struct table *)&t;

--- a/xj-analysis/examples/table_storage.c
+++ b/xj-analysis/examples/table_storage.c
@@ -1,0 +1,93 @@
+/* Why the domain needs memory reasoning — the `table->storage` shape.
+ *
+ * Each function below walks a buffer with a local cursor. They differ only
+ * in where the cursor's base comes from, and that difference decides
+ * whether the pointer transform can collapse the cursor onto its base (so
+ * the translation lowers to an index into a slice) or has to keep it as a
+ * frozen handle (`*mut c_char` + `.offset()`).
+ *
+ * `checksum_named` needs nothing beyond copy propagation over variables.
+ * `checksum` is the case this library exists for: its base is an lvalue
+ * path through a parameter, so with variables-only cells there is no
+ * candidate for `p` to resolve to and the cursor does not collapse. Today
+ * that collapse happens in the pointer pass, textually, via
+ * BaseMutationFinder — so losing it is a regression, not a missing
+ * feature.
+ *
+ * The last two mark the boundary, which is worth having in the same file
+ * as the motivating case: a store to a sibling field is provably not a
+ * write to the base, and an opaque call is.
+ *
+ * The annotations are what *this library* must produce. The M0 spike can
+ * run the file (see README.md) and agrees on the first three, but reports
+ * `t->storage` for `checksum_logged`, because it has no clobber rule and
+ * so invalidates nothing at a call. That disagreement is the rule M1 adds,
+ * not a disagreement about the example.
+ */
+
+struct table
+{
+    char *storage;
+    unsigned len;
+};
+
+extern void log_start(void);
+
+/* Tier 0/1. The base is a parameter's name, so a variables-only cell
+   alphabet already resolves it. This is the only shape slicing can use:
+   `detectRoots` accepts a base only when it equals a pointer parameter's
+   name. */
+unsigned checksum_named(char *buf, unsigned len)
+{
+    char *p = buf;
+    unsigned sum = 0;
+    for (unsigned i = 0; i < len; i++)
+        sum += (unsigned char)p[i]; /* xj-expect: checksum_named: p -> buf */
+    return sum;
+}
+
+/* Tier 2, and the point of the file. `p`'s base is `t->storage`, which is
+   not any variable's name, so it is a candidate only once cells are access
+   paths. With `--no-memory-candidates` this resolves to nothing and the
+   cursor lowers as a raw pointer. */
+unsigned checksum(struct table *t)
+{
+    char *p = t->storage;
+    unsigned sum = 0;
+    for (unsigned i = 0; i < t->len; i++)
+        sum += (unsigned char)p[i]; /* xj-expect: checksum: p -> t->storage */
+    return sum;
+}
+
+/* Still resolves, and this is capability the framework route could not
+   have had. `t->len` and `t->storage` share the prefix `Var(t) . Deref`
+   and then diverge at two distinct members of a struct, so the store
+   provably does not write the base — a fact about C's object model, not an
+   assumption. A model whose cells are opaque locations has to clear the
+   base here. */
+unsigned checksum_and_reset(struct table *t)
+{
+    char *p = t->storage;
+    unsigned sum = 0;
+    for (unsigned i = 0; i < t->len; i++)
+        sum += (unsigned char)p[i]; /* xj-expect: checksum_and_reset: p -> t->storage */
+    t->len = 0;
+    return sum;
+}
+
+/* Does not resolve, soundly. `t` is a parameter, so the object it points
+   at is reachable from the caller, therefore possibly from a global,
+   therefore possibly from `log_start` — which could assign `t->storage`
+   without taking an argument. Substituting `t->storage` at the use would
+   be a miscompilation. The equality survives only in a call-free window,
+   and measuring how often the corpus has that shape is what the M3 oracle
+   run is for. */
+unsigned checksum_logged(struct table *t)
+{
+    char *p = t->storage;
+    unsigned sum = 0;
+    log_start();
+    for (unsigned i = 0; i < t->len; i++)
+        sum += (unsigned char)p[i]; /* xj-expect: checksum_logged: p -> none */
+    return sum;
+}

--- a/xj-analysis/examples/table_storage.c
+++ b/xj-analysis/examples/table_storage.c
@@ -1,28 +1,7 @@
-/* Why the domain needs memory reasoning — the `table->storage` shape.
- *
- * Each function below walks a buffer with a local cursor. They differ only
- * in where the cursor's base comes from, and that difference decides
- * whether the pointer transform can collapse the cursor onto its base (so
- * the translation lowers to an index into a slice) or has to keep it as a
- * frozen handle (`*mut c_char` + `.offset()`).
- *
- * `checksum_named` needs nothing beyond copy propagation over variables.
- * `checksum` is the case this library exists for: its base is an lvalue
- * path through a parameter, so with variables-only cells there is no
- * candidate for `p` to resolve to and the cursor does not collapse. Today
- * that collapse happens in the pointer pass, textually, via
- * BaseMutationFinder — so losing it is a regression, not a missing
- * feature.
- *
- * The last two mark the boundary, which is worth having in the same file
- * as the motivating case: a store to a sibling field is provably not a
- * write to the base, and an opaque call is.
- *
- * The annotations are what *this library* must produce. The M0 spike can
- * run the file (see README.md) and agrees on the first three, but reports
- * `t->storage` for `checksum_logged`, because it has no clobber rule and
- * so invalidates nothing at a call. That disagreement is the rule M1 adds,
- * not a disagreement about the example.
+/* Why bases that are field paths matter. Each function walks a buffer with a
+ * local cursor, and they differ only in where the cursor's base comes from.
+ * That difference decides whether the pointer transform can delete the cursor
+ * and index off its base instead, or has to leave it as a moving pointer.
  */
 
 struct table
@@ -33,10 +12,8 @@ struct table
 
 extern void log_start(void);
 
-/* Tier 0/1. The base is a parameter's name, so a variables-only cell
-   alphabet already resolves it. This is the only shape slicing can use:
-   `detectRoots` accepts a base only when it equals a pointer parameter's
-   name. */
+/* The base is a parameter's name. This is the only shape slicing can use:
+   `detectRoots` accepts a base only when it is a pointer parameter. */
 unsigned checksum_named(char *buf, unsigned len)
 {
     char *p = buf;
@@ -46,10 +23,8 @@ unsigned checksum_named(char *buf, unsigned len)
     return sum;
 }
 
-/* Tier 2, and the point of the file. `p`'s base is `t->storage`, which is
-   not any variable's name, so it is a candidate only once cells are access
-   paths. With `--no-memory-candidates` this resolves to nothing and the
-   cursor lowers as a raw pointer. */
+/* The base is `t->storage`, which is not any variable's name. This is the
+   case the library exists for. */
 unsigned checksum(struct table *t)
 {
     char *p = t->storage;
@@ -59,12 +34,8 @@ unsigned checksum(struct table *t)
     return sum;
 }
 
-/* Still resolves, and this is capability the framework route could not
-   have had. `t->len` and `t->storage` share the prefix `Var(t) . Deref`
-   and then diverge at two distinct members of a struct, so the store
-   provably does not write the base — a fact about C's object model, not an
-   assumption. A model whose cells are opaque locations has to clear the
-   base here. */
+/* The store is to a different member of the same struct, so it cannot touch
+   the base. */
 unsigned checksum_and_reset(struct table *t)
 {
     char *p = t->storage;
@@ -75,13 +46,8 @@ unsigned checksum_and_reset(struct table *t)
     return sum;
 }
 
-/* Does not resolve, soundly. `t` is a parameter, so the object it points
-   at is reachable from the caller, therefore possibly from a global,
-   therefore possibly from `log_start` — which could assign `t->storage`
-   without taking an argument. Substituting `t->storage` at the use would
-   be a miscompilation. The equality survives only in a call-free window,
-   and measuring how often the corpus has that shape is what the M3 oracle
-   run is for. */
+/* `t` points at an object the caller can reach, so `log_start` may reach it
+   too — through a global, say — and assign `t->storage`. */
 unsigned checksum_logged(struct table *t)
 {
     char *p = t->storage;

--- a/xj-analysis/examples/table_storage_input.c
+++ b/xj-analysis/examples/table_storage_input.c
@@ -1,0 +1,28 @@
+/* The input side of the `table->storage` example: what the pointer pass
+ * sees today, before anything has been rewritten.
+ *
+ * `p` is a moving cursor whose base is the lvalue path `t->storage`. Today
+ * xj-prepare-pointertransform recognises that textually, via
+ * BaseMutationFinder, and *collapses* the cursor: `p` is deleted and its
+ * accesses are rewritten against the base. See README.md for the recorded
+ * metadata and the rewritten source.
+ *
+ * That collapse is the behaviour PR 3 relocates into this library. It is
+ * why memory reasoning is not a new capability here — it is what keeps an
+ * existing one.
+ */
+
+struct table
+{
+    char *storage;
+    unsigned len;
+};
+
+unsigned checksum(struct table *t)
+{
+    char *p = t->storage;
+    unsigned sum = 0;
+    for (unsigned i = 0; i < t->len; i++)
+        sum += (unsigned char)*p++;
+    return sum;
+}

--- a/xj-analysis/examples/table_storage_input.c
+++ b/xj-analysis/examples/table_storage_input.c
@@ -1,15 +1,5 @@
-/* The input side of the `table->storage` example: what the pointer pass
- * sees today, before anything has been rewritten.
- *
- * `p` is a moving cursor whose base is the lvalue path `t->storage`. Today
- * xj-prepare-pointertransform recognises that textually, via
- * BaseMutationFinder, and *collapses* the cursor: `p` is deleted and its
- * accesses are rewritten against the base. See README.md for the recorded
- * metadata and the rewritten source.
- *
- * That collapse is the behaviour PR 3 relocates into this library. It is
- * why memory reasoning is not a new capability here — it is what keeps an
- * existing one.
+/* The same loop before any rewriting: `p` is a cursor whose base is the
+ * lvalue path `t->storage`.
  */
 
 struct table

--- a/xj-analysis/tools/xj-musteq-check/main.cpp
+++ b/xj-analysis/tools/xj-musteq-check/main.cpp
@@ -1,0 +1,186 @@
+// xj-musteq-check — annotation-driven test driver for xj-analysis.
+//
+// Reads a C file, runs MustEqualAnalysis over every function defined in it,
+// and verifies the `xj-expect` comments against what the analysis produced:
+//
+//     use(p);   /* xj-expect: copy_of_param: p -> buf */
+//     use(p);   /* xj-expect: opaque_rhs: p -> none */
+//
+// The annotation is per (function, pointer), not per site, because the fact
+// the library exposes is the reduced one — an annotation naming a line would
+// be testing `sitesFor`, which is a different question. `-> none` asserts
+// that no candidate agreed at every use site.
+//
+// This is the primary test surface, and it is why the transfer's havoc
+// rules are worth stating one at a time: every rule gets a two-line C case.
+
+#include "MustEqual.h"
+#include "ResolveParameter.h"
+#include "VarMutation.h"
+
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/Decl.h"
+#include "clang/Basic/SourceManager.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendAction.h"
+#include "clang/Tooling/CommonOptionsParser.h"
+#include "clang/Tooling/Tooling.h"
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <map>
+#include <string>
+#include <utility>
+
+using namespace clang;
+
+static llvm::cl::OptionCategory
+    Category("xj-musteq-check options");
+
+static llvm::cl::opt<bool>
+    Dump("dump",
+         llvm::cl::desc("Print every resolution instead of checking "
+                        "annotations"),
+         llvm::cl::init(false), llvm::cl::cat(Category));
+
+namespace
+{
+
+  unsigned Checked = 0;
+  unsigned Failed = 0;
+
+  using Key = std::pair<std::string, std::string>; // (function, pointer)
+
+  // `xj-expect: <function>: <pointer> -> <cell text|none>`
+  std::map<Key, std::string> parseExpectations(llvm::StringRef Buffer)
+  {
+    std::map<Key, std::string> Out;
+    size_t Pos = 0;
+    const llvm::StringRef Marker = "xj-expect:";
+    while ((Pos = Buffer.find(Marker, Pos)) != llvm::StringRef::npos)
+    {
+      llvm::StringRef Rest = Buffer.substr(Pos + Marker.size());
+      Rest = Rest.take_until([](char C)
+                             { return C == '\n'; });
+      // Stop at a trailing comment terminator so `*/` never lands in the
+      // expected text.
+      size_t End = Rest.find("*/");
+      if (End != llvm::StringRef::npos)
+        Rest = Rest.substr(0, End);
+
+      auto [Fn, After] = Rest.split(':');
+      auto [Ptr, Want] = After.split("->");
+      if (!After.contains("->"))
+      {
+        Pos += Marker.size();
+        continue;
+      }
+      Out[{Fn.trim().str(), Ptr.trim().str()}] = Want.trim().str();
+      Pos += Marker.size();
+    }
+    return Out;
+  }
+
+  class Consumer : public ASTConsumer
+  {
+  public:
+    void HandleTranslationUnit(ASTContext &Ctx) override
+    {
+      const SourceManager &SM = Ctx.getSourceManager();
+      auto Expect =
+          parseExpectations(SM.getBufferData(SM.getMainFileID()));
+
+      xj::analysis::Options Opts;
+
+      for (Decl *D : Ctx.getTranslationUnitDecl()->decls())
+      {
+        auto *FD = llvm::dyn_cast<FunctionDecl>(D);
+        if (FD == nullptr || !FD->doesThisDeclarationHaveABody() ||
+            !SM.isWrittenInMainFile(FD->getLocation()))
+          continue;
+
+        std::string Fn = FD->getNameAsString();
+        auto Analysis = xj::analysis::MustEqualAnalysis::run(Ctx, *FD, Opts);
+        if (!Analysis)
+        {
+          llvm::errs() << "declined " << Fn << ": "
+                       << llvm::toString(Analysis.takeError()) << "\n";
+          continue;
+        }
+
+        auto Resolver =
+            xj::analysis::ParameterResolver::run(*FD, *Analysis);
+
+        for (const VarDecl *V : Resolver.tracked())
+        {
+          std::string Ptr = V->getNameAsString();
+          auto R = Resolver.resolve(V);
+          std::string Got =
+              R ? Analysis->cells().print(R->Cell) : std::string("none");
+
+          if (Dump)
+          {
+            llvm::errs() << Fn << ": " << Ptr << " -> " << Got;
+            if (R)
+            {
+              llvm::errs() << " [" << R->Sites << " sites";
+              if (R->EntryAnchored)
+                llvm::errs() << ", entry-anchored";
+              llvm::errs() << "]";
+            }
+            if (xj::analysis::neverReassigned(V, *FD))
+              llvm::errs() << " never-reassigned";
+            llvm::errs() << "\n";
+            continue;
+          }
+
+          auto It = Expect.find({Fn, Ptr});
+          if (It == Expect.end())
+            continue;
+          ++Checked;
+          bool OK = It->second == Got;
+          if (!OK)
+            ++Failed;
+          llvm::errs() << (OK ? "ok   " : "FAIL ") << Fn << ":" << Ptr
+                       << " want=" << It->second << " got=" << Got << "\n";
+        }
+      }
+    }
+  };
+
+  class Action : public ASTFrontendAction
+  {
+  public:
+    std::unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance &,
+                                                   llvm::StringRef) override
+    {
+      return std::make_unique<Consumer>();
+    }
+  };
+
+} // namespace
+
+int main(int argc, const char **argv)
+{
+  auto Parser = tooling::CommonOptionsParser::create(argc, argv, Category);
+  if (!Parser)
+  {
+    llvm::errs() << Parser.takeError();
+    return 2;
+  }
+
+  tooling::ClangTool Tool(Parser->getCompilations(),
+                          Parser->getSourcePathList());
+  if (Tool.run(tooling::newFrontendActionFactory<Action>().get()) != 0)
+    return 2;
+
+  if (Dump)
+    return 0;
+  llvm::errs() << "\n"
+               << (Checked - Failed) << "/" << Checked
+               << " expectations met\n";
+  return Failed == 0 ? 0 : 1;
+}

--- a/xj-prepare-baserewrite/BaseRewriteAction.cpp
+++ b/xj-prepare-baserewrite/BaseRewriteAction.cpp
@@ -1,0 +1,44 @@
+#include "BaseRewriteAction.h"
+
+bool g_base_inplace = false;
+bool g_base_verbose = false;
+std::string g_base_metadata_in;
+std::string g_base_metadata_out;
+xj::PtrIndexMetadata g_base_metadata;
+std::set<std::string> g_base_handled;
+xj::ReconstructionStats g_base_stats;
+
+namespace {
+
+class BaseRewriteConsumer : public ASTConsumer {
+  public:
+    explicit BaseRewriteConsumer(Rewriter &R) : TheRewriter(R) {}
+
+    void HandleTranslationUnit(ASTContext &Ctx) override {
+        xj::Reconstructor Rec(TheRewriter, g_base_metadata, g_base_handled,
+                              g_base_stats, g_base_verbose);
+        Rec.run(Ctx);
+    }
+
+  private:
+    Rewriter &TheRewriter;
+};
+
+} // namespace
+
+// Flush edits to disk (--inplace) or stream the rewritten main buffer to
+// stdout, mirroring the two sibling tools.
+void BaseRewriteAction::EndSourceFileAction() {
+    SourceManager &SM = TheRewriter.getSourceMgr();
+    if (g_base_inplace) {
+        TheRewriter.overwriteChangedFiles();
+    } else {
+        TheRewriter.getEditBuffer(SM.getMainFileID()).write(llvm::outs());
+    }
+}
+
+std::unique_ptr<ASTConsumer>
+BaseRewriteAction::CreateASTConsumer(CompilerInstance &CI, StringRef file) {
+    TheRewriter.setSourceMgr(CI.getSourceManager(), CI.getLangOpts());
+    return std::make_unique<BaseRewriteConsumer>(TheRewriter);
+}

--- a/xj-prepare-baserewrite/BaseRewriteAction.h
+++ b/xj-prepare-baserewrite/BaseRewriteAction.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "PtrIndexMetadata.h"
+#include "Reconstructor.h"
+
+#include "clang/AST/ASTConsumer.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendActions.h"
+#include "clang/Rewrite/Core/Rewriter.h"
+#include "clang/Tooling/CommonOptionsParser.h"
+#include "clang/Tooling/Tooling.h"
+#include "llvm/Support/CommandLine.h"
+
+#include <set>
+#include <string>
+
+using namespace clang;
+using namespace clang::tooling;
+using namespace llvm;
+
+// CLI flags, published from main.cpp.
+extern bool g_base_inplace;
+extern bool g_base_verbose;
+extern std::string g_base_metadata_in;
+extern std::string g_base_metadata_out;
+
+// The side-file, read once at startup and *mutated* as bases are proved:
+// this tool is both a consumer and a producer of it.
+extern xj::PtrIndexMetadata g_base_metadata;
+// Function keys already reconstructed, so that a function defined in a
+// header is not rewritten again when the next TU includes it.
+extern std::set<std::string> g_base_handled;
+extern xj::ReconstructionStats g_base_stats;
+
+// Per-translation-unit FrontendAction: runs the must-equality analysis
+// over each function with records in the side-file and substitutes the
+// bases it proves. One sweep — unlike the slice pass, nothing here depends
+// on a fact from another TU.
+class BaseRewriteAction : public ASTFrontendAction
+{
+public:
+  BaseRewriteAction() = default;
+
+  void EndSourceFileAction() override;
+  std::unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance &CI,
+                                                 StringRef file) override;
+
+private:
+  Rewriter TheRewriter; // Holds all source edits for this TU.
+};

--- a/xj-prepare-baserewrite/CMakeLists.txt
+++ b/xj-prepare-baserewrite/CMakeLists.txt
@@ -1,0 +1,50 @@
+cmake_minimum_required(VERSION 3.17)
+project(xj-prepare-baserewrite)
+
+set(XJ_LLVM_ROOT "${CMAKE_CURRENT_LIST_DIR}/../_local/xj-llvm")
+set(XJ_SUPPORT_DIR "${CMAKE_CURRENT_LIST_DIR}/../xj-prepare-support")
+
+include_directories("${XJ_LLVM_ROOT}/include" "${XJ_SUPPORT_DIR}")
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
+
+# The must-equality library this tool is the first consumer of. It is its
+# own CMake project, pulled in as a subdirectory rather than installed;
+# EXCLUDE_FROM_ALL keeps its two hand-driven check tools out of this
+# build, which only wants the library.
+#
+# Note that xj-analysis/CMakeLists.txt sets the LLVM include path with a
+# bare `include_directories`, which does not propagate out of
+# add_subdirectory — hence the one above, as in the sibling tools.
+add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/../xj-analysis" xj-analysis EXCLUDE_FROM_ALL)
+
+add_executable(xj-prepare-baserewrite
+    main.cpp
+    BaseRewriteAction.cpp
+    Reconstructor.cpp
+    "${XJ_SUPPORT_DIR}/PtrIndexMetadata.cpp"
+    "${XJ_SUPPORT_DIR}/FunctionKey.cpp"
+)
+
+set_target_properties(xj-prepare-baserewrite PROPERTIES
+    CXX_STANDARD 17
+    CXX_EXTENSIONS OFF
+)
+
+set(XJ_LLVM_LIB_DIR "${XJ_LLVM_ROOT}/lib")
+find_library(XJ_LLVM_LIBCLANG
+	NAMES libclang${CMAKE_SHARED_LIBRARY_SUFFIX}
+	PATHS "${XJ_LLVM_LIB_DIR}" REQUIRED NO_DEFAULT_PATH)
+find_library(XJ_LLVM_LIBCLANGCPP
+	NAMES libclang-cpp${CMAKE_SHARED_LIBRARY_SUFFIX}
+	PATHS "${XJ_LLVM_LIB_DIR}" REQUIRED NO_DEFAULT_PATH)
+find_library(XJ_LLVM_LIBLLVM
+	NAMES libLLVM${CMAKE_SHARED_LIBRARY_SUFFIX}
+	PATHS "${XJ_LLVM_LIB_DIR}" REQUIRED NO_DEFAULT_PATH)
+
+target_link_libraries(xj-prepare-baserewrite
+	xj-analysis
+	${XJ_LLVM_LIBCLANG}
+	${XJ_LLVM_LIBCLANGCPP}
+	${XJ_LLVM_LIBLLVM}
+)

--- a/xj-prepare-baserewrite/Reconstructor.cpp
+++ b/xj-prepare-baserewrite/Reconstructor.cpp
@@ -1,0 +1,782 @@
+// `run` walks the translation unit and hands every non-system function
+// definition to `reconstructFunction`, which is where all of it lives:
+//
+//   1. Look the function up in the side-file by `functionKey`, and skip it
+//      if an earlier TU already rewrote it.
+//
+//   2. Run `MustEqualAnalysis` over the body.
+//
+//   3. Collect candidates: pointers the analysis tracks *and* the pointer
+//      pass recorded, matched on the decl position in the record and
+//      cross-checked against the recorded name. Two sets matter here and
+//      they are not the same one:
+//
+//        `Candidates`      may be deleted (recorded, so it has an index var)
+//        `R.tracked()`     may be substituted (proved, whoever recorded it)
+//
+//      The analysis tracks every pointer local, including ones the pointer
+//      pass left alone, and those make perfectly good bases. That gap is
+//      what step 4a and step 5 are about.
+//
+//   4. Plan each candidate. Either half may decline, and the reason is
+//      reported rather than swallowed:
+//
+//        a. `resolve` it to a cell, preferring one this run will not
+//           itself delete. When every agreeing cell is a casualty, take
+//           the library's own pick and leave it to step 5.
+//        b. `checkSubstitutable` — the syntactic side conditions the proof
+//           says nothing about: macro expansions, `sizeof`, `p += n`,
+//           side-effecting stores, stores in positions that cannot be
+//           deleted on their own, and a base whose spelling something else
+//           in the function shadows.
+//
+//   5. Backstop for 4a: drop any surviving plan whose base is rooted at a
+//      pointer another surviving plan deletes. Iterated to a fixpoint,
+//      which terminates because dropping is monotone.
+//
+//   6. `buildEdits` per plan, in *original* file offsets: delete the
+//      declaration, delete each store's comma arm, fold the index forms,
+//      then substitute the base at every remaining mention. A plan with an
+//      edit outside the function's own file is dropped whole rather than
+//      half-applied.
+//
+//   7. `applyEdits` once for the function: outermost edit wins over any it
+//      overlaps, and edits land back-to-front so earlier offsets stay
+//      valid.
+//
+//   8. Write the proved base back into the side-file, for the committed
+//      plans only, so an empty `base_text` still means "its own base".
+//
+// Steps 4b and 6 share one notion of what a store to the pointer looks
+// like: the left arm of the comma the pointer pass emits, recognized in
+// `checkSubstitutable` and recorded on the `Plan` for `buildEdits` to
+// delete. That is deliberate. They used to recognize it separately, and
+// `checkSubstitutable` admitted a shape — a store that is a statement of
+// its own — that `buildEdits` did not delete, so the base was substituted
+// into the store's left-hand side and `p = NULL;` silently became
+// `t->storage = NULL;`.
+
+#include "Reconstructor.h"
+
+#include "FunctionKey.h"
+
+#include "clang/AST/ParentMapContext.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Lex/Lexer.h"
+#include "clang/Tooling/Core/Replacement.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/STLFunctionalExtras.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <algorithm>
+#include <map>
+#include <utility>
+
+using namespace clang;
+
+namespace xj
+{
+  namespace
+  {
+
+    // The variable an expression names, stripped of the parens and implicit
+    // conversions that carry no meaning here.
+    const VarDecl *bareVar(const Expr *E)
+    {
+      if (E == nullptr)
+        return nullptr;
+      const auto *DRE = dyn_cast<DeclRefExpr>(E->IgnoreParenImpCasts());
+      return DRE ? dyn_cast<VarDecl>(DRE->getDecl()) : nullptr;
+    }
+
+    std::string textOf(const Expr *E, ASTContext &Ctx)
+    {
+      return Lexer::getSourceText(
+                 CharSourceRange::getTokenRange(E->getSourceRange()),
+                 Ctx.getSourceManager(), Ctx.getLangOpts())
+          .str();
+    }
+
+    // Either end inside a macro expansion is enough to disqualify: neither
+    // end can be rewritten, and the two need not agree.
+    bool inMacro(const Stmt *S)
+    {
+      return S->getBeginLoc().isMacroID() || S->getEndLoc().isMacroID();
+    }
+
+    bool mentionsVar(const Stmt *S, const VarDecl *V)
+    {
+      if (S == nullptr)
+        return false;
+      if (const auto *DRE = dyn_cast<DeclRefExpr>(S))
+        if (dyn_cast<VarDecl>(DRE->getDecl()) == V)
+          return true;
+      for (const Stmt *C : S->children())
+        if (mentionsVar(C, V))
+          return true;
+      return false;
+    }
+
+    // `(p + p_index_xj)` — the form the pointer pass emits wherever the
+    // pointer's *value* is read rather than an element of it.
+    bool isBasePlusIndex(const Expr *E, const VarDecl *Ptr, const VarDecl *Idx)
+    {
+      if (E == nullptr)
+        return false;
+      const auto *BO = dyn_cast<BinaryOperator>(E->IgnoreParenImpCasts());
+      return BO != nullptr && BO->getOpcode() == BO_Add &&
+             bareVar(BO->getLHS()) == Ptr && bareVar(BO->getRHS()) == Idx;
+    }
+
+    // The single parent statement of `S`, looking through parentheses.
+    const Stmt *parentThroughParens(const Stmt *S, ASTContext &Ctx)
+    {
+      while (S != nullptr)
+      {
+        DynTypedNodeList Parents = Ctx.getParents(*S);
+        if (Parents.size() != 1)
+          return nullptr;
+        const Stmt *P = Parents[0].get<Stmt>();
+        if (P == nullptr || !isa<ParenExpr>(P))
+          return P;
+        S = P;
+      }
+      return nullptr;
+    }
+
+    // Everything about one pointer's occurrences that bears on whether it
+    // can be reconstructed, gathered in a single walk of the body.
+    class RefCollector : public RecursiveASTVisitor<RefCollector>
+    {
+    public:
+      RefCollector(const VarDecl *V, ASTContext &Ctx) : V(V), Ctx(Ctx) {}
+
+      const VarDecl *V;
+      ASTContext &Ctx;
+
+      std::vector<const DeclRefExpr *> Refs;
+      std::vector<const BinaryOperator *> Assigns;
+      const DeclStmt *Decl = nullptr;
+
+      bool InMacro = false;
+      bool MultiDeclarator = false;
+      // A use whose value depends on the pointer's *type* rather than its
+      // value: `sizeof p` is not `sizeof buf` when the base is an array.
+      bool Unevaluated = false;
+      // The pointer's own storage is written by something other than a
+      // plain `p = RHS`, so no substitution can stand in for it.
+      bool Mutated = false;
+      // Deleting a store means deleting its right-hand side, which is only
+      // safe when evaluating it did nothing else.
+      bool SideEffectingStore = false;
+
+      bool VisitDeclRefExpr(DeclRefExpr *DRE)
+      {
+        if (dyn_cast<VarDecl>(DRE->getDecl()) != V)
+          return true;
+        Refs.push_back(DRE);
+        InMacro |= inMacro(DRE);
+        return true;
+      }
+
+      bool VisitDeclStmt(DeclStmt *DS)
+      {
+        if (!llvm::is_contained(DS->decls(), V))
+          return true;
+        Decl = DS;
+        MultiDeclarator |= !DS->isSingleDecl();
+        InMacro |= inMacro(DS);
+        if (const Expr *Init = V->getInit())
+          SideEffectingStore |= Init->HasSideEffects(Ctx);
+        return true;
+      }
+
+      bool VisitUnaryExprOrTypeTraitExpr(UnaryExprOrTypeTraitExpr *E)
+      {
+        if (!E->isArgumentType() && mentionsVar(E->getArgumentExpr(), V))
+          Unevaluated = true;
+        return true;
+      }
+
+      bool VisitBinaryOperator(BinaryOperator *BO)
+      {
+        if (!BO->isAssignmentOp() || bareVar(BO->getLHS()) != V)
+          return true;
+        // `p += n` moves the pointer itself. The pointer pass rewrites
+        // those onto the index, so one here is something it left alone.
+        if (BO->getOpcode() != BO_Assign)
+        {
+          Mutated = true;
+          return true;
+        }
+        Assigns.push_back(BO);
+        SideEffectingStore |= BO->getRHS()->HasSideEffects(Ctx);
+        return true;
+      }
+
+      bool VisitUnaryOperator(UnaryOperator *UO)
+      {
+        if (UO->isIncrementDecrementOp() && bareVar(UO->getSubExpr()) == V)
+          Mutated = true;
+        return true;
+      }
+    };
+
+    // Every variable `FD` declares: its parameters, then the locals in its
+    // body. Parameters are visited by hand because traversing the body does
+    // not reach them.
+    void forEachVarDecl(const FunctionDecl &FD,
+                        llvm::function_ref<void(const VarDecl *)> F)
+    {
+      class Walker : public RecursiveASTVisitor<Walker>
+      {
+      public:
+        explicit Walker(llvm::function_ref<void(const VarDecl *)> F) : F(F) {}
+
+        bool VisitVarDecl(VarDecl *VD)
+        {
+          F(VD);
+          return true;
+        }
+
+      private:
+        llvm::function_ref<void(const VarDecl *)> F;
+      } W(F);
+
+      for (const ParmVarDecl *P : FD.parameters())
+        F(P);
+      W.TraverseStmt(const_cast<Stmt *>(FD.getBody()));
+    }
+
+    // Is any variable other than `Root` in this function spelled the same?
+    // The substituted text is a *spelling*, so a shadowing declaration
+    // between the proof and the use would silently rebind it.
+    bool rootNameIsAmbiguous(const FunctionDecl &FD, const VarDecl *Root)
+    {
+      const VarDecl *Canonical = Root->getCanonicalDecl();
+      bool Ambiguous = false;
+      forEachVarDecl(FD, [&](const VarDecl *VD)
+                     {
+        if (VD->getName() == Root->getName() &&
+            VD->getCanonicalDecl() != Canonical)
+          Ambiguous = true; });
+      return Ambiguous;
+    }
+
+    const VarDecl *findLocalVarNamed(const FunctionDecl &FD, StringRef Name)
+    {
+      const VarDecl *Found = nullptr;
+      forEachVarDecl(FD, [&](const VarDecl *VD)
+                     {
+        if (Found == nullptr && !isa<ParmVarDecl>(VD) && VD->getName() == Name)
+          Found = VD; });
+      return Found;
+    }
+
+    // Widen [Begin, End) to the whole line when the rest of that line is
+    // blank, so a deleted declaration leaves no empty line behind.
+    //
+    // Done here, in original offsets, rather than with the Rewriter's
+    // RemoveLineIfEmpty: see the note on Reconstructor::Edit for why that
+    // option cannot be mixed with other edits.
+    void expandToWholeLine(llvm::StringRef Text, unsigned &Begin, unsigned &End)
+    {
+      unsigned LineStart = Begin;
+      while (LineStart > 0 && Text[LineStart - 1] != '\n')
+      {
+        if (!isHorizontalWhitespace(Text[LineStart - 1]))
+          return; // something else shares the line
+        --LineStart;
+      }
+      unsigned LineEnd = End;
+      while (LineEnd < Text.size() && Text[LineEnd] != '\n')
+      {
+        if (!isHorizontalWhitespace(Text[LineEnd]))
+          return;
+        ++LineEnd;
+      }
+      Begin = LineStart;
+      End = LineEnd < Text.size() ? LineEnd + 1 : LineEnd;
+    }
+
+  } // namespace
+
+  void Reconstructor::run(ASTContext &Ctx)
+  {
+    class DefCollector : public RecursiveASTVisitor<DefCollector>
+    {
+    public:
+      std::vector<const FunctionDecl *> Defs;
+
+      bool VisitFunctionDecl(FunctionDecl *FD)
+      {
+        if (FD->doesThisDeclarationHaveABody() && FD->getBody() != nullptr)
+          Defs.push_back(FD);
+        return true;
+      }
+    } C;
+    C.TraverseDecl(Ctx.getTranslationUnitDecl());
+
+    SourceManager &SM = Ctx.getSourceManager();
+    for (const FunctionDecl *FD : C.Defs)
+    {
+      if (SM.isInSystemHeader(FD->getLocation()))
+        continue;
+      reconstructFunction(*FD, Ctx);
+    }
+  }
+
+  void Reconstructor::reconstructFunction(const FunctionDecl &FD,
+                                          ASTContext &Ctx)
+  {
+    SourceManager &SM = Ctx.getSourceManager();
+    const std::string Key = functionKey(&FD, SM);
+
+    // Every way out of this function is a decline, and each one names the
+    // pointer, the base it would have used (if it got that far) and why.
+    auto decline = [&](unsigned &Counter, llvm::StringRef Name,
+                       llvm::StringRef Base, llvm::StringRef Why)
+    {
+      ++Counter;
+      if (Verbose)
+        llvm::errs() << "[declined] " << Key << " '" << Name << "'"
+                     << (Base.empty() ? "" : " -> ") << Base << ": " << Why
+                     << "\n";
+    };
+
+    // 1. Should we run on this function?
+    auto It = Meta.functions.find(Key);
+    if (It == Meta.functions.end())
+      return;
+    if (!Handled.insert(Key).second)
+      return;
+
+    std::vector<PtrIndexPointerRecord> &Ptrs = It->second.pointers;
+
+    // Records are matched on the position the pointer pass recorded, which
+    // it mapped through its own Rewriter so that it names this file. A bare
+    // name would be ambiguous under shadowing.
+    std::map<std::pair<int, int>, size_t> ByPos;
+    for (size_t I = 0; I != Ptrs.size(); ++I)
+      if (Ptrs[I].decl_line != 0)
+        ByPos[{Ptrs[I].decl_line, Ptrs[I].decl_col}] = I;
+    if (ByPos.empty())
+      return;
+
+    // 2. Run must-equals
+    auto A = analysis::MustEqualAnalysis::run(Ctx, FD);
+    if (!A)
+    {
+      llvm::consumeError(A.takeError());
+      ++Stats.FunctionsDeclined;
+      return;
+    }
+
+    auto Resolver = analysis::ParameterResolver::run(FD, *A);
+
+    // 3. The pointers this run may delete: those the analysis tracks *and*
+    // the pointer pass recorded.
+
+    // Pairs of <V, I> s.t. V is the Decl corresponding to the record
+    // with index I.
+    llvm::SmallVector<std::pair<const VarDecl *, size_t>, 8> Candidates;
+    llvm::SmallPtrSet<const VarDecl *, 8> Reconstructable;
+    for (const VarDecl *V : Resolver.tracked())
+    {
+      SourceLocation Loc = V->getLocation();
+      auto PosIt =
+          ByPos.find({static_cast<int>(SM.getSpellingLineNumber(Loc)),
+                      static_cast<int>(SM.getSpellingColumnNumber(Loc))});
+      if (PosIt == ByPos.end())
+        continue; // not a pointer this pipeline rewrote
+      // Cross-check the mapped position against the name it was recorded
+      // under. A wrong mapping is the one silent failure mode here, and it
+      // would otherwise reconstruct against the wrong base.
+      const PtrIndexPointerRecord &Rec = Ptrs[PosIt->second];
+      if (Rec.name != V->getNameAsString() || Rec.index_var.empty())
+        continue;
+      Candidates.push_back({V, PosIt->second});
+      Reconstructable.insert(V->getCanonicalDecl());
+    }
+
+    // 4. One plan per candidate that survives both halves.
+    std::vector<Plan> Plans;
+    for (const auto &[V, RecordIndex] : Candidates)
+    {
+      PtrIndexPointerRecord &Rec = Ptrs[RecordIndex];
+      ++Stats.Considered;
+
+      // 4.
+      // Prefer a base that cannot itself be reconstructed away.
+      // `resolve` knows nothing about which pointers this run intends to
+      // delete, so its preferred candidate can be one of them: in
+      //
+      //     cp_pixel_t *pix = img->pix;
+      //     cp_pixel_t *a = pix;  cp_pixel_t *b = pix;
+      //
+      // `a`, `b` and `pix` share a class, `b` beats `pix` on spelling, and
+      // `a` would resolve to a name about to go away. Narrowing the
+      // candidate set puts both cursors on `pix`, which the pointer pass
+      // never rewrote and this tool will not touch.
+      auto isSafeBase = [&](analysis::CellId C)
+      { return !Reconstructable.contains(A->cells().get(C).Root); };
+      std::optional<analysis::Resolution> Res = Resolver.resolve(V, isSafeBase);
+      if (!Res)
+        // Nothing safe agreed everywhere. Fall back to the unrestricted
+        // answer and let step 5 decide whether it survives.
+        Res = Resolver.resolve(V);
+      if (!Res)
+      {
+        decline(Stats.Unresolved, Rec.name, "", Resolver.explain(V).Summary);
+        continue;
+      }
+
+      Plan P;
+      P.Ptr = V;
+      P.Record = RecordIndex;
+      P.Cell = Res->Cell;
+      P.Kind = Res->Kind;
+      P.Base = A->cells().print(P.Cell);
+
+      auto Why = checkSubstitutable(FD, P, Rec.index_var, Resolver, Ctx);
+      if (Why.has_value())
+      {
+        decline(Stats.Declined, Rec.name, P.Base, *Why);
+        continue;
+      }
+      Plans.push_back(std::move(P));
+    }
+
+    // 5. The backstop for the fallback in 4: when *every* candidate that
+    // agreed was itself a pointer this run intends to delete, there was
+    // nothing safe to switch to, and substituting a name that is about to
+    // go away would not compile. Dropping is monotone — a dropped plan can
+    // only free others — so iterating settles it.
+    for (bool Changed = true; Changed;)
+    {
+      Changed = false;
+      llvm::SmallPtrSet<const VarDecl *, 8> Deleted;
+      for (const Plan &P : Plans)
+        Deleted.insert(P.Ptr->getCanonicalDecl());
+      for (auto PI = Plans.begin(); PI != Plans.end(); ++PI)
+        if (Deleted.contains(A->cells().get(PI->Cell).Root))
+        {
+          decline(Stats.Declined, PI->Ptr->getName(), PI->Base,
+                  "its base is itself being reconstructed away");
+          Plans.erase(PI);
+          Changed = true;
+          break;
+        }
+    }
+
+    // 6. Edits, per plan, all-or-nothing.
+    std::vector<Edit> Edits;
+    std::vector<const Plan *> Committed;
+    for (const Plan &P : Plans)
+    {
+      std::vector<Edit> Mine;
+      buildEdits(FD, P, Resolver, Ctx, Mine);
+      if (Mine.empty())
+      {
+        decline(Stats.Declined, P.Ptr->getName(), P.Base,
+                "an edit fell outside the function's own file");
+        continue;
+      }
+      Edits.insert(Edits.end(), Mine.begin(), Mine.end());
+      Committed.push_back(&P);
+
+      switch (P.Kind)
+      {
+      case analysis::CandidateKind::Param:
+        ++Stats.Params;
+        break;
+      case analysis::CandidateKind::Local:
+        ++Stats.Locals;
+        break;
+      case analysis::CandidateKind::LValue:
+        ++Stats.LValues;
+        break;
+      }
+      if (Verbose)
+        llvm::errs() << "[reconstructed] " << Key << " '" << P.Ptr->getName()
+                     << "' -> " << P.Base << "\n";
+    }
+
+    // 7. and 8.
+    applyEdits(Edits, SM.getFileID(FD.getBody()->getBeginLoc()), Ctx);
+
+    // The base is the fact the slice pass consumes in place of the guess
+    // the pointer pass used to make. It is written only for pointers that
+    // were actually substituted, so an empty base_text still means exactly
+    // "this pointer is its own base".
+    for (const Plan *P : Committed)
+      Ptrs[P->Record].base_text = P->Base;
+  }
+
+  // Returns the reason the pointer cannot be substituted, or nullopt.
+  std::optional<std::string>
+  Reconstructor::checkSubstitutable(const FunctionDecl &FD, Plan &P,
+                                    llvm::StringRef IndexName,
+                                    const analysis::ParameterResolver &Resolver,
+                                    ASTContext &Ctx)
+  {
+    RefCollector RC(P.Ptr, Ctx);
+    RC.TraverseStmt(const_cast<Stmt *>(FD.getBody()));
+
+    if (RC.Decl == nullptr)
+      return "no declaration found in this function";
+    if (RC.MultiDeclarator)
+      return "declared alongside another declarator";
+    if (RC.InMacro)
+      return "declared or used inside a macro expansion";
+    if (RC.Unevaluated)
+      return "used in sizeof, where the base's type need not match";
+    if (RC.Mutated)
+      return "moved by something other than a plain assignment";
+    if (RC.SideEffectingStore)
+      return "a store to it has a side-effecting right-hand side";
+
+    // A declaration in a for-init cannot simply be deleted: the `;` that
+    // ends it is the first `;` of the `for` header, and has to stay.
+    if (const auto *For =
+            dyn_cast_or_null<ForStmt>(parentThroughParens(RC.Decl, Ctx)))
+      P.DeclIsForInit = For->getInit() == RC.Decl;
+
+    // Every store has to be the left arm of the comma the pointer pass
+    // emits, which is the one shape whose deletion is local. A store that
+    // is a statement of its own would need its `;` taken with it, and one
+    // anywhere else cannot be removed without changing what its context
+    // evaluates to; the pointer stays in both cases.
+    //
+    // Recording the commas is what lets `buildEdits` delete them without
+    // recognizing the shape a second time — the two recognizers used to be
+    // separate, and disagreed.
+    for (const BinaryOperator *BO : RC.Assigns)
+    {
+      const auto *Comma =
+          dyn_cast_or_null<BinaryOperator>(parentThroughParens(BO, Ctx));
+      if (Comma == nullptr || Comma->getOpcode() != BO_Comma ||
+          Comma->getLHS()->IgnoreParens() != BO)
+        return "a store to it is not the left arm of a comma";
+      P.StoreCommas.push_back(Comma);
+    }
+
+    const VarDecl *Root = Resolver.cells().get(P.Cell).Root;
+    if (Root == nullptr)
+      return "the proved cell has no root";
+    if (rootNameIsAmbiguous(FD, Root))
+      return "another declaration of '" + Root->getNameAsString() +
+             "' would shadow the substituted text";
+
+    P.Index = findLocalVarNamed(FD, IndexName);
+    if (P.Index == nullptr)
+      return "its index variable '" + IndexName.str() + "' is not a local here";
+    P.Decl = RC.Decl;
+    P.Refs = std::move(RC.Refs);
+    return std::nullopt;
+  }
+
+  void Reconstructor::buildEdits(const FunctionDecl &FD, const Plan &P,
+                                 const analysis::ParameterResolver &Resolver,
+                                 ASTContext &Ctx, std::vector<Edit> &Out)
+  {
+    SourceManager &SM = Ctx.getSourceManager();
+    const FileID FID = SM.getFileID(FD.getBody()->getBeginLoc());
+    const llvm::StringRef Buffer = SM.getBufferData(FID);
+
+    // Every edit is resolved to original file offsets as it is made, so
+    // that nothing downstream holds a range in two coordinate systems at
+    // once. `Escaped` is the one failure: offsets are only comparable
+    // within one file, and a location that is not a plain file location
+    // cannot be rewritten at all. Both are ruled out by the macro check,
+    // so hitting it means dropping the pointer rather than emitting half
+    // a rewrite.
+    bool Escaped = false;
+    auto emit = [&](CharSourceRange Range, llvm::StringRef Text, bool WholeLine)
+    {
+      SourceLocation B = Range.getBegin();
+      SourceLocation E = Range.getEnd();
+      if (Range.isTokenRange())
+        E = Lexer::getLocForEndOfToken(E, 0, SM, Ctx.getLangOpts());
+      if (!B.isFileID() || !E.isFileID() || SM.getFileID(B) != FID ||
+          SM.getFileID(E) != FID)
+      {
+        Escaped = true;
+        return;
+      }
+      unsigned Begin = SM.getFileOffset(B);
+      unsigned End = SM.getFileOffset(E);
+      // Widens `Begin` backwards past the range's start, which is why an
+      // edit cannot be re-derived from its range once it is made.
+      if (WholeLine)
+        expandToWholeLine(Buffer, Begin, End);
+      Out.push_back(Edit{Begin, End, Text.str()});
+    };
+
+    auto add = [&](CharSourceRange Range, llvm::StringRef Text)
+    { emit(Range, Text, /*WholeLine=*/false); };
+
+    // 1. The declaration goes away entirely, along with the line it sat
+    //    on. Its `;` is the DeclStmt's own end location — which in a
+    //    for-init is the header's own first `;`, so there the declaration
+    //    is replaced by that semicolon rather than removed.
+    const CharSourceRange DeclRange =
+        CharSourceRange::getTokenRange(P.Decl->getSourceRange());
+    if (P.DeclIsForInit)
+      add(DeclRange, ";");
+    else
+      emit(DeclRange, "", /*WholeLine=*/true);
+
+    // 2. Each store's arm goes away, leaving the index assignment beside
+    //    it: `(p = ROOT, p_index_xj = OFF)` becomes `(p_index_xj = OFF)`.
+    //    `checkSubstitutable` already proved every store has this shape,
+    //    so there is nothing left to recognize here.
+    for (const BinaryOperator *Comma : P.StoreCommas)
+      add(CharSourceRange::getCharRange(Comma->getLHS()->getBeginLoc(),
+                                        Comma->getRHS()->getBeginLoc()),
+          "");
+
+    // 3. Index-form recovery.
+    class IndexFormWalker : public RecursiveASTVisitor<IndexFormWalker>
+    {
+    public:
+      using AddFn = llvm::function_ref<void(CharSourceRange, llvm::StringRef)>;
+
+      IndexFormWalker(const Plan &P,
+                      const analysis::ParameterResolver &Resolver,
+                      ASTContext &Ctx, AddFn Add)
+          : P(P), Resolver(Resolver), Ctx(Ctx), Add(Add) {}
+
+      bool VisitBinaryOperator(BinaryOperator *BO)
+      {
+        // Both sides name the same *cell*, which is decl identity plus
+        // field path — never matching spellings.
+        if (!isBasePlusIndex(BO->getLHS(), P.Ptr, P.Index))
+          return true;
+        const Expr *RHS = BO->getRHS()->IgnoreParenImpCasts();
+        const std::string Idx = P.Index->getNameAsString();
+        const CharSourceRange Whole =
+            CharSourceRange::getTokenRange(BO->getSourceRange());
+
+        // `(p + idx) - B` is the index outright.
+        if (BO->getOpcode() == BO_Sub && sameCell(RHS))
+        {
+          Add(Whole, Idx);
+          return true;
+        }
+        if (!BO->isComparisonOp())
+          return true;
+        const std::string Op =
+            BinaryOperator::getOpcodeStr(BO->getOpcode()).str();
+        // `(p + idx) OP B`
+        if (sameCell(RHS))
+        {
+          Add(Whole, Idx + " " + Op + " 0");
+          return true;
+        }
+        // `(p + idx) OP B + e` — the (ptr, len) family, and the one shape
+        // plain substitution would leave in a form `detectRoots` rejects.
+        if (const auto *Sum = dyn_cast<BinaryOperator>(RHS))
+        {
+          if (Sum->getOpcode() != BO_Add)
+            return true;
+          const Expr *Other = nullptr;
+          if (sameCell(Sum->getLHS()))
+            Other = Sum->getRHS();
+          else if (sameCell(Sum->getRHS()))
+            Other = Sum->getLHS();
+          if (Other != nullptr)
+            Add(Whole, Idx + " " + Op + " " + textOf(Other, Ctx));
+        }
+        return true;
+      }
+
+    private:
+      bool sameCell(const Expr *E) const
+      {
+        if (E == nullptr)
+          return false;
+        auto C = Resolver.cells().lookup(E->IgnoreParenImpCasts());
+        return C && *C == P.Cell;
+      }
+
+      const Plan &P;
+      const analysis::ParameterResolver &Resolver;
+      ASTContext &Ctx;
+      AddFn Add;
+    } W(P, Resolver, Ctx, add);
+    W.TraverseStmt(const_cast<Stmt *>(FD.getBody()));
+
+    // 4. Every remaining mention of the pointer becomes the base. Edits
+    //    that a deletion or a fold already swallowed are dropped by
+    //    applyEdits, which keeps the outermost of any overlapping pair.
+    for (const DeclRefExpr *DRE : P.Refs)
+      add(CharSourceRange::getTokenRange(DRE->getSourceRange()), P.Base);
+
+    // One edit that could not be resolved drops the whole plan.
+    if (Escaped)
+      Out.clear();
+  }
+
+  void Reconstructor::applyEdits(std::vector<Edit> &Edits, FileID FID,
+                                 ASTContext &Ctx)
+  {
+    // Outermost first, so that a fold swallowing a subscript wins over the
+    // substitution inside it.
+    std::stable_sort(Edits.begin(), Edits.end(),
+                     [](const Edit &X, const Edit &Y)
+                     {
+                       if (X.Begin != Y.Begin)
+                         return X.Begin < Y.Begin;
+                       return X.End > Y.End;
+                     });
+
+    // Now that `Edits` ascends by start offset, an edit overlaps one
+    // already kept exactly when it starts before the furthest point those
+    // reach.
+    std::vector<Edit> Kept;
+    unsigned Reach = 0;
+    for (const Edit &E : Edits)
+      if (E.Begin >= Reach)
+      {
+        Reach = E.End;
+        Kept.push_back(E);
+      }
+
+    // Original offsets and an explicit original length: the Rewriter
+    // overloads taking a range would re-measure it against the rewrite
+    // buffer, which is exactly the coordinate system these offsets are
+    // not in. `tooling::Replacement` *is* that contract — a (file, offset,
+    // length, text) triple whose `apply` rebuilds the location as
+    // `getLocForStartOfFile(FID) + offset` and calls `ReplaceText` with
+    // the original length — so both the arithmetic and the back-to-front
+    // ordering are upstream's here rather than hand-rolled.
+    //
+    // What upstream will not do is resolve a conflict: `Replacements::add`
+    // rejects an order-dependent overlap rather than choosing between the
+    // pair, and a fold swallowing a subscript is exactly such an overlap.
+    // That is why the outermost-wins pass above stays this tool's own —
+    // what it hands over is already non-overlapping, and single-file
+    // because `buildEdits` drops any plan that reaches outside `FID`.
+    SourceManager &SM = Ctx.getSourceManager();
+    const SourceLocation FileStart = SM.getLocForStartOfFile(FID);
+    tooling::Replacements Replaces;
+    for (const Edit &E : Kept)
+      if (llvm::Error Err = Replaces.add(tooling::Replacement(
+              SM, FileStart.getLocWithOffset(E.Begin), E.End - E.Begin,
+              E.Text)))
+      {
+        // Unreachable unless the scan above let a conflict through. Half
+        // an applied set is the one outcome worse than declining, so the
+        // whole function goes untouched.
+        llvm::errs() << "xj-prepare-baserewrite: conflicting edits, nothing "
+                     << "rewritten in this function: "
+                     << llvm::toString(std::move(Err)) << "\n";
+        return;
+      }
+
+    tooling::applyAllReplacements(Replaces, Rewrite);
+  }
+
+} // namespace xj

--- a/xj-prepare-baserewrite/Reconstructor.h
+++ b/xj-prepare-baserewrite/Reconstructor.h
@@ -1,0 +1,163 @@
+// Reconstructor — prove a base, substitute it, delete the pointer.
+//
+// This is the middle stage of the pointer_transform pipeline:
+//
+//     xj-prepare-pointertransform   total, syntactic (base, index) rewrite
+//     xj-prepare-baserewrite        prove a base, substitute it, delete p
+//     xj-prepare-slicetransform     detect and reshape
+//
+// The pointer pass is deliberately without an opinion about bases: it
+// retains every tracked pointer as its own base and spells each access
+// `p[p_index_xj]`. That is total but it is not progress on its own — a
+// retained pointer lowers to `*mut T` plus `.offset()`. What turns it back
+// into an index into something nameable is a *proof*, which is what
+// xj::analysis::MustEqualAnalysis supplies: for pointer `p` it answers
+// "is there one cell `p` equals at every one of its reachable use sites?".
+//
+// Given such a cell, the rewrite is mechanical:
+//
+//     T *p = <anything>;                  deleted (a for-init keeps its `;`)
+//     p[E]                                B[E]
+//     (p = ROOT, p_index_xj = OFF)        p_index_xj = OFF
+//     (p + p_index_xj)                    (B + p_index_xj)
+//     (p + p_index_xj) OP B + e           p_index_xj OP e
+//     (p + p_index_xj) OP B               p_index_xj OP 0
+//     (p + p_index_xj) - B                p_index_xj
+//
+// The last three are index-form recovery, and they are why folding lives
+// here rather than in the slice pass: `detectRoots`' bound scan accepts
+// `idx OP lenparam` but not `base + idx OP base + lenparam`, which is what
+// plain substitution leaves behind for the (ptr, len) family. "Same cell"
+// is decl identity plus field path, taken from the analysis — never source
+// text.
+//
+// Declining is always safe, because the retained form is exactly what the
+// pointer pass already emitted and already compiles.
+
+#pragma once
+
+#include "PtrIndexMetadata.h"
+
+#include "ResolveParameter.h"
+
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/Decl.h"
+#include "clang/AST/Expr.h"
+#include "clang/Rewrite/Core/Rewriter.h"
+
+#include <set>
+#include <string>
+#include <vector>
+
+namespace xj
+{
+
+  // Run-wide tally, printed once at the end. The LValue count is the
+  // figure this project set out to recover: on main, 23.5% of collapses
+  // had a struct field for a base, and those are the ones that need the
+  // memory rules rather than plain copy propagation.
+  struct ReconstructionStats
+  {
+    unsigned Considered = 0; // pointers with a record and a decl position
+    unsigned Params = 0;
+    unsigned Locals = 0;
+    unsigned LValues = 0;
+    unsigned Unresolved = 0; // the analysis had no answer
+    unsigned Declined = 0;   // resolved, but not safely substitutable
+    unsigned FunctionsDeclined = 0;
+  };
+
+  class Reconstructor
+  {
+  public:
+    Reconstructor(clang::Rewriter &Rewrite, PtrIndexMetadata &Meta,
+                  std::set<std::string> &Handled, ReconstructionStats &Stats,
+                  bool Verbose)
+        : Rewrite(Rewrite), Meta(Meta), Handled(Handled), Stats(Stats),
+          Verbose(Verbose) {}
+
+    void run(clang::ASTContext &Ctx);
+
+  private:
+    // One pointer that survived every check, ready to be rewritten.
+    struct Plan
+    {
+      // The pointer to replace
+      const clang::VarDecl *Ptr = nullptr;
+      // The index
+      const clang::VarDecl *Index = nullptr;
+      // The declaration
+      const clang::DeclStmt *Decl = nullptr;
+      // Is it in a `for` statement?
+      bool DeclIsForInit = false;
+      size_t Record = 0; // index into the function record's `pointers`
+      analysis::CellId Cell{};
+      analysis::CandidateKind Kind = analysis::CandidateKind::LValue;
+      // The replacement pointer's spelling
+      std::string Base;
+      // Uses of `Ptr`, to be rewritten
+      std::vector<const clang::DeclRefExpr *> Refs;
+      // The comma expressions whose left arm stores to the pointer, as
+      // recognized once by `checkSubstitutable`. Deleting that arm is all
+      // of `buildEdits`' step 2.
+      std::vector<const clang::BinaryOperator *> StoreCommas;
+    };
+
+    // One pending source edit, in *original* file offsets.
+    //
+    // Original coordinates throughout, and applied with an explicit
+    // original length, is not a detail. The Rewriter's CharSourceRange
+    // overloads re-measure the range against the rewrite buffer, and
+    // `RemoveLineIfEmpty` records the line it takes at a rewrite-buffer
+    // offset as though it were an original one — so one earlier edit
+    // lower in the file makes a later range come out short, silently.
+    // This is the same triple `clang::tooling::Replacement` carries, for
+    // the same reason, and `applyEdits` converts to one to apply it.
+    //
+    // Offsets only: `buildEdits` resolves each range as it makes the edit
+    // — end-of-token, file check, whole-line widening — and nothing after
+    // that has any use for the range it came from. Widening in particular
+    // moves `Begin` off the range's start, so the two would not agree.
+    // A deletion is empty `Text`, which is what a `Replacement` says too.
+    struct Edit
+    {
+      unsigned Begin = 0;
+      unsigned End = 0;
+      std::string Text;
+    };
+
+    void reconstructFunction(const clang::FunctionDecl &FD,
+                             clang::ASTContext &Ctx);
+
+    // Everything that has to hold before a proved base may be substituted,
+    // beyond the proof itself. Resolves `IndexName` — the spelling the
+    // pointer pass recorded — to the local it names, fills `P.Decl`,
+    // `P.Index` and `P.Refs`, and returns nullopt when the pointer passes —
+    // otherwise the reason it did not, which `explain()` cannot give because
+    // it is not about the proof.
+    std::optional<std::string> checkSubstitutable(const clang::FunctionDecl &FD, Plan &P,
+                                                  llvm::StringRef IndexName,
+                                                  const analysis::ParameterResolver &Resolver,
+                                                  clang::ASTContext &Ctx);
+
+    void buildEdits(const clang::FunctionDecl &FD, const Plan &P,
+                    const analysis::ParameterResolver &Resolver,
+                    clang::ASTContext &Ctx, std::vector<Edit> &Out);
+
+    // `FID` is the function's own file, the one every edit's offsets are
+    // measured in — `buildEdits` drops any plan that would reach outside
+    // it.
+    void applyEdits(std::vector<Edit> &Edits, clang::FileID FID,
+                    clang::ASTContext &Ctx);
+
+    clang::Rewriter &Rewrite;
+    PtrIndexMetadata &Meta;
+    // Function keys already reconstructed in this run. A function defined
+    // in a header is parsed once per including TU; the first TU rewrites it
+    // on disk, and the rest must not try again.
+    std::set<std::string> &Handled;
+    ReconstructionStats &Stats;
+    bool Verbose;
+  };
+
+} // namespace xj

--- a/xj-prepare-baserewrite/main.cpp
+++ b/xj-prepare-baserewrite/main.cpp
@@ -1,0 +1,109 @@
+// CLI entry point for the base reconstruction tool.
+//
+// Runs between xj-prepare-pointertransform and xj-prepare-slicetransform.
+// The pointer pass hands it a side-file naming every pointer it rewrote;
+// for each of them this tool asks xj::analysis::MustEqualAnalysis whether
+// the pointer equals one nameable cell at every use, and where it does,
+// substitutes that cell's spelling and deletes the pointer.
+//
+// The side-file is both input and output: `--metadata-in` and
+// `--metadata-out` are normally the same path. What comes back out carries
+// `base_text` for every pointer that was reconstructed, which is the fact
+// the slice pass groups and anchors on.
+
+#include "BaseRewriteAction.h"
+#include "PtrIndexMetadata.h"
+
+static llvm::cl::OptionCategory MyToolCategory("base-rewrite options");
+static cl::extrahelp CommonHelp(CommonOptionsParser::HelpMessage);
+
+// --inplace: overwrite source files instead of streaming the rewritten
+// translation unit to stdout.
+static cl::opt<bool> InplaceOpt(
+    "inplace",
+    cl::desc("Overwrite source files in-place instead of writing to stdout"),
+    cl::init(false),
+    cl::cat(MyToolCategory));
+
+// --verbose: one line per pointer, saying what was proved or why nothing
+// was. `explain()` is the analysis's own account, so this is the first
+// place to look when a base comes out wrong.
+static cl::opt<bool> VerboseOpt(
+    "verbose",
+    cl::desc("Log every pointer considered, and why it did or did not resolve"),
+    cl::init(false),
+    cl::cat(MyToolCategory));
+
+static cl::opt<std::string> MetadataInOpt(
+    "metadata-in",
+    cl::desc("Path to pointer/index metadata JSON from xj-prepare-pointertransform"),
+    cl::init(""),
+    cl::cat(MyToolCategory));
+
+static cl::opt<std::string> MetadataOutOpt(
+    "metadata-out",
+    cl::desc("Path to re-write that metadata to, with proved bases filled in"),
+    cl::init(""),
+    cl::cat(MyToolCategory));
+
+int main(int argc, const char **argv) {
+    auto ExpectedParser = CommonOptionsParser::create(argc, argv, MyToolCategory);
+    if (!ExpectedParser) {
+        llvm::errs() << ExpectedParser.takeError();
+        return 1;
+    }
+    CommonOptionsParser &OptionsParser = ExpectedParser.get();
+
+    g_base_inplace = InplaceOpt;
+    g_base_verbose = VerboseOpt;
+    g_base_metadata_in = MetadataInOpt;
+    g_base_metadata_out = MetadataOutOpt;
+
+    if (!g_base_metadata_in.empty() &&
+        !g_base_metadata.readFromFile(g_base_metadata_in)) {
+        llvm::errs() << "xj-prepare-baserewrite: failed to read metadata from "
+                     << g_base_metadata_in << "\n";
+        return 1;
+    }
+
+    // Process each source file with its OWN ClangTool (fresh FileManager).
+    // A shared FileManager caches each header's size on first read, and
+    // this tool rewrites headers in --inplace mode; re-reading one against
+    // a stale size aborts the process. See the matching comment in
+    // xj-prepare-pointertransform.
+    int rc = 0;
+    for (const std::string &Source : OptionsParser.getSourcePathList()) {
+        ClangTool Tool(OptionsParser.getCompilations(), {Source});
+        int r = Tool.run(newFrontendActionFactory<BaseRewriteAction>().get());
+        if (r != 0)
+            rc = r;
+    }
+
+    const xj::ReconstructionStats &S = g_base_stats;
+    llvm::errs() << "[SUMMARY] xj-prepare-baserewrite: considered "
+                 << S.Considered << " pointers, reconstructed "
+                 << (S.Params + S.Locals + S.LValues) << " (param " << S.Params
+                 << ", local " << S.Locals << ", lvalue " << S.LValues
+                 << "); " << S.Unresolved << " unresolved, " << S.Declined
+                 << " declined, " << S.FunctionsDeclined
+                 << " functions not analyzable\n";
+
+    // The recorded declaration positions were valid in this tool's *input*.
+    // It has just rewritten that input, so they are stale now; drop them
+    // rather than leave a later consumer something to trust.
+    if (!g_base_metadata_out.empty()) {
+        for (auto &[Key, FnRec] : g_base_metadata.functions) {
+            (void)Key;
+            for (auto &P : FnRec.pointers) {
+                P.decl_line = 0;
+                P.decl_col = 0;
+            }
+        }
+        if (!g_base_metadata.writeToFile(g_base_metadata_out)) {
+            llvm::errs() << "xj-prepare-baserewrite: failed to write metadata to "
+                         << g_base_metadata_out << "\n";
+            rc = 1;
+        }
+    }
+    return rc;
+}

--- a/xj-prepare-support/PtrIndexMetadata.cpp
+++ b/xj-prepare-support/PtrIndexMetadata.cpp
@@ -16,6 +16,14 @@ namespace xj
         O["index_var"] = R.index_var;
         O["param_index"] = R.param_index;
         O["base_text"] = R.base_text;
+        // Omitted rather than written as 0 so that the side-file the base tool
+        // re-emits differs from the pointer pass's by the absence of a stale
+        // position, not by a zero that reads like one.
+        if (R.decl_line != 0)
+        {
+            O["decl_line"] = R.decl_line;
+            O["decl_col"] = R.decl_col;
+        }
         return O;
     }
 
@@ -30,6 +38,8 @@ namespace xj
         R.index_var = IndexVar->str();
         R.param_index = static_cast<int>(O.getInteger("param_index").value_or(-1));
         R.base_text = O.getString("base_text").value_or("").str();
+        R.decl_line = static_cast<int>(O.getInteger("decl_line").value_or(0));
+        R.decl_col = static_cast<int>(O.getInteger("decl_col").value_or(0));
         return true;
     }
 

--- a/xj-prepare-support/PtrIndexMetadata.cpp
+++ b/xj-prepare-support/PtrIndexMetadata.cpp
@@ -6,88 +6,99 @@
 
 #include <system_error>
 
-namespace xj {
+namespace xj
+{
 
-static llvm::json::Object pointerToJson(const PtrIndexPointerRecord &R) {
-    llvm::json::Object O;
-    O["name"] = R.name;
-    O["index_var"] = R.index_var;
-    O["param_index"] = R.param_index;
-    O["base_text"] = R.base_text;
-    return O;
-}
-
-static bool pointerFromJson(const llvm::json::Object &O,
-                            PtrIndexPointerRecord &R) {
-    auto Name = O.getString("name");
-    auto IndexVar = O.getString("index_var");
-    if (!Name || !IndexVar)
-        return false;
-    R.name = Name->str();
-    R.index_var = IndexVar->str();
-    R.param_index = static_cast<int>(O.getInteger("param_index").value_or(-1));
-    R.base_text = O.getString("base_text").value_or("").str();
-    return true;
-}
-
-bool PtrIndexMetadata::writeToFile(const std::string &path) const {
-    llvm::json::Object Root;
-
-    llvm::json::Object Functions;
-    for (const auto &[FnName, FnRec] : functions) {
-        llvm::json::Array Pointers;
-        for (const auto &P : FnRec.pointers)
-            Pointers.push_back(pointerToJson(P));
-        llvm::json::Object FnObj;
-        FnObj["file"] = FnRec.file;
-        FnObj["pointers"] = std::move(Pointers);
-        Functions[FnName] = std::move(FnObj);
+    static llvm::json::Object pointerToJson(const PtrIndexPointerRecord &R)
+    {
+        llvm::json::Object O;
+        O["name"] = R.name;
+        O["index_var"] = R.index_var;
+        O["param_index"] = R.param_index;
+        O["base_text"] = R.base_text;
+        return O;
     }
-    Root["functions"] = std::move(Functions);
 
-    std::error_code EC;
-    llvm::raw_fd_ostream OS(path, EC);
-    if (EC)
-        return false;
-    OS << llvm::formatv("{0:2}", llvm::json::Value(std::move(Root)));
-    return !OS.has_error();
-}
-
-bool PtrIndexMetadata::readFromFile(const std::string &path) {
-    auto BufOrErr = llvm::MemoryBuffer::getFile(path);
-    if (!BufOrErr)
-        return false;
-    auto Parsed = llvm::json::parse((*BufOrErr)->getBuffer());
-    if (!Parsed) {
-        llvm::consumeError(Parsed.takeError());
-        return false;
+    static bool pointerFromJson(const llvm::json::Object &O,
+                                PtrIndexPointerRecord &R)
+    {
+        auto Name = O.getString("name");
+        auto IndexVar = O.getString("index_var");
+        if (!Name || !IndexVar)
+            return false;
+        R.name = Name->str();
+        R.index_var = IndexVar->str();
+        R.param_index = static_cast<int>(O.getInteger("param_index").value_or(-1));
+        R.base_text = O.getString("base_text").value_or("").str();
+        return true;
     }
-    const llvm::json::Object *Root = Parsed->getAsObject();
-    if (!Root)
-        return false;
 
-    functions.clear();
+    bool PtrIndexMetadata::writeToFile(const std::string &path) const
+    {
+        llvm::json::Object Root;
 
-    if (const llvm::json::Object *Functions = Root->getObject("functions")) {
-        for (const auto &[Key, Val] : *Functions) {
-            const llvm::json::Object *FnObj = Val.getAsObject();
-            if (!FnObj)
-                return false;
-            PtrIndexFunctionRecord FnRec;
-            FnRec.file = FnObj->getString("file").value_or("").str();
-            if (const llvm::json::Array *Pointers = FnObj->getArray("pointers")) {
-                for (const auto &PV : *Pointers) {
-                    const llvm::json::Object *PO = PV.getAsObject();
-                    PtrIndexPointerRecord R;
-                    if (!PO || !pointerFromJson(*PO, R))
-                        return false;
-                    FnRec.pointers.push_back(std::move(R));
-                }
-            }
-            functions[Key.str()] = std::move(FnRec);
+        llvm::json::Object Functions;
+        for (const auto &[FnName, FnRec] : functions)
+        {
+            llvm::json::Array Pointers;
+            for (const auto &P : FnRec.pointers)
+                Pointers.push_back(pointerToJson(P));
+            llvm::json::Object FnObj;
+            FnObj["file"] = FnRec.file;
+            FnObj["pointers"] = std::move(Pointers);
+            Functions[FnName] = std::move(FnObj);
         }
+        Root["functions"] = std::move(Functions);
+
+        std::error_code EC;
+        llvm::raw_fd_ostream OS(path, EC);
+        if (EC)
+            return false;
+        OS << llvm::formatv("{0:2}", llvm::json::Value(std::move(Root)));
+        return !OS.has_error();
     }
-    return true;
-}
+
+    bool PtrIndexMetadata::readFromFile(const std::string &path)
+    {
+        auto BufOrErr = llvm::MemoryBuffer::getFile(path);
+        if (!BufOrErr)
+            return false;
+        auto Parsed = llvm::json::parse((*BufOrErr)->getBuffer());
+        if (!Parsed)
+        {
+            llvm::consumeError(Parsed.takeError());
+            return false;
+        }
+        const llvm::json::Object *Root = Parsed->getAsObject();
+        if (!Root)
+            return false;
+
+        functions.clear();
+
+        if (const llvm::json::Object *Functions = Root->getObject("functions"))
+        {
+            for (const auto &[Key, Val] : *Functions)
+            {
+                const llvm::json::Object *FnObj = Val.getAsObject();
+                if (!FnObj)
+                    return false;
+                PtrIndexFunctionRecord FnRec;
+                FnRec.file = FnObj->getString("file").value_or("").str();
+                if (const llvm::json::Array *Pointers = FnObj->getArray("pointers"))
+                {
+                    for (const auto &PV : *Pointers)
+                    {
+                        const llvm::json::Object *PO = PV.getAsObject();
+                        PtrIndexPointerRecord R;
+                        if (!PO || !pointerFromJson(*PO, R))
+                            return false;
+                        FnRec.pointers.push_back(std::move(R));
+                    }
+                }
+                functions[Key.str()] = std::move(FnRec);
+            }
+        }
+        return true;
+    }
 
 } // namespace xj

--- a/xj-prepare-support/PtrIndexMetadata.h
+++ b/xj-prepare-support/PtrIndexMetadata.h
@@ -23,6 +23,21 @@ namespace xj
         // Source text of the base array this pointer indexes into (e.g. "buf",
         // "bs->buf"). Empty when the pointer is its own base (a parameter).
         std::string base_text;
+
+        // Spelling position of the pointer's *declaring identifier*.
+        //
+        // A bare name is ambiguous under shadowing, so the base tool needs
+        // a position to match a VarDecl on — but the position has to be
+        // valid in the file the base tool parses, which is the pointer
+        // pass's *output*. The pointer pass therefore maps the location
+        // through its Rewriter at end of TU, once every edit is applied.
+        //
+        // Valid only in that intermediate. The base tool rewrites the file
+        // in turn, so it clears these when it re-emits the side-file rather
+        // than leave a stale position for a later consumer to trust. 0
+        // means "no position recorded".
+        int decl_line = 0;
+        int decl_col = 0;
     };
 
     struct PtrIndexFunctionRecord


### PR DESCRIPTION
**Context:** we want to relax the single-base requirement of the pointer transform so that we can rewrite more pointers into base + index form. At the same time, in support of the slice transform, it is better to use a _single_ name for a given pointer's base when possible (i.e., if we have pointer `T *p` and `T* q = p`, if `q` always points to the same base as `p` then it is preferable to delete  `q` and use the name `p`). Tracking base equality in the same analysis as pointer splitting leads to a complicated implementation. Instead we should:

1) Split pointers into pointer base + index (pointer transform)
2) Recover equalities (rewrite equivalent bases into a single name, preferring function parameters)
3) Run the slice transform

**This PR** adds a new tool that rewrites pointers `p` that are provably equivalent to some function parameter `x`'s value on entry. This is a prereque

To that end:
1) Adds a MustEqual analysis, which is mostly standard with some very coarse support for reasoning about memory. The analysis is based on a simplified version of the abstract domain described in [A polynomial-time algorithm for global value numbering](https://www.sciencedirect.com/science/article/pii/S0167642306001596).
2) Adds the xj-prepare-basewrite client of the must equal analysis, which performs the actual transform

