### PR TITLE
Cook pkg-config prefixes within installed sysroots

### DIFF
--- a/cli/provisioning.py
+++ b/cli/provisioning.py
@@ -669,6 +669,23 @@ def cook_pkg_config_placeholders_within(target: Path) -> None:
         pc_file.write_text(data, encoding="utf-8")
 
 
+def cook_pkg_config_sysroot_prefixes_within(sysroot: Path) -> None:
+    """Point absolute /usr pkg-config prefixes into an installed sysroot."""
+    installed_usr = (sysroot / "usr").resolve().as_posix()
+    old_prefix = "prefix=/usr"
+
+    for pc_file in sysroot.rglob("*.pc"):
+        data = pc_file.read_text(encoding="utf-8")
+        rewritten = "".join(
+            f"prefix={installed_usr}{line[len(old_prefix) :]}"
+            if line.rstrip("\r\n") == old_prefix
+            else line
+            for line in data.splitlines(keepends=True)
+        )
+        if rewritten != data:
+            pc_file.write_text(rewritten, encoding="utf-8")
+
+
 def want_10j_more_deps():
     def provision_10j_more_deps_with(version: str, keyname: str):
         loweros = {"Linux": "linux", "Darwin": "macos"}[platform.system()]
@@ -973,6 +990,7 @@ def provision_debian_bullseye_sysroot_with(dest_sysroot: Path):
         raise ProvisioningError("Sysroot hash verification failed!")
     shutil.unpack_archive(tarball, dest_sysroot, filter="tar")
     tarball.unlink()
+    cook_pkg_config_sysroot_prefixes_within(dest_sysroot)
 
 
 def provision_opam_binary_with(opam_version: str) -> None:

--- a/tests/test_provisioning.py
+++ b/tests/test_provisioning.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+from provisioning import cook_pkg_config_sysroot_prefixes_within
+
+
+def test_cook_pkg_config_sysroot_prefixes_within(tmp_path: Path):
+    sysroot = tmp_path / "llvm" / "sysroot"
+    pkgconfig = sysroot / "usr" / "lib" / "pkgconfig"
+    pkgconfig.mkdir(parents=True)
+
+    affected = pkgconfig / "affected.pc"
+    affected.write_text(
+        "prefix=/usr\nexec_prefix=${prefix}\nlibdir=${prefix}/lib\n",
+        encoding="utf-8",
+    )
+    unaffected = pkgconfig / "unaffected.pc"
+    unaffected_data = "prefix=/usr/local\n# prefix=/usr\n"
+    unaffected.write_text(unaffected_data, encoding="utf-8")
+
+    cook_pkg_config_sysroot_prefixes_within(sysroot)
+
+    assert affected.read_text(encoding="utf-8") == (
+        f"prefix={(sysroot / 'usr').resolve().as_posix()}\n"
+        "exec_prefix=${prefix}\n"
+        "libdir=${prefix}/lib\n"
+    )
+    assert unaffected.read_text(encoding="utf-8") == unaffected_data


### PR DESCRIPTION
Otherwise, builds will be directed to host files instead of hermetic files.